### PR TITLE
feat: budget-aware dispatch (issue #7)

### DIFF
--- a/cmd/octi-pulpo/main.go
+++ b/cmd/octi-pulpo/main.go
@@ -7,6 +7,7 @@ import (
 	"github.com/AgentGuardHQ/octi-pulpo/internal/coordination"
 	"github.com/AgentGuardHQ/octi-pulpo/internal/mcp"
 	"github.com/AgentGuardHQ/octi-pulpo/internal/memory"
+	"github.com/AgentGuardHQ/octi-pulpo/internal/routing"
 )
 
 func main() {
@@ -33,7 +34,10 @@ func main() {
 	}
 	defer coord.Close()
 
-	server := mcp.New(mem, coord)
+	healthDir := os.Getenv("AGENTGUARD_HEALTH_DIR")
+	router := routing.NewRouter(healthDir) // defaults to ~/.agentguard/driver-health/
+
+	server := mcp.New(mem, coord, router)
 	if err := server.Serve(); err != nil {
 		fmt.Fprintf(os.Stderr, "server: %v\n", err)
 		os.Exit(1)

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/AgentGuardHQ/octi-pulpo/internal/coordination"
 	"github.com/AgentGuardHQ/octi-pulpo/internal/memory"
+	"github.com/AgentGuardHQ/octi-pulpo/internal/routing"
 )
 
 // ToolDef describes an MCP tool for the ListTools response.
@@ -43,13 +44,14 @@ type RPCError struct {
 
 // Server is the Octi Pulpo MCP server.
 type Server struct {
-	mem   *memory.Store
-	coord *coordination.Engine
+	mem    *memory.Store
+	coord  *coordination.Engine
+	router *routing.Router
 }
 
 // New creates an MCP server backed by the given memory and coordination engines.
-func New(mem *memory.Store, coord *coordination.Engine) *Server {
-	return &Server{mem: mem, coord: coord}
+func New(mem *memory.Store, coord *coordination.Engine, router *routing.Router) *Server {
+	return &Server{mem: mem, coord: coord, router: router}
 }
 
 // Serve runs the MCP server on stdio (stdin/stdout JSON-RPC).
@@ -186,14 +188,14 @@ func (s *Server) handleToolCall(req Request) Response {
 			Budget          string `json:"budget"`
 		}
 		json.Unmarshal(params.Arguments, &args)
-		// Placeholder — will use swarm history + telemetry for real routing
-		model := "claude-opus-4"
-		reason := "Complex task — tier A agent"
-		if args.Budget == "low" {
-			model = "copilot"
-			reason = "Low budget — tier C agent"
-		}
-		return textResult(req.ID, fmt.Sprintf("Recommended: %s — %s", model, reason))
+		dec := s.router.Recommend(args.TaskDescription, args.Budget)
+		data, _ := json.Marshal(dec)
+		return textResult(req.ID, string(data))
+
+	case "health_report":
+		report := s.router.HealthReport()
+		data, _ := json.Marshal(report)
+		return textResult(req.ID, string(data))
 
 	default:
 		return errorResp(req.ID, -32601, fmt.Sprintf("unknown tool: %s", params.Name))
@@ -271,14 +273,22 @@ func toolDefs() []ToolDef {
 		},
 		{
 			Name:        "route_recommend",
-			Description: "Get the recommended model for a task based on cost, capability, and swarm history.",
+			Description: "Get the recommended driver for a task based on cost tier and driver health. Returns cheapest healthy driver with fallback options.",
 			InputSchema: map[string]interface{}{
 				"type": "object",
 				"properties": map[string]interface{}{
 					"taskDescription": map[string]string{"type": "string", "description": "Describe the task"},
-					"budget":          map[string]interface{}{"type": "string", "enum": []string{"low", "medium", "high"}, "description": "Budget tier"},
+					"budget":          map[string]interface{}{"type": "string", "enum": []string{"low", "medium", "high"}, "description": "Budget tier — low (local only), medium (local+subscription+cli), high (all)"},
 				},
 				"required": []string{"taskDescription"},
+			},
+		},
+		{
+			Name:        "health_report",
+			Description: "Get current health status of all drivers in the swarm — circuit breaker state, failure counts, last success/failure timestamps.",
+			InputSchema: map[string]interface{}{
+				"type":       "object",
+				"properties": map[string]interface{}{},
 			},
 		},
 	}

--- a/internal/routing/health.go
+++ b/internal/routing/health.go
@@ -1,0 +1,77 @@
+package routing
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// HealthFile is the on-disk format of a driver health JSON file.
+type HealthFile struct {
+	State       string `json:"state"`        // CLOSED, OPEN, HALF
+	Failures    int    `json:"failures"`
+	LastFailure string `json:"last_failure"`
+	LastSuccess string `json:"last_success"`
+	OpenedAt    string `json:"opened_at"`
+	ProbedAt    string `json:"probed_at"`
+	Updated     string `json:"updated"`
+}
+
+// ReadDriverHealth reads a single driver health file and returns a DriverHealth.
+func ReadDriverHealth(healthDir, driver string) DriverHealth {
+	dh := DriverHealth{
+		Name:         driver,
+		CircuitState: "CLOSED", // default: assume healthy
+	}
+
+	path := filepath.Join(healthDir, driver+".json")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return dh // file missing = healthy
+	}
+
+	var hf HealthFile
+	if err := json.Unmarshal(data, &hf); err != nil {
+		return dh
+	}
+
+	if hf.State != "" {
+		dh.CircuitState = hf.State
+	}
+	dh.Failures = hf.Failures
+	dh.LastFailure = hf.LastFailure
+	dh.LastSuccess = hf.LastSuccess
+	return dh
+}
+
+// DiscoverDrivers lists all driver names from .json files in the health directory.
+// Returns an empty slice if the directory doesn't exist.
+func DiscoverDrivers(healthDir string) []string {
+	entries, err := os.ReadDir(healthDir)
+	if err != nil {
+		return nil
+	}
+
+	var drivers []string
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		if strings.HasSuffix(name, ".json") {
+			drivers = append(drivers, strings.TrimSuffix(name, ".json"))
+		}
+	}
+	return drivers
+}
+
+// ReadAllHealth reads health status for all discovered drivers.
+func ReadAllHealth(healthDir string) []DriverHealth {
+	drivers := DiscoverDrivers(healthDir)
+	results := make([]DriverHealth, 0, len(drivers))
+	for _, d := range drivers {
+		results = append(results, ReadDriverHealth(healthDir, d))
+	}
+	return results
+}

--- a/internal/routing/router.go
+++ b/internal/routing/router.go
@@ -1,0 +1,170 @@
+package routing
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// CostTier represents the cost category of a driver.
+type CostTier string
+
+const (
+	TierLocal        CostTier = "local"
+	TierSubscription CostTier = "subscription"
+	TierCLI          CostTier = "cli"
+	TierAPI          CostTier = "api"
+)
+
+// tierOrder defines the cost cascade: cheapest first.
+var tierOrder = []CostTier{TierLocal, TierSubscription, TierCLI, TierAPI}
+
+// driverTiers maps each known driver to its cost tier.
+var driverTiers = map[string]CostTier{
+	// Local ($0)
+	"ollama":   TierLocal,
+	"nemotron": TierLocal,
+	// Subscription (browser-based)
+	"openclaw": TierSubscription,
+	// CLI (metered)
+	"claude-code": TierCLI,
+	"copilot":     TierCLI,
+	"codex":       TierCLI,
+	"gemini":      TierCLI,
+	"goose":       TierCLI,
+}
+
+// DriverHealth represents the runtime health of a single driver.
+type DriverHealth struct {
+	Name         string `json:"name"`
+	CircuitState string `json:"circuit_state"` // CLOSED, OPEN, HALF
+	Failures     int    `json:"failures"`
+	LastFailure  string `json:"last_failure"`
+	LastSuccess  string `json:"last_success"`
+}
+
+// RouteDecision is the output of the routing engine.
+type RouteDecision struct {
+	Driver     string   `json:"driver"`
+	Tier       string   `json:"tier"`
+	Confidence float64  `json:"confidence"`
+	Reason     string   `json:"reason"`
+	Fallbacks  []string `json:"fallbacks"`
+	Skip       bool     `json:"skip"`
+}
+
+// Router makes budget-aware driver routing decisions.
+type Router struct {
+	healthDir string
+}
+
+// NewRouter creates a Router that reads driver health from the given directory.
+// If healthDir is empty, it defaults to ~/.agentguard/driver-health/.
+func NewRouter(healthDir string) *Router {
+	if healthDir == "" {
+		home, _ := os.UserHomeDir()
+		healthDir = filepath.Join(home, ".agentguard", "driver-health")
+	}
+	return &Router{healthDir: healthDir}
+}
+
+// Recommend returns the cheapest healthy driver for the given task.
+// The budget parameter controls which cost tiers are considered:
+//   - "low"    -> local only
+//   - "medium" -> local + subscription + cli
+//   - "high"   -> all tiers
+//   - ""       -> all tiers (default)
+func (r *Router) Recommend(taskType, budget string) RouteDecision {
+	maxTier := maxTierForBudget(budget)
+	drivers := DiscoverDrivers(r.healthDir)
+
+	// Build health map from discovered drivers.
+	// Only drivers with health files on disk are candidates.
+	healthMap := make(map[string]DriverHealth)
+	for _, d := range drivers {
+		healthMap[d] = ReadDriverHealth(r.healthDir, d)
+	}
+
+	var chosen *RouteDecision
+	var fallbacks []string
+
+	// Walk tiers in cost order: cheapest first.
+	for _, tier := range tierOrder {
+		if tierIndex(tier) > tierIndex(maxTier) {
+			break
+		}
+		for name, health := range healthMap {
+			driverTier := tierFor(name)
+			if driverTier != tier {
+				continue
+			}
+			if health.CircuitState == "OPEN" {
+				continue // skip exhausted drivers
+			}
+
+			confidence := 1.0
+			if health.CircuitState == "HALF" {
+				confidence = 0.5
+			}
+
+			if chosen == nil {
+				chosen = &RouteDecision{
+					Driver:     name,
+					Tier:       string(tier),
+					Confidence: confidence,
+					Reason:     fmt.Sprintf("cheapest healthy driver (tier: %s, state: %s)", tier, health.CircuitState),
+				}
+			} else {
+				fallbacks = append(fallbacks, name)
+			}
+		}
+	}
+
+	if chosen == nil {
+		return RouteDecision{
+			Skip:   true,
+			Reason: "all drivers exhausted — circuit breakers OPEN",
+		}
+	}
+
+	chosen.Fallbacks = fallbacks
+	return *chosen
+}
+
+// HealthReport returns current health status for all discovered drivers.
+func (r *Router) HealthReport() []DriverHealth {
+	return ReadAllHealth(r.healthDir)
+}
+
+// maxTierForBudget returns the highest tier to consider for a budget level.
+func maxTierForBudget(budget string) CostTier {
+	switch strings.ToLower(budget) {
+	case "low":
+		return TierLocal
+	case "medium":
+		return TierCLI
+	case "high", "":
+		return TierAPI
+	default:
+		return TierAPI
+	}
+}
+
+// tierFor returns the cost tier for a driver, defaulting to CLI.
+func tierFor(driver string) CostTier {
+	if t, ok := driverTiers[driver]; ok {
+		return t
+	}
+	return TierCLI // unknown drivers default to CLI tier
+}
+
+// tierIndex returns the position in the cost cascade.
+func tierIndex(t CostTier) int {
+	for i, tier := range tierOrder {
+		if tier == t {
+			return i
+		}
+	}
+	return len(tierOrder)
+}

--- a/internal/routing/router_test.go
+++ b/internal/routing/router_test.go
@@ -1,0 +1,248 @@
+package routing
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// writeHealth writes a driver health JSON file into the temp directory.
+func writeHealth(t *testing.T, dir, driver string, hf HealthFile) {
+	t.Helper()
+	data, err := json.Marshal(hf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, driver+".json"), data, 0644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestRecommend_HealthyDriver(t *testing.T) {
+	dir := t.TempDir()
+	writeHealth(t, dir, "claude-code", HealthFile{State: "CLOSED", Failures: 0})
+	writeHealth(t, dir, "copilot", HealthFile{State: "CLOSED", Failures: 0})
+
+	r := NewRouter(dir)
+	dec := r.Recommend("code-review", "high")
+
+	if dec.Skip {
+		t.Fatal("expected a driver recommendation, got Skip")
+	}
+	if dec.Driver == "" {
+		t.Fatal("expected a driver name, got empty")
+	}
+	// Both are CLI tier — either is valid
+	if dec.Tier != string(TierCLI) {
+		t.Fatalf("expected tier cli, got %s", dec.Tier)
+	}
+}
+
+func TestRecommend_SkipsOpenDrivers(t *testing.T) {
+	dir := t.TempDir()
+	writeHealth(t, dir, "claude-code", HealthFile{State: "OPEN", Failures: 5})
+	writeHealth(t, dir, "copilot", HealthFile{State: "CLOSED", Failures: 0})
+
+	r := NewRouter(dir)
+	dec := r.Recommend("code-review", "high")
+
+	if dec.Skip {
+		t.Fatal("expected a driver recommendation, got Skip")
+	}
+	if dec.Driver != "copilot" {
+		t.Fatalf("expected copilot (healthy), got %s", dec.Driver)
+	}
+}
+
+func TestRecommend_AllDriversOpen(t *testing.T) {
+	dir := t.TempDir()
+	writeHealth(t, dir, "claude-code", HealthFile{State: "OPEN", Failures: 10})
+	writeHealth(t, dir, "copilot", HealthFile{State: "OPEN", Failures: 8})
+
+	r := NewRouter(dir)
+	dec := r.Recommend("anything", "high")
+
+	if !dec.Skip {
+		t.Fatalf("expected Skip=true when all drivers OPEN, got driver=%s", dec.Driver)
+	}
+	if dec.Reason == "" {
+		t.Fatal("expected a reason when skipping")
+	}
+}
+
+func TestRecommend_CostTierOrdering(t *testing.T) {
+	dir := t.TempDir()
+	// Local driver should be chosen over CLI when both healthy
+	writeHealth(t, dir, "ollama", HealthFile{State: "CLOSED", Failures: 0})
+	writeHealth(t, dir, "claude-code", HealthFile{State: "CLOSED", Failures: 0})
+
+	r := NewRouter(dir)
+	dec := r.Recommend("simple-task", "high")
+
+	if dec.Skip {
+		t.Fatal("expected a driver recommendation, got Skip")
+	}
+	if dec.Driver != "ollama" {
+		t.Fatalf("expected ollama (cheapest tier), got %s", dec.Driver)
+	}
+	if dec.Tier != string(TierLocal) {
+		t.Fatalf("expected tier local, got %s", dec.Tier)
+	}
+	// claude-code should be a fallback
+	if len(dec.Fallbacks) == 0 {
+		t.Fatal("expected claude-code as fallback")
+	}
+}
+
+func TestRecommend_MissingHealthFileDefaultsClosed(t *testing.T) {
+	dir := t.TempDir()
+	// Write a valid file for copilot (OPEN), but claude-code has no file
+	// Manually create a file with missing/empty state
+	writeHealth(t, dir, "copilot", HealthFile{State: "OPEN", Failures: 3})
+	writeHealth(t, dir, "claude-code", HealthFile{}) // empty state defaults to CLOSED in ReadDriverHealth
+
+	r := NewRouter(dir)
+	dec := r.Recommend("any-task", "high")
+
+	if dec.Skip {
+		t.Fatal("expected a driver recommendation, got Skip")
+	}
+	// claude-code should be chosen since copilot is OPEN
+	// and empty state in ReadDriverHealth becomes whatever the file says (empty string)
+	// We need to check: empty state should be treated as healthy
+	if dec.Driver != "claude-code" {
+		t.Fatalf("expected claude-code (copilot is OPEN), got %s", dec.Driver)
+	}
+}
+
+func TestRecommend_NoDriversAvailable(t *testing.T) {
+	dir := t.TempDir()
+	// Empty directory — no drivers discovered
+
+	r := NewRouter(dir)
+	dec := r.Recommend("any-task", "high")
+
+	if !dec.Skip {
+		t.Fatalf("expected Skip=true with no drivers, got driver=%s", dec.Driver)
+	}
+}
+
+func TestRecommend_LowBudgetOnlyLocal(t *testing.T) {
+	dir := t.TempDir()
+	writeHealth(t, dir, "ollama", HealthFile{State: "CLOSED", Failures: 0})
+	writeHealth(t, dir, "claude-code", HealthFile{State: "CLOSED", Failures: 0})
+
+	r := NewRouter(dir)
+	dec := r.Recommend("task", "low")
+
+	// Low budget only allows local tier — should pick ollama, skip claude-code
+	if dec.Skip {
+		t.Fatal("expected ollama recommendation, got Skip")
+	}
+	if dec.Driver != "ollama" {
+		t.Fatalf("expected ollama (local tier), got %s", dec.Driver)
+	}
+	// claude-code should NOT be in fallbacks (it's CLI tier, above budget)
+	for _, fb := range dec.Fallbacks {
+		if fb == "claude-code" {
+			t.Fatal("claude-code should not be a fallback for low budget")
+		}
+	}
+}
+
+func TestRecommend_LowBudgetAllLocalOpen(t *testing.T) {
+	dir := t.TempDir()
+	writeHealth(t, dir, "ollama", HealthFile{State: "OPEN", Failures: 5})
+	writeHealth(t, dir, "claude-code", HealthFile{State: "CLOSED", Failures: 0})
+
+	r := NewRouter(dir)
+	dec := r.Recommend("task", "low")
+
+	// ollama OPEN, and low budget prevents using CLI tier claude-code
+	if !dec.Skip {
+		t.Fatalf("expected Skip (local OPEN, can't use CLI at low budget), got driver=%s", dec.Driver)
+	}
+}
+
+func TestRecommend_HalfOpenReducedConfidence(t *testing.T) {
+	dir := t.TempDir()
+	writeHealth(t, dir, "claude-code", HealthFile{State: "HALF", Failures: 2})
+
+	r := NewRouter(dir)
+	dec := r.Recommend("task", "high")
+
+	if dec.Skip {
+		t.Fatal("expected a recommendation for HALF-open driver")
+	}
+	if dec.Driver != "claude-code" {
+		t.Fatalf("expected claude-code, got %s", dec.Driver)
+	}
+	if dec.Confidence != 0.5 {
+		t.Fatalf("expected confidence 0.5 for HALF driver, got %f", dec.Confidence)
+	}
+}
+
+func TestRecommend_SubscriptionTier(t *testing.T) {
+	dir := t.TempDir()
+	writeHealth(t, dir, "openclaw", HealthFile{State: "CLOSED", Failures: 0})
+	writeHealth(t, dir, "claude-code", HealthFile{State: "CLOSED", Failures: 0})
+
+	r := NewRouter(dir)
+	dec := r.Recommend("task", "high")
+
+	if dec.Skip {
+		t.Fatal("expected recommendation, got Skip")
+	}
+	// openclaw (subscription) is cheaper than claude-code (cli)
+	if dec.Driver != "openclaw" {
+		t.Fatalf("expected openclaw (subscription tier, cheaper), got %s", dec.Driver)
+	}
+}
+
+func TestHealthReport(t *testing.T) {
+	dir := t.TempDir()
+	writeHealth(t, dir, "claude-code", HealthFile{State: "CLOSED", Failures: 0})
+	writeHealth(t, dir, "copilot", HealthFile{State: "OPEN", Failures: 5, LastFailure: "2026-03-29T10:00:00Z"})
+
+	r := NewRouter(dir)
+	report := r.HealthReport()
+
+	if len(report) != 2 {
+		t.Fatalf("expected 2 drivers in report, got %d", len(report))
+	}
+
+	found := make(map[string]DriverHealth)
+	for _, dh := range report {
+		found[dh.Name] = dh
+	}
+
+	if cc, ok := found["claude-code"]; !ok {
+		t.Fatal("missing claude-code in report")
+	} else if cc.CircuitState != "CLOSED" {
+		t.Fatalf("expected CLOSED for claude-code, got %s", cc.CircuitState)
+	}
+
+	if cp, ok := found["copilot"]; !ok {
+		t.Fatal("missing copilot in report")
+	} else if cp.CircuitState != "OPEN" {
+		t.Fatalf("expected OPEN for copilot, got %s", cp.CircuitState)
+	} else if cp.Failures != 5 {
+		t.Fatalf("expected 5 failures for copilot, got %d", cp.Failures)
+	}
+}
+
+func TestDiscoverDrivers_EmptyDir(t *testing.T) {
+	dir := t.TempDir()
+	drivers := DiscoverDrivers(dir)
+	if len(drivers) != 0 {
+		t.Fatalf("expected 0 drivers in empty dir, got %d", len(drivers))
+	}
+}
+
+func TestDiscoverDrivers_NonexistentDir(t *testing.T) {
+	drivers := DiscoverDrivers("/nonexistent/path/that/does/not/exist")
+	if drivers != nil {
+		t.Fatalf("expected nil for nonexistent dir, got %v", drivers)
+	}
+}


### PR DESCRIPTION
## Summary
- **New `internal/routing` package** with budget-aware driver routing — reads circuit breaker health files, cascades through cost tiers (local -> subscription -> CLI -> API), and returns the cheapest healthy driver with fallback options
- **Replaced placeholder `route_recommend`** MCP tool with real routing logic that respects driver health state (CLOSED/OPEN/HALF) and budget constraints (low/medium/high)
- **New `health_report` MCP tool** so agents can query current swarm driver health before starting work
- **13 tests** covering tier ordering, OPEN driver skip, all-exhausted skip, budget caps, HALF-open confidence reduction, and health report accuracy

## Context
The swarm crashed at 36.6% pass rate because all 4 driver budgets exhausted simultaneously with no routing intelligence. This PR adds the core dispatch logic so Octi Pulpo can route tasks to the cheapest available driver and signal agents to skip when all drivers are down.

## Test plan
- [x] `go build ./cmd/octi-pulpo/` passes
- [x] `go test ./...` — 13 tests pass across all packages
- [x] `go vet ./...` clean
- [ ] Integration test: set AGENTGUARD_HEALTH_DIR to a test directory and invoke route_recommend via MCP stdio
- [ ] Validate with live driver health files on jared-box

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)