### PR TITLE
feat: event-driven dispatcher

### DIFF
--- a/cmd/octi-pulpo/main.go
+++ b/cmd/octi-pulpo/main.go
@@ -3,11 +3,14 @@ package main
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/AgentGuardHQ/octi-pulpo/internal/coordination"
+	"github.com/AgentGuardHQ/octi-pulpo/internal/dispatch"
 	"github.com/AgentGuardHQ/octi-pulpo/internal/mcp"
 	"github.com/AgentGuardHQ/octi-pulpo/internal/memory"
 	"github.com/AgentGuardHQ/octi-pulpo/internal/routing"
+	"github.com/redis/go-redis/v9"
 )
 
 func main() {
@@ -37,7 +40,41 @@ func main() {
 	healthDir := os.Getenv("AGENTGUARD_HEALTH_DIR")
 	router := routing.NewRouter(healthDir) // defaults to ~/.agentguard/driver-health/
 
+	// Set up the event-driven dispatcher
+	opts, err := redis.ParseURL(redisURL)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "parse redis url: %v\n", err)
+		os.Exit(1)
+	}
+	rdb := redis.NewClient(opts)
+	defer rdb.Close()
+
+	home, _ := os.UserHomeDir()
+	queueFile := os.Getenv("AGENTGUARD_QUEUE_FILE")
+	if queueFile == "" {
+		queueFile = filepath.Join(home, ".agentguard", "queue.txt")
+	}
+
+	eventRouter := dispatch.NewEventRouter(dispatch.DefaultRules())
+	dispatcher := dispatch.NewDispatcher(rdb, router, coord, eventRouter, queueFile, namespace)
+
 	server := mcp.New(mem, coord, router)
+	server.SetDispatcher(dispatcher)
+
+	// Optional HTTP mode: run webhook server alongside MCP
+	httpPort := os.Getenv("OCTI_HTTP_PORT")
+	if httpPort != "" {
+		secretFile := os.Getenv("AGENTGUARD_WEBHOOK_SECRET_FILE")
+		ws := dispatch.NewWebhookServer(dispatcher, secretFile)
+		go func() {
+			addr := ":" + httpPort
+			fmt.Fprintf(os.Stderr, "webhook server listening on %s\n", addr)
+			if err := ws.ListenAndServe(addr); err != nil {
+				fmt.Fprintf(os.Stderr, "webhook server: %v\n", err)
+			}
+		}()
+	}
+
 	if err := server.Serve(); err != nil {
 		fmt.Fprintf(os.Stderr, "server: %v\n", err)
 		os.Exit(1)

--- a/internal/dispatch/bridge.go
+++ b/internal/dispatch/bridge.go
@@ -1,0 +1,51 @@
+package dispatch
+
+import (
+	"bufio"
+	"os"
+	"strings"
+	"syscall"
+)
+
+// BridgeToFileQueue writes a dispatched agent to the legacy queue file (~/.agentguard/queue.txt)
+// for backward compatibility with existing workers.
+//
+// Migration path:
+//   - Phase 1 (now): Dispatcher writes to queue.txt (workers unchanged)
+//   - Phase 2 (later): Workers read from Redis priority queue directly
+//   - Phase 3 (final): Remove queue.txt entirely
+//
+// Uses flock to match existing enqueue.sh behavior.
+func (d *Dispatcher) BridgeToFileQueue(agentName string) error {
+	if d.queueFile == "" {
+		return nil // bridge disabled
+	}
+
+	// Open or create queue file
+	f, err := os.OpenFile(d.queueFile, os.O_RDWR|os.O_CREATE, 0644)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	// Acquire exclusive lock (matching enqueue.sh flock behavior)
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX); err != nil {
+		return err
+	}
+	defer syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+
+	// Check for duplicates -- don't enqueue if already present
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		if strings.TrimSpace(scanner.Text()) == agentName {
+			return nil // already queued
+		}
+	}
+
+	// Seek to end and append
+	if _, err := f.Seek(0, 2); err != nil {
+		return err
+	}
+	_, err = f.WriteString(agentName + "\n")
+	return err
+}

--- a/internal/dispatch/dispatcher.go
+++ b/internal/dispatch/dispatcher.go
@@ -1,0 +1,258 @@
+package dispatch
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/AgentGuardHQ/octi-pulpo/internal/coordination"
+	"github.com/AgentGuardHQ/octi-pulpo/internal/routing"
+	"github.com/redis/go-redis/v9"
+)
+
+// DispatchResult is the outcome of a dispatch decision.
+type DispatchResult struct {
+	Action    string `json:"action"`     // "dispatched", "skipped", "queued"
+	Agent     string `json:"agent"`      // agent name
+	Reason    string `json:"reason"`     // human-readable explanation
+	Driver    string `json:"driver"`     // chosen driver (empty if skipped)
+	QueuePos  int64  `json:"queue_pos"`  // position in queue (0 if not queued)
+	ClaimID   string `json:"claim_id"`   // coordination claim ID (empty if skipped)
+	Timestamp string `json:"timestamp"`
+}
+
+// DispatchRecord is persisted to Redis for observability.
+type DispatchRecord struct {
+	Agent     string `json:"agent"`
+	Event     Event  `json:"event"`
+	Result    string `json:"result"` // action taken
+	Reason    string `json:"reason"`
+	Driver    string `json:"driver"`
+	Timestamp string `json:"timestamp"`
+}
+
+// Dispatcher coordinates all agent scheduling based on events.
+type Dispatcher struct {
+	rdb       *redis.Client
+	router    *routing.Router
+	coord     *coordination.Engine
+	events    *EventRouter
+	queueFile string // ~/.agentguard/queue.txt (compatibility bridge)
+	namespace string
+}
+
+// NewDispatcher creates an event-driven dispatcher.
+func NewDispatcher(rdb *redis.Client, router *routing.Router, coord *coordination.Engine, events *EventRouter, queueFile, namespace string) *Dispatcher {
+	return &Dispatcher{
+		rdb:       rdb,
+		router:    router,
+		coord:     coord,
+		events:    events,
+		queueFile: queueFile,
+		namespace: namespace,
+	}
+}
+
+// Dispatch decides whether to run an agent based on event + coordination state.
+// The decision flow:
+//  1. Check cooldown -- has this agent been dispatched too recently?
+//  2. Check coord_claim -- is another instance already running/claimed?
+//  3. Check route_recommend -- is a healthy driver + budget available?
+//  4. If yes to all: claim the task + enqueue to priority queue
+//  5. If driver exhausted: queue for later (backpressure, don't fail)
+//  6. Return the decision with reason
+func (d *Dispatcher) Dispatch(ctx context.Context, event Event, agentName string, priority int) (DispatchResult, error) {
+	now := time.Now().UTC()
+	result := DispatchResult{
+		Agent:     agentName,
+		Timestamp: now.Format(time.RFC3339),
+	}
+
+	// 1. Check cooldown
+	cooldownKey := d.key("cooldown:" + agentName)
+	exists, err := d.rdb.Exists(ctx, cooldownKey).Result()
+	if err != nil {
+		return result, fmt.Errorf("check cooldown: %w", err)
+	}
+	if exists > 0 {
+		ttl, _ := d.rdb.TTL(ctx, cooldownKey).Result()
+		result.Action = "skipped"
+		result.Reason = fmt.Sprintf("cooldown active (%s remaining)", ttl.Round(time.Second))
+		d.recordDispatch(ctx, agentName, event, result)
+		return result, nil
+	}
+
+	// 2. Check coordination claims -- is this agent already running?
+	claimKey := d.key("claim:" + agentName)
+	claimExists, err := d.rdb.Exists(ctx, claimKey).Result()
+	if err != nil {
+		return result, fmt.Errorf("check claim: %w", err)
+	}
+	if claimExists > 0 {
+		result.Action = "skipped"
+		result.Reason = "agent already has active claim (another instance running)"
+		d.recordDispatch(ctx, agentName, event, result)
+		return result, nil
+	}
+
+	// 3. Check driver health/budget
+	routeDecision := d.router.Recommend(agentName, "high")
+
+	if routeDecision.Skip {
+		// All drivers exhausted -- queue for later (backpressure)
+		if err := d.Enqueue(ctx, agentName, priority); err != nil {
+			return result, fmt.Errorf("enqueue for backpressure: %w", err)
+		}
+		queueDepth, _ := d.PendingCount(ctx)
+		result.Action = "queued"
+		result.Reason = fmt.Sprintf("all drivers exhausted — queued for retry (depth: %d)", queueDepth)
+		result.QueuePos = queueDepth
+		d.recordDispatch(ctx, agentName, event, result)
+		return result, nil
+	}
+
+	// 4. All checks pass -- claim + enqueue + set cooldown
+	claim, err := d.coord.ClaimTask(ctx, agentName, fmt.Sprintf("event:%s", event.Type), 900)
+	if err != nil {
+		return result, fmt.Errorf("claim task: %w", err)
+	}
+
+	// Set cooldown based on event rules
+	cooldown := d.events.CooldownFor(agentName)
+	if cooldown > 0 {
+		d.rdb.Set(ctx, cooldownKey, "1", cooldown)
+	}
+
+	// Enqueue to priority queue
+	if err := d.Enqueue(ctx, agentName, priority); err != nil {
+		return result, fmt.Errorf("enqueue: %w", err)
+	}
+
+	// Bridge to file queue for backward compatibility
+	if bridgeErr := d.BridgeToFileQueue(agentName); bridgeErr != nil {
+		// Non-fatal: Redis queue is the source of truth, file queue is just compatibility
+		_ = bridgeErr
+	}
+
+	queueDepth, _ := d.PendingCount(ctx)
+	result.Action = "dispatched"
+	result.Reason = fmt.Sprintf("dispatched via %s (tier: %s, confidence: %.1f)", routeDecision.Driver, routeDecision.Tier, routeDecision.Confidence)
+	result.Driver = routeDecision.Driver
+	result.ClaimID = claim.ClaimID
+	result.QueuePos = queueDepth
+
+	d.recordDispatch(ctx, agentName, event, result)
+	return result, nil
+}
+
+// DispatchEvent routes an event through the event rules and dispatches matching agents.
+func (d *Dispatcher) DispatchEvent(ctx context.Context, event Event) ([]DispatchResult, error) {
+	matches := d.events.Match(event)
+	if len(matches) == 0 {
+		return nil, nil
+	}
+
+	var results []DispatchResult
+	for _, rule := range matches {
+		priority := rule.Priority
+		if event.Priority > 0 && event.Priority < priority {
+			priority = event.Priority // event can escalate, not downgrade
+		}
+		result, err := d.Dispatch(ctx, event, rule.AgentName, priority)
+		if err != nil {
+			results = append(results, DispatchResult{
+				Agent:     rule.AgentName,
+				Action:    "error",
+				Reason:    err.Error(),
+				Timestamp: time.Now().UTC().Format(time.RFC3339),
+			})
+			continue
+		}
+		results = append(results, result)
+	}
+	return results, nil
+}
+
+// Enqueue adds agent to the priority queue (Redis sorted set).
+// Score = priority * 1e12 + unix_ms (lower score = higher priority, FIFO within tier).
+func (d *Dispatcher) Enqueue(ctx context.Context, agentName string, priority int) error {
+	score := float64(priority)*1e12 + float64(time.Now().UnixMilli())
+	return d.rdb.ZAdd(ctx, d.key("dispatch-queue"), redis.Z{
+		Score:  score,
+		Member: agentName,
+	}).Err()
+}
+
+// Dequeue returns the highest-priority agent (lowest score) and removes it from the queue.
+func (d *Dispatcher) Dequeue(ctx context.Context) (string, error) {
+	results, err := d.rdb.ZPopMin(ctx, d.key("dispatch-queue"), 1).Result()
+	if err != nil {
+		return "", err
+	}
+	if len(results) == 0 {
+		return "", nil
+	}
+	return results[0].Member.(string), nil
+}
+
+// PendingCount returns the queue depth.
+func (d *Dispatcher) PendingCount(ctx context.Context) (int64, error) {
+	return d.rdb.ZCard(ctx, d.key("dispatch-queue")).Result()
+}
+
+// PendingAgents returns all agents currently in the queue, ordered by priority.
+func (d *Dispatcher) PendingAgents(ctx context.Context) ([]string, error) {
+	return d.rdb.ZRange(ctx, d.key("dispatch-queue"), 0, -1).Result()
+}
+
+// RecentDispatches returns the last N dispatch decisions for observability.
+func (d *Dispatcher) RecentDispatches(ctx context.Context, limit int) ([]DispatchRecord, error) {
+	raw, err := d.rdb.LRange(ctx, d.key("dispatch-log"), 0, int64(limit)-1).Result()
+	if err != nil {
+		return nil, err
+	}
+	var records []DispatchRecord
+	for _, r := range raw {
+		var rec DispatchRecord
+		if err := json.Unmarshal([]byte(r), &rec); err != nil {
+			continue
+		}
+		records = append(records, rec)
+	}
+	return records, nil
+}
+
+// SetCooldown manually sets a cooldown for an agent.
+func (d *Dispatcher) SetCooldown(ctx context.Context, agentName string, duration time.Duration) error {
+	return d.rdb.Set(ctx, d.key("cooldown:"+agentName), "1", duration).Err()
+}
+
+// ClearCooldown removes a cooldown for an agent.
+func (d *Dispatcher) ClearCooldown(ctx context.Context, agentName string) error {
+	return d.rdb.Del(ctx, d.key("cooldown:"+agentName)).Err()
+}
+
+func (d *Dispatcher) recordDispatch(ctx context.Context, agentName string, event Event, result DispatchResult) {
+	record := DispatchRecord{
+		Agent:     agentName,
+		Event:     event,
+		Result:    result.Action,
+		Reason:    result.Reason,
+		Driver:    result.Driver,
+		Timestamp: result.Timestamp,
+	}
+	data, err := json.Marshal(record)
+	if err != nil {
+		return
+	}
+
+	pipe := d.rdb.Pipeline()
+	pipe.LPush(ctx, d.key("dispatch-log"), data)
+	pipe.LTrim(ctx, d.key("dispatch-log"), 0, 499) // keep last 500
+	pipe.Exec(ctx)
+}
+
+func (d *Dispatcher) key(suffix string) string {
+	return d.namespace + ":" + suffix
+}

--- a/internal/dispatch/dispatcher_test.go
+++ b/internal/dispatch/dispatcher_test.go
@@ -1,0 +1,488 @@
+package dispatch
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/AgentGuardHQ/octi-pulpo/internal/coordination"
+	"github.com/AgentGuardHQ/octi-pulpo/internal/routing"
+	"github.com/redis/go-redis/v9"
+)
+
+// testSetup creates a Dispatcher backed by real Redis for integration tests.
+// Requires Redis on localhost:6379 (the standard dev setup).
+func testSetup(t *testing.T) (*Dispatcher, context.Context) {
+	t.Helper()
+
+	redisURL := os.Getenv("OCTI_REDIS_URL")
+	if redisURL == "" {
+		redisURL = "redis://localhost:6379"
+	}
+
+	opts, err := redis.ParseURL(redisURL)
+	if err != nil {
+		t.Skipf("skipping: cannot parse redis URL: %v", err)
+	}
+	rdb := redis.NewClient(opts)
+
+	ctx := context.Background()
+	if err := rdb.Ping(ctx).Err(); err != nil {
+		t.Skipf("skipping: redis not available: %v", err)
+	}
+
+	// Use a unique namespace per test to avoid cross-contamination
+	ns := "octi-test-" + t.Name()
+
+	// Clean up test keys before and after
+	cleanup := func() {
+		keys, _ := rdb.Keys(ctx, ns+":*").Result()
+		if len(keys) > 0 {
+			rdb.Del(ctx, keys...)
+		}
+	}
+	cleanup()
+	t.Cleanup(func() {
+		cleanup()
+		rdb.Close()
+	})
+
+	// Create a health directory with a healthy driver
+	healthDir := t.TempDir()
+	writeHealthFile(t, healthDir, "claude-code", "CLOSED")
+
+	coord, err := coordination.New(redisURL, ns)
+	if err != nil {
+		t.Fatalf("coordination engine: %v", err)
+	}
+	t.Cleanup(func() { coord.Close() })
+
+	router := routing.NewRouter(healthDir)
+	eventRouter := NewEventRouter(DefaultRules())
+
+	queueFile := filepath.Join(t.TempDir(), "queue.txt")
+
+	d := NewDispatcher(rdb, router, coord, eventRouter, queueFile, ns)
+	return d, ctx
+}
+
+func writeHealthFile(t *testing.T, dir, driver, state string) {
+	t.Helper()
+	hf := map[string]interface{}{"state": state, "failures": 0}
+	data, _ := json.Marshal(hf)
+	if err := os.WriteFile(filepath.Join(dir, driver+".json"), data, 0644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// --- Dispatch Tests ---
+
+func TestDispatch_BasicSuccess(t *testing.T) {
+	d, ctx := testSetup(t)
+
+	event := Event{Type: EventManual, Source: "test"}
+	result, err := d.Dispatch(ctx, event, "test-agent", 2)
+	if err != nil {
+		t.Fatalf("dispatch error: %v", err)
+	}
+
+	if result.Action != "dispatched" {
+		t.Fatalf("expected action=dispatched, got %s (reason: %s)", result.Action, result.Reason)
+	}
+	if result.Driver == "" {
+		t.Fatal("expected a driver to be assigned")
+	}
+	if result.ClaimID == "" {
+		t.Fatal("expected a claim ID")
+	}
+}
+
+func TestDispatch_RespectsCoordClaim(t *testing.T) {
+	d, ctx := testSetup(t)
+
+	// First dispatch succeeds and creates a claim
+	event := Event{Type: EventManual, Source: "test"}
+	result1, err := d.Dispatch(ctx, event, "agent-dedup", 2)
+	if err != nil {
+		t.Fatalf("first dispatch: %v", err)
+	}
+	if result1.Action != "dispatched" {
+		t.Fatalf("expected first dispatch to succeed, got %s", result1.Action)
+	}
+
+	// Second dispatch should be skipped (agent already has a claim)
+	result2, err := d.Dispatch(ctx, event, "agent-dedup", 2)
+	if err != nil {
+		t.Fatalf("second dispatch: %v", err)
+	}
+	if result2.Action != "skipped" {
+		t.Fatalf("expected second dispatch to be skipped, got %s (reason: %s)", result2.Action, result2.Reason)
+	}
+	if result2.Reason == "" {
+		t.Fatal("expected a reason for skip")
+	}
+}
+
+func TestDispatch_CooldownPreventsRapidRedispatch(t *testing.T) {
+	d, ctx := testSetup(t)
+
+	// Set a short cooldown for this test agent
+	d.SetCooldown(ctx, "cooldown-agent", 5*time.Second)
+
+	event := Event{Type: EventManual, Source: "test"}
+	result, err := d.Dispatch(ctx, event, "cooldown-agent", 2)
+	if err != nil {
+		t.Fatalf("dispatch error: %v", err)
+	}
+	if result.Action != "skipped" {
+		t.Fatalf("expected skipped due to cooldown, got %s", result.Action)
+	}
+	if result.Reason == "" || result.Reason == "agent already has active claim (another instance running)" {
+		t.Fatalf("expected cooldown reason, got: %s", result.Reason)
+	}
+}
+
+func TestDispatch_DriversExhausted_QueuesForLater(t *testing.T) {
+	redisURL := os.Getenv("OCTI_REDIS_URL")
+	if redisURL == "" {
+		redisURL = "redis://localhost:6379"
+	}
+	opts, err := redis.ParseURL(redisURL)
+	if err != nil {
+		t.Skipf("skipping: %v", err)
+	}
+	rdb := redis.NewClient(opts)
+	ctx := context.Background()
+	if err := rdb.Ping(ctx).Err(); err != nil {
+		t.Skipf("skipping: redis not available: %v", err)
+	}
+
+	ns := "octi-test-exhausted"
+	keys, _ := rdb.Keys(ctx, ns+":*").Result()
+	if len(keys) > 0 {
+		rdb.Del(ctx, keys...)
+	}
+	t.Cleanup(func() {
+		keys, _ := rdb.Keys(ctx, ns+":*").Result()
+		if len(keys) > 0 {
+			rdb.Del(ctx, keys...)
+		}
+		rdb.Close()
+	})
+
+	// Health directory with ALL drivers OPEN
+	healthDir := t.TempDir()
+	writeHealthFile(t, healthDir, "claude-code", "OPEN")
+	writeHealthFile(t, healthDir, "copilot", "OPEN")
+
+	coord, _ := coordination.New(redisURL, ns)
+	t.Cleanup(func() { coord.Close() })
+
+	router := routing.NewRouter(healthDir)
+	eventRouter := NewEventRouter(DefaultRules())
+	d := NewDispatcher(rdb, router, coord, eventRouter, "", ns)
+
+	event := Event{Type: EventManual, Source: "test"}
+	result, err := d.Dispatch(ctx, event, "queued-agent", 2)
+	if err != nil {
+		t.Fatalf("dispatch error: %v", err)
+	}
+	if result.Action != "queued" {
+		t.Fatalf("expected action=queued when all drivers OPEN, got %s (reason: %s)", result.Action, result.Reason)
+	}
+	if result.QueuePos < 1 {
+		t.Fatalf("expected queue position >= 1, got %d", result.QueuePos)
+	}
+}
+
+// --- Priority Queue Tests ---
+
+func TestPriorityQueue_Ordering(t *testing.T) {
+	d, ctx := testSetup(t)
+
+	// Enqueue agents with different priorities
+	d.Enqueue(ctx, "background-agent", 3)
+	d.Enqueue(ctx, "critical-agent", 0)
+	d.Enqueue(ctx, "normal-agent", 2)
+	d.Enqueue(ctx, "high-agent", 1)
+
+	// Dequeue should return in priority order (lowest score first)
+	expected := []string{"critical-agent", "high-agent", "normal-agent", "background-agent"}
+	for _, want := range expected {
+		got, err := d.Dequeue(ctx)
+		if err != nil {
+			t.Fatalf("dequeue error: %v", err)
+		}
+		if got != want {
+			t.Fatalf("expected %s, got %s", want, got)
+		}
+	}
+
+	// Queue should be empty now
+	count, _ := d.PendingCount(ctx)
+	if count != 0 {
+		t.Fatalf("expected empty queue, got %d", count)
+	}
+}
+
+func TestPriorityQueue_DequeueEmpty(t *testing.T) {
+	d, ctx := testSetup(t)
+
+	agent, err := d.Dequeue(ctx)
+	if err != nil {
+		t.Fatalf("dequeue error: %v", err)
+	}
+	if agent != "" {
+		t.Fatalf("expected empty string from empty queue, got %s", agent)
+	}
+}
+
+func TestPriorityQueue_PendingCount(t *testing.T) {
+	d, ctx := testSetup(t)
+
+	d.Enqueue(ctx, "a", 1)
+	d.Enqueue(ctx, "b", 2)
+	d.Enqueue(ctx, "c", 3)
+
+	count, err := d.PendingCount(ctx)
+	if err != nil {
+		t.Fatalf("pending count error: %v", err)
+	}
+	if count != 3 {
+		t.Fatalf("expected 3 pending, got %d", count)
+	}
+}
+
+// --- Event Routing Tests ---
+
+func TestEventRouter_MatchesPROpened(t *testing.T) {
+	er := NewEventRouter(DefaultRules())
+
+	event := Event{
+		Type:   EventPROpened,
+		Source: "github",
+		Repo:   "AgentGuardHQ/agentguard",
+	}
+
+	matches := er.Match(event)
+	if len(matches) == 0 {
+		t.Fatal("expected at least one match for pr.opened on AgentGuardHQ/agentguard")
+	}
+
+	found := false
+	for _, m := range matches {
+		if m.AgentName == "workspace-pr-review-agent" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatal("expected workspace-pr-review-agent to match")
+	}
+}
+
+func TestEventRouter_MatchesCICompleted(t *testing.T) {
+	er := NewEventRouter(DefaultRules())
+
+	event := Event{
+		Type:   EventCICompleted,
+		Source: "github",
+		Repo:   "AgentGuardHQ/agentguard-cloud",
+	}
+
+	matches := er.Match(event)
+	found := false
+	for _, m := range matches {
+		if m.AgentName == "pr-merger-agent-cloud" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatal("expected pr-merger-agent-cloud to match ci.completed on agentguard-cloud")
+	}
+}
+
+func TestEventRouter_NoMatchForUnknownRepo(t *testing.T) {
+	er := NewEventRouter(DefaultRules())
+
+	event := Event{
+		Type:   EventPROpened,
+		Source: "github",
+		Repo:   "SomeOrg/some-repo",
+	}
+
+	matches := er.Match(event)
+	if len(matches) != 0 {
+		t.Fatalf("expected no matches for unknown repo, got %d", len(matches))
+	}
+}
+
+func TestEventRouter_TimerMatchesWithoutRepo(t *testing.T) {
+	er := NewEventRouter(DefaultRules())
+
+	event := Event{
+		Type:   EventTimer,
+		Source: "cron",
+	}
+
+	matches := er.Match(event)
+	if len(matches) == 0 {
+		t.Fatal("expected timer events to match agents")
+	}
+
+	agentNames := make(map[string]bool)
+	for _, m := range matches {
+		agentNames[m.AgentName] = true
+	}
+	if !agentNames["kernel-sr"] {
+		t.Fatal("expected kernel-sr in timer matches")
+	}
+}
+
+func TestEventRouter_CooldownFor(t *testing.T) {
+	er := NewEventRouter(DefaultRules())
+
+	cd := er.CooldownFor("pr-merger-agent")
+	if cd != 10*time.Minute {
+		t.Fatalf("expected 10m cooldown for pr-merger-agent, got %s", cd)
+	}
+
+	cd = er.CooldownFor("kernel-sr")
+	if cd != 3*time.Hour {
+		t.Fatalf("expected 3h cooldown for kernel-sr, got %s", cd)
+	}
+}
+
+// --- Bridge Tests ---
+
+func TestBridgeToFileQueue(t *testing.T) {
+	d, _ := testSetup(t)
+
+	// Override queue file to a temp location
+	queueFile := filepath.Join(t.TempDir(), "queue.txt")
+	d.queueFile = queueFile
+
+	// Write first agent
+	err := d.BridgeToFileQueue("agent-a")
+	if err != nil {
+		t.Fatalf("bridge error: %v", err)
+	}
+
+	// Write second agent
+	err = d.BridgeToFileQueue("agent-b")
+	if err != nil {
+		t.Fatalf("bridge error: %v", err)
+	}
+
+	// Read and verify
+	data, err := os.ReadFile(queueFile)
+	if err != nil {
+		t.Fatalf("read queue file: %v", err)
+	}
+	content := string(data)
+	if content != "agent-a\nagent-b\n" {
+		t.Fatalf("expected 'agent-a\\nagent-b\\n', got %q", content)
+	}
+}
+
+func TestBridgeToFileQueue_Dedup(t *testing.T) {
+	d, _ := testSetup(t)
+
+	queueFile := filepath.Join(t.TempDir(), "queue.txt")
+	d.queueFile = queueFile
+
+	// Write same agent twice
+	d.BridgeToFileQueue("agent-dup")
+	d.BridgeToFileQueue("agent-dup")
+
+	data, _ := os.ReadFile(queueFile)
+	content := string(data)
+	if content != "agent-dup\n" {
+		t.Fatalf("expected single entry, got %q", content)
+	}
+}
+
+func TestBridgeToFileQueue_Disabled(t *testing.T) {
+	d, _ := testSetup(t)
+	d.queueFile = "" // disable bridge
+
+	err := d.BridgeToFileQueue("agent-x")
+	if err != nil {
+		t.Fatalf("expected no error when bridge disabled, got %v", err)
+	}
+}
+
+// --- DispatchEvent Integration Tests ---
+
+func TestDispatchEvent_PROpenedRoutes(t *testing.T) {
+	d, ctx := testSetup(t)
+
+	event := Event{
+		Type:   EventPROpened,
+		Source: "github",
+		Repo:   "AgentGuardHQ/agentguard",
+	}
+
+	results, err := d.DispatchEvent(ctx, event)
+	if err != nil {
+		t.Fatalf("dispatch event error: %v", err)
+	}
+	if len(results) == 0 {
+		t.Fatal("expected at least one dispatch result")
+	}
+
+	found := false
+	for _, r := range results {
+		if r.Agent == "workspace-pr-review-agent" {
+			found = true
+			if r.Action != "dispatched" {
+				t.Fatalf("expected dispatched, got %s (reason: %s)", r.Action, r.Reason)
+			}
+			break
+		}
+	}
+	if !found {
+		t.Fatal("expected workspace-pr-review-agent in results")
+	}
+}
+
+func TestDispatchEvent_NoRulesMatch(t *testing.T) {
+	d, ctx := testSetup(t)
+
+	event := Event{
+		Type:   EventBudgetChange,
+		Source: "system",
+	}
+
+	results, err := d.DispatchEvent(ctx, event)
+	if err != nil {
+		t.Fatalf("dispatch event error: %v", err)
+	}
+	if len(results) != 0 {
+		t.Fatalf("expected no results for unmatched event, got %d", len(results))
+	}
+}
+
+// --- Dispatch Record Tests ---
+
+func TestRecentDispatches_Recorded(t *testing.T) {
+	d, ctx := testSetup(t)
+
+	event := Event{Type: EventManual, Source: "test"}
+	d.Dispatch(ctx, event, "recorded-agent", 1)
+
+	records, err := d.RecentDispatches(ctx, 10)
+	if err != nil {
+		t.Fatalf("recent dispatches error: %v", err)
+	}
+	if len(records) == 0 {
+		t.Fatal("expected at least one dispatch record")
+	}
+	if records[0].Agent != "recorded-agent" {
+		t.Fatalf("expected recorded-agent, got %s", records[0].Agent)
+	}
+}

--- a/internal/dispatch/events.go
+++ b/internal/dispatch/events.go
@@ -1,0 +1,210 @@
+package dispatch
+
+import (
+	"path/filepath"
+	"time"
+)
+
+// EventType classifies the trigger for a dispatch.
+type EventType string
+
+const (
+	EventPROpened     EventType = "pr.opened"
+	EventPRUpdated    EventType = "pr.updated"
+	EventCICompleted  EventType = "ci.completed"
+	EventTimer        EventType = "timer"         // replaces cron
+	EventBudgetChange EventType = "budget.change"
+	EventManual       EventType = "manual"
+	EventSlackAction  EventType = "slack.action"
+)
+
+// Event is the core unit of work entering the dispatcher.
+type Event struct {
+	Type     EventType         `json:"type"`
+	Source   string            `json:"source"`   // "github", "cron", "slack", "manual"
+	Repo     string            `json:"repo"`     // "AgentGuardHQ/agentguard"
+	Payload  map[string]string `json:"payload"`  // event-specific data
+	Priority int               `json:"priority"` // 0=critical, 1=high, 2=normal, 3=background
+}
+
+// EventRule maps an event pattern to an agent that should handle it.
+type EventRule struct {
+	EventType EventType     // which event triggers this rule
+	RepoMatch string        // glob pattern, e.g. "AgentGuardHQ/*"
+	AgentName string        // agent to dispatch
+	Priority  int           // default priority for this rule
+	Cooldown  time.Duration // minimum time between dispatches for same agent
+}
+
+// EventRouter maps incoming events to the agents that should handle them.
+type EventRouter struct {
+	rules []EventRule
+}
+
+// NewEventRouter creates a router with the given rules.
+func NewEventRouter(rules []EventRule) *EventRouter {
+	return &EventRouter{rules: rules}
+}
+
+// Match returns all rules that match the given event.
+func (er *EventRouter) Match(event Event) []EventRule {
+	var matched []EventRule
+	for _, rule := range er.rules {
+		if rule.EventType != event.Type {
+			continue
+		}
+		if rule.RepoMatch != "" && event.Repo != "" {
+			ok, _ := filepath.Match(rule.RepoMatch, event.Repo)
+			if !ok {
+				continue
+			}
+		}
+		matched = append(matched, rule)
+	}
+	return matched
+}
+
+// CooldownFor returns the cooldown duration for an agent.
+// Returns the longest cooldown if multiple rules reference the same agent.
+func (er *EventRouter) CooldownFor(agentName string) time.Duration {
+	var longest time.Duration
+	for _, rule := range er.rules {
+		if rule.AgentName == agentName && rule.Cooldown > longest {
+			longest = rule.Cooldown
+		}
+	}
+	return longest
+}
+
+// DefaultRules returns the standard event routing rules matching
+// the existing webhook-listener.py mappings and schedule.json timers.
+func DefaultRules() []EventRule {
+	return []EventRule{
+		// PR review agents (triggered by PR events)
+		{
+			EventType: EventPROpened,
+			RepoMatch: "AgentGuardHQ/agentguard",
+			AgentName: "workspace-pr-review-agent",
+			Priority:  1,
+			Cooldown:  5 * time.Minute,
+		},
+		{
+			EventType: EventPRUpdated,
+			RepoMatch: "AgentGuardHQ/agentguard",
+			AgentName: "workspace-pr-review-agent",
+			Priority:  1,
+			Cooldown:  5 * time.Minute,
+		},
+		{
+			EventType: EventPROpened,
+			RepoMatch: "AgentGuardHQ/agentguard-cloud",
+			AgentName: "code-review-agent-cloud",
+			Priority:  1,
+			Cooldown:  5 * time.Minute,
+		},
+		{
+			EventType: EventPRUpdated,
+			RepoMatch: "AgentGuardHQ/agentguard-cloud",
+			AgentName: "code-review-agent-cloud",
+			Priority:  1,
+			Cooldown:  5 * time.Minute,
+		},
+		{
+			EventType: EventPROpened,
+			RepoMatch: "AgentGuardHQ/agentguard-analytics",
+			AgentName: "analytics-pr-review-agent",
+			Priority:  1,
+			Cooldown:  5 * time.Minute,
+		},
+		{
+			EventType: EventPROpened,
+			RepoMatch: "AgentGuardHQ/agentguard-workspace",
+			AgentName: "workspace-pr-review-agent",
+			Priority:  1,
+			Cooldown:  5 * time.Minute,
+		},
+
+		// PR merger agents (triggered by CI completion)
+		{
+			EventType: EventCICompleted,
+			RepoMatch: "AgentGuardHQ/agentguard",
+			AgentName: "pr-merger-agent",
+			Priority:  2,
+			Cooldown:  10 * time.Minute, // prevents stampede (was 214 runs/day)
+		},
+		{
+			EventType: EventCICompleted,
+			RepoMatch: "AgentGuardHQ/agentguard-cloud",
+			AgentName: "pr-merger-agent-cloud",
+			Priority:  2,
+			Cooldown:  10 * time.Minute,
+		},
+		{
+			EventType: EventCICompleted,
+			RepoMatch: "AgentGuardHQ/agentguard-analytics",
+			AgentName: "analytics-pr-review-agent",
+			Priority:  2,
+			Cooldown:  10 * time.Minute,
+		},
+		{
+			EventType: EventCICompleted,
+			RepoMatch: "AgentGuardHQ/agentguard-workspace",
+			AgentName: "pr-merger-agent",
+			Priority:  2,
+			Cooldown:  10 * time.Minute,
+		},
+
+		// Timer-based agents (replacing blind cron)
+		{
+			EventType: EventTimer,
+			RepoMatch: "",
+			AgentName: "kernel-sr",
+			Priority:  2,
+			Cooldown:  3 * time.Hour,
+		},
+		{
+			EventType: EventTimer,
+			RepoMatch: "",
+			AgentName: "kernel-em",
+			Priority:  1,
+			Cooldown:  6 * time.Hour,
+		},
+		{
+			EventType: EventTimer,
+			RepoMatch: "",
+			AgentName: "cloud-em",
+			Priority:  1,
+			Cooldown:  6 * time.Hour,
+		},
+		{
+			EventType: EventTimer,
+			RepoMatch: "",
+			AgentName: "platform-em",
+			Priority:  1,
+			Cooldown:  6 * time.Hour,
+		},
+		{
+			EventType: EventTimer,
+			RepoMatch: "",
+			AgentName: "analytics-em",
+			Priority:  1,
+			Cooldown:  6 * time.Hour,
+		},
+
+		// Manual and Slack triggers (no cooldown -- explicit human action)
+		{
+			EventType: EventManual,
+			RepoMatch: "",
+			AgentName: "*", // wildcard -- manual can trigger any agent
+			Priority:  0,
+			Cooldown:  0,
+		},
+		{
+			EventType: EventSlackAction,
+			RepoMatch: "",
+			AgentName: "*",
+			Priority:  1,
+			Cooldown:  2 * time.Minute,
+		},
+	}
+}

--- a/internal/dispatch/webhook.go
+++ b/internal/dispatch/webhook.go
@@ -1,0 +1,297 @@
+package dispatch
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// WebhookServer is a lightweight HTTP server for receiving GitHub webhooks.
+// It replaces webhook-listener.py with coordinated dispatch.
+type WebhookServer struct {
+	dispatcher *Dispatcher
+	secret     []byte
+	mux        *http.ServeMux
+}
+
+// NewWebhookServer creates a webhook handler backed by the dispatcher.
+// If secretFile is empty, it defaults to ~/.agentguard/webhook-secret.
+func NewWebhookServer(dispatcher *Dispatcher, secretFile string) *WebhookServer {
+	if secretFile == "" {
+		home, _ := os.UserHomeDir()
+		secretFile = filepath.Join(home, ".agentguard", "webhook-secret")
+	}
+
+	var secret []byte
+	if data, err := os.ReadFile(secretFile); err == nil {
+		secret = []byte(strings.TrimSpace(string(data)))
+	}
+
+	ws := &WebhookServer{
+		dispatcher: dispatcher,
+		secret:     secret,
+		mux:        http.NewServeMux(),
+	}
+	ws.mux.HandleFunc("/webhook", ws.handleWebhook)
+	ws.mux.HandleFunc("/health", ws.handleHealth)
+	ws.mux.HandleFunc("/dispatch/status", ws.handleStatus)
+	ws.mux.HandleFunc("/dispatch/trigger", ws.handleTrigger)
+	return ws
+}
+
+// ServeHTTP implements the http.Handler interface.
+func (ws *WebhookServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	ws.mux.ServeHTTP(w, r)
+}
+
+// ListenAndServe starts the webhook server on the given address.
+func (ws *WebhookServer) ListenAndServe(addr string) error {
+	server := &http.Server{
+		Addr:         addr,
+		Handler:      ws,
+		ReadTimeout:  10 * time.Second,
+		WriteTimeout: 10 * time.Second,
+	}
+	return server.ListenAndServe()
+}
+
+func (ws *WebhookServer) handleHealth(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(map[string]string{"status": "ok", "service": "octi-pulpo"})
+}
+
+func (ws *WebhookServer) handleWebhook(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		http.Error(w, "read body failed", http.StatusBadRequest)
+		return
+	}
+	defer r.Body.Close()
+
+	// Verify HMAC-SHA256 signature if secret is configured
+	if len(ws.secret) > 0 {
+		sig := r.Header.Get("X-Hub-Signature-256")
+		if !ws.verifySignature(body, sig) {
+			http.Error(w, "invalid signature", http.StatusForbidden)
+			return
+		}
+	}
+
+	// Parse the GitHub payload
+	var payload map[string]interface{}
+	if err := json.Unmarshal(body, &payload); err != nil {
+		http.Error(w, "invalid JSON", http.StatusBadRequest)
+		return
+	}
+
+	githubEvent := r.Header.Get("X-GitHub-Event")
+	action := getString(payload, "action")
+	repo := getNestedString(payload, "repository", "full_name")
+
+	// Convert GitHub event to our Event type
+	event := ws.parseGitHubEvent(githubEvent, action, repo, payload)
+	if event == nil {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(map[string]interface{}{"ok": true, "action": "ignored"})
+		return
+	}
+
+	// Dispatch through the coordinator
+	ctx := context.Background()
+	results, err := ws.dispatcher.DispatchEvent(ctx, *event)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(map[string]interface{}{"ok": true, "dispatched": results})
+}
+
+func (ws *WebhookServer) handleStatus(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	ctx := context.Background()
+	depth, _ := ws.dispatcher.PendingCount(ctx)
+	agents, _ := ws.dispatcher.PendingAgents(ctx)
+	recent, _ := ws.dispatcher.RecentDispatches(ctx, 20)
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"queue_depth":      depth,
+		"pending_agents":   agents,
+		"recent_dispatches": recent,
+	})
+}
+
+func (ws *WebhookServer) handleTrigger(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var req struct {
+		Agent    string `json:"agent"`
+		Priority int    `json:"priority"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "invalid JSON body", http.StatusBadRequest)
+		return
+	}
+	if req.Agent == "" {
+		http.Error(w, "agent name required", http.StatusBadRequest)
+		return
+	}
+
+	event := Event{
+		Type:     EventManual,
+		Source:   "http",
+		Priority: req.Priority,
+		Payload:  map[string]string{"triggered_by": "http_api"},
+	}
+
+	ctx := context.Background()
+	result, err := ws.dispatcher.Dispatch(ctx, event, req.Agent, req.Priority)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(result)
+}
+
+func (ws *WebhookServer) parseGitHubEvent(eventType, action, repo string, payload map[string]interface{}) *Event {
+	switch eventType {
+	case "pull_request":
+		switch action {
+		case "opened", "ready_for_review":
+			return &Event{
+				Type:     EventPROpened,
+				Source:   "github",
+				Repo:     repo,
+				Priority: 1,
+				Payload: map[string]string{
+					"action":    action,
+					"pr_number": fmt.Sprintf("%.0f", getNestedNumber(payload, "pull_request", "number")),
+				},
+			}
+		case "synchronize":
+			return &Event{
+				Type:     EventPRUpdated,
+				Source:   "github",
+				Repo:     repo,
+				Priority: 1,
+				Payload: map[string]string{
+					"action":    action,
+					"pr_number": fmt.Sprintf("%.0f", getNestedNumber(payload, "pull_request", "number")),
+				},
+			}
+		}
+
+	case "check_suite", "check_run":
+		if action == "completed" {
+			return &Event{
+				Type:     EventCICompleted,
+				Source:   "github",
+				Repo:     repo,
+				Priority: 2,
+				Payload: map[string]string{
+					"event_type": eventType,
+					"action":     action,
+				},
+			}
+		}
+	}
+
+	return nil // unrecognized event
+}
+
+func (ws *WebhookServer) verifySignature(payload []byte, signature string) bool {
+	if !strings.HasPrefix(signature, "sha256=") {
+		return false
+	}
+	sigBytes, err := hex.DecodeString(strings.TrimPrefix(signature, "sha256="))
+	if err != nil {
+		return false
+	}
+	mac := hmac.New(sha256.New, ws.secret)
+	mac.Write(payload)
+	expected := mac.Sum(nil)
+	return hmac.Equal(sigBytes, expected)
+}
+
+// JSON helper functions for navigating untyped webhook payloads.
+
+func getString(m map[string]interface{}, key string) string {
+	if v, ok := m[key]; ok {
+		if s, ok := v.(string); ok {
+			return s
+		}
+	}
+	return ""
+}
+
+func getNestedString(m map[string]interface{}, keys ...string) string {
+	current := m
+	for i, key := range keys {
+		v, ok := current[key]
+		if !ok {
+			return ""
+		}
+		if i == len(keys)-1 {
+			if s, ok := v.(string); ok {
+				return s
+			}
+			return ""
+		}
+		if next, ok := v.(map[string]interface{}); ok {
+			current = next
+		} else {
+			return ""
+		}
+	}
+	return ""
+}
+
+func getNestedNumber(m map[string]interface{}, keys ...string) float64 {
+	current := m
+	for i, key := range keys {
+		v, ok := current[key]
+		if !ok {
+			return 0
+		}
+		if i == len(keys)-1 {
+			if n, ok := v.(float64); ok {
+				return n
+			}
+			return 0
+		}
+		if next, ok := v.(map[string]interface{}); ok {
+			current = next
+		} else {
+			return 0
+		}
+	}
+	return 0
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/AgentGuardHQ/octi-pulpo/internal/coordination"
+	"github.com/AgentGuardHQ/octi-pulpo/internal/dispatch"
 	"github.com/AgentGuardHQ/octi-pulpo/internal/memory"
 	"github.com/AgentGuardHQ/octi-pulpo/internal/routing"
 )
@@ -44,14 +45,20 @@ type RPCError struct {
 
 // Server is the Octi Pulpo MCP server.
 type Server struct {
-	mem    *memory.Store
-	coord  *coordination.Engine
-	router *routing.Router
+	mem        *memory.Store
+	coord      *coordination.Engine
+	router     *routing.Router
+	dispatcher *dispatch.Dispatcher
 }
 
 // New creates an MCP server backed by the given memory and coordination engines.
 func New(mem *memory.Store, coord *coordination.Engine, router *routing.Router) *Server {
 	return &Server{mem: mem, coord: coord, router: router}
+}
+
+// SetDispatcher adds dispatch capabilities to the MCP server.
+func (s *Server) SetDispatcher(d *dispatch.Dispatcher) {
+	s.dispatcher = d
 }
 
 // Serve runs the MCP server on stdio (stdin/stdout JSON-RPC).
@@ -197,6 +204,75 @@ func (s *Server) handleToolCall(req Request) Response {
 		data, _ := json.Marshal(report)
 		return textResult(req.ID, string(data))
 
+	case "dispatch_event":
+		if s.dispatcher == nil {
+			return errorResp(req.ID, -32000, "dispatcher not initialized")
+		}
+		var args struct {
+			EventType string            `json:"eventType"`
+			Source    string            `json:"source"`
+			Repo     string            `json:"repo"`
+			Payload  map[string]string `json:"payload"`
+			Priority int               `json:"priority"`
+		}
+		json.Unmarshal(params.Arguments, &args)
+		if args.EventType == "" {
+			return errorResp(req.ID, -32602, "eventType is required")
+		}
+		event := dispatch.Event{
+			Type:     dispatch.EventType(args.EventType),
+			Source:   args.Source,
+			Repo:     args.Repo,
+			Payload:  args.Payload,
+			Priority: args.Priority,
+		}
+		results, err := s.dispatcher.DispatchEvent(ctx, event)
+		if err != nil {
+			return errorResp(req.ID, -32000, err.Error())
+		}
+		data, _ := json.Marshal(results)
+		return textResult(req.ID, string(data))
+
+	case "dispatch_status":
+		if s.dispatcher == nil {
+			return errorResp(req.ID, -32000, "dispatcher not initialized")
+		}
+		depth, _ := s.dispatcher.PendingCount(ctx)
+		agents, _ := s.dispatcher.PendingAgents(ctx)
+		recent, _ := s.dispatcher.RecentDispatches(ctx, 10)
+
+		status := map[string]interface{}{
+			"queue_depth":       depth,
+			"pending_agents":    agents,
+			"recent_dispatches": recent,
+		}
+		data, _ := json.Marshal(status)
+		return textResult(req.ID, string(data))
+
+	case "dispatch_trigger":
+		if s.dispatcher == nil {
+			return errorResp(req.ID, -32000, "dispatcher not initialized")
+		}
+		var args struct {
+			Agent    string `json:"agent"`
+			Priority int    `json:"priority"`
+		}
+		json.Unmarshal(params.Arguments, &args)
+		if args.Agent == "" {
+			return errorResp(req.ID, -32602, "agent name is required")
+		}
+		event := dispatch.Event{
+			Type:     dispatch.EventManual,
+			Source:   "mcp",
+			Payload:  map[string]string{"triggered_by": agentID},
+		}
+		result, err := s.dispatcher.Dispatch(ctx, event, args.Agent, args.Priority)
+		if err != nil {
+			return errorResp(req.ID, -32000, err.Error())
+		}
+		data, _ := json.Marshal(result)
+		return textResult(req.ID, string(data))
+
 	default:
 		return errorResp(req.ID, -32601, fmt.Sprintf("unknown tool: %s", params.Name))
 	}
@@ -289,6 +365,41 @@ func toolDefs() []ToolDef {
 			InputSchema: map[string]interface{}{
 				"type":       "object",
 				"properties": map[string]interface{}{},
+			},
+		},
+		{
+			Name:        "dispatch_event",
+			Description: "Submit an event for routing through the dispatcher. The event is matched against rules and dispatched to the appropriate agent(s) with coordination, cooldown, and budget checks.",
+			InputSchema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"eventType": map[string]interface{}{"type": "string", "enum": []string{"pr.opened", "pr.updated", "ci.completed", "timer", "budget.change", "manual", "slack.action"}, "description": "Event type"},
+					"source":    map[string]string{"type": "string", "description": "Event source (github, cron, slack, manual)"},
+					"repo":      map[string]string{"type": "string", "description": "Repository full name (e.g. AgentGuardHQ/agentguard)"},
+					"payload":   map[string]interface{}{"type": "object", "description": "Event-specific key-value data"},
+					"priority":  map[string]interface{}{"type": "number", "description": "Priority (0=critical, 1=high, 2=normal, 3=background)"},
+				},
+				"required": []string{"eventType"},
+			},
+		},
+		{
+			Name:        "dispatch_status",
+			Description: "Show current dispatch queue depth, pending agents, and recent dispatch decisions.",
+			InputSchema: map[string]interface{}{
+				"type":       "object",
+				"properties": map[string]interface{}{},
+			},
+		},
+		{
+			Name:        "dispatch_trigger",
+			Description: "Manually trigger an agent run. Bypasses event matching but still respects cooldown and coordination claims.",
+			InputSchema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"agent":    map[string]string{"type": "string", "description": "Agent name to trigger"},
+					"priority": map[string]interface{}{"type": "number", "description": "Priority (0=critical, 1=high, 2=normal, 3=background). Default: 1"},
+				},
+				"required": []string{"agent"},
 			},
 		},
 	}


### PR DESCRIPTION
## Summary
- Replaces blind cron-based scheduling with an event-driven dispatch system that coordinates agent runs through cooldowns, dedup (coord_claim), driver health checks, and a Redis priority queue
- Adds `internal/dispatch` package: Dispatcher, EventRouter (maps GitHub/timer events to agents with repo-glob matching), Bridge (queue.txt backward compat with flock), and WebhookServer (HTTP endpoint replacing webhook-listener.py with HMAC-SHA256 verification)
- Exposes 3 new MCP tools: `dispatch_event`, `dispatch_status`, `dispatch_trigger`
- Fixes the pr-merger stampede (214 runs/day) with a 10-minute cooldown per agent

## Architecture
- **Phase 1 (this PR)**: Dispatcher writes to both Redis priority queue AND queue.txt (workers unchanged)
- **Phase 2 (later)**: Workers read from Redis priority queue directly
- **Phase 3 (final)**: Remove queue.txt entirely

Optional HTTP mode: `OCTI_HTTP_PORT=8787 ./octi-pulpo` runs both MCP stdio and webhook receiver.

## Test plan
- [x] 18 tests pass: dispatch dedup, cooldown, priority ordering, driver-exhausted backpressure, event routing, bridge file I/O, dispatch records
- [x] `go build ./cmd/octi-pulpo/` clean
- [x] `go vet ./...` clean
- [ ] Manual: point a GitHub webhook at `:8787/webhook` and verify PR events dispatch correctly
- [ ] Manual: verify `POST /dispatch/trigger` respects cooldown

🤖 Generated with [Claude Code](https://claude.com/claude-code)