### PR TITLE
feat: cost-tier routing cascade — task-type capability floor + API tier (#8)

### DIFF
--- a/internal/routing/router.go
+++ b/internal/routing/router.go
@@ -25,14 +25,21 @@ var driverTiers = map[string]CostTier{
 	// Local ($0)
 	"ollama":   TierLocal,
 	"nemotron": TierLocal,
-	// Subscription (browser-based)
-	"openclaw": TierSubscription,
-	// CLI (metered)
+	// Subscription (browser-based, already paying)
+	"openclaw":    TierSubscription,
+	"chatgpt":     TierSubscription,
+	"notebooklm":  TierSubscription,
+	"gemini-app":  TierSubscription,
+	// CLI (metered by seat, not per-token)
 	"claude-code": TierCLI,
 	"copilot":     TierCLI,
 	"codex":       TierCLI,
 	"gemini":      TierCLI,
 	"goose":       TierCLI,
+	// API (per-token billing)
+	"anthropic":  TierAPI,
+	"openai":     TierAPI,
+	"gemini-api": TierAPI,
 }
 
 // DriverHealth represents the runtime health of a single driver.
@@ -69,14 +76,32 @@ func NewRouter(healthDir string) *Router {
 	return &Router{healthDir: healthDir}
 }
 
-// Recommend returns the cheapest healthy driver for the given task.
-// The budget parameter controls which cost tiers are considered:
-//   - "low"    -> local only
-//   - "medium" -> local + subscription + cli
-//   - "high"   -> all tiers
-//   - ""       -> all tiers (default)
+// Recommend returns the cheapest capable healthy driver for the given task.
+//
+// Two constraints are applied:
+//   - minTier: capability floor derived from taskType — tiers below this lack
+//     the capability to handle the task (e.g. local LLMs for code-review).
+//   - maxTier: cost ceiling derived from budget — tiers above this are too
+//     expensive for the caller's budget envelope.
+//
+// Budget values:
+//   - "low"    -> cap at local
+//   - "medium" -> cap at cli
+//   - "high"   -> all tiers (default)
 func (r *Router) Recommend(taskType, budget string) RouteDecision {
+	minTier := taskTypeMinTier(taskType)
 	maxTier := maxTierForBudget(budget)
+
+	// If the capability floor exceeds the budget ceiling the caller has
+	// painted themselves into a corner — skip rather than return a driver
+	// that can't do the job.
+	if tierIndex(minTier) > tierIndex(maxTier) {
+		return RouteDecision{
+			Skip:   true,
+			Reason: fmt.Sprintf("task type %q requires minimum tier %s but budget caps at %s", taskType, minTier, maxTier),
+		}
+	}
+
 	drivers := DiscoverDrivers(r.healthDir)
 
 	// Build health map from discovered drivers.
@@ -89,10 +114,13 @@ func (r *Router) Recommend(taskType, budget string) RouteDecision {
 	var chosen *RouteDecision
 	var fallbacks []string
 
-	// Walk tiers in cost order: cheapest first.
+	// Walk tiers in cost order: cheapest capable tier first.
 	for _, tier := range tierOrder {
+		if tierIndex(tier) < tierIndex(minTier) {
+			continue // below capability floor for this task type
+		}
 		if tierIndex(tier) > tierIndex(maxTier) {
-			break
+			break // above budget ceiling
 		}
 		for name, health := range healthMap {
 			driverTier := tierFor(name)
@@ -109,11 +137,15 @@ func (r *Router) Recommend(taskType, budget string) RouteDecision {
 			}
 
 			if chosen == nil {
+				reason := fmt.Sprintf("cheapest capable driver for %q (tier: %s, state: %s)", taskType, tier, health.CircuitState)
+				if taskType == "" {
+					reason = fmt.Sprintf("cheapest healthy driver (tier: %s, state: %s)", tier, health.CircuitState)
+				}
 				chosen = &RouteDecision{
 					Driver:     name,
 					Tier:       string(tier),
 					Confidence: confidence,
-					Reason:     fmt.Sprintf("cheapest healthy driver (tier: %s, state: %s)", tier, health.CircuitState),
+					Reason:     reason,
 				}
 			} else {
 				fallbacks = append(fallbacks, name)
@@ -167,4 +199,64 @@ func tierIndex(t CostTier) int {
 		}
 	}
 	return len(tierOrder)
+}
+
+// taskTypeMinTier returns the minimum capable tier for a task type.
+// Tiers below this floor lack the capability to handle the task reliably.
+//
+// Mapping rationale (from issue #8 spec):
+//   - local:        classification, triage, summarisation, simple tasks
+//   - subscription: briefings, research artifacts, document generation
+//   - cli:          coding, code-review, PRs, commits, tests
+//   - api:          programmatic/burst access requiring raw API semantics
+func taskTypeMinTier(taskType string) CostTier {
+	lower := strings.ToLower(taskType)
+	switch {
+	case containsAny(lower, "code", "review", "commit", "test", "refactor", "coding", "debug", "lint", "build") ||
+		containsWord(lower, "pr"):
+		return TierCLI
+	case containsAny(lower, "briefing", "research", "artifact", "document", "report", "notebook"):
+		return TierSubscription
+	case containsAny(lower, "burst", "programmatic", "batch") || containsWord(lower, "api"):
+		return TierAPI
+	default:
+		// classification, triage, summarisation, simple tasks → local is capable
+		return TierLocal
+	}
+}
+
+// containsAny reports whether s contains any of the given substrings.
+func containsAny(s string, subs ...string) bool {
+	for _, sub := range subs {
+		if strings.Contains(s, sub) {
+			return true
+		}
+	}
+	return false
+}
+
+// containsWord reports whether word appears as a standalone token in s.
+// A token is delimited by start/end of string or a non-alphanumeric character.
+func containsWord(s, word string) bool {
+	if s == word {
+		return true
+	}
+	isDelim := func(r byte) bool {
+		return (r < 'a' || r > 'z') && (r < 'A' || r > 'Z') && (r < '0' || r > '9')
+	}
+	idx := strings.Index(s, word)
+	for idx >= 0 {
+		end := idx + len(word)
+		beforeOK := idx == 0 || isDelim(s[idx-1])
+		afterOK := end == len(s) || isDelim(s[end])
+		if beforeOK && afterOK {
+			return true
+		}
+		next := strings.Index(s[idx+1:], word)
+		if next < 0 {
+			break
+		}
+		idx = idx + 1 + next
+	}
+	return false
 }

--- a/internal/routing/router_test.go
+++ b/internal/routing/router_test.go
@@ -246,3 +246,173 @@ func TestDiscoverDrivers_NonexistentDir(t *testing.T) {
 		t.Fatalf("expected nil for nonexistent dir, got %v", drivers)
 	}
 }
+
+// ── task-type minimum tier ─────────────────────────────────────────────────
+
+func TestRecommend_CodeReviewSkipsLocalTier(t *testing.T) {
+	dir := t.TempDir()
+	// Both ollama (local) and claude-code (cli) are healthy.
+	// "code-review" task type requires minimum CLI tier, so ollama must be skipped.
+	writeHealth(t, dir, "ollama", HealthFile{State: "CLOSED", Failures: 0})
+	writeHealth(t, dir, "claude-code", HealthFile{State: "CLOSED", Failures: 0})
+
+	r := NewRouter(dir)
+	dec := r.Recommend("code-review", "high")
+
+	if dec.Skip {
+		t.Fatal("expected a recommendation, got Skip")
+	}
+	if dec.Driver != "claude-code" {
+		t.Fatalf("expected claude-code (CLI tier min for code-review), got %s", dec.Driver)
+	}
+	if dec.Tier != string(TierCLI) {
+		t.Fatalf("expected tier cli, got %s", dec.Tier)
+	}
+	// ollama should NOT be a fallback — it's below the capability floor
+	for _, fb := range dec.Fallbacks {
+		if fb == "ollama" {
+			t.Fatal("ollama should not appear as fallback for code-review (below min tier)")
+		}
+	}
+}
+
+func TestRecommend_BriefingSkipsLocalTier(t *testing.T) {
+	dir := t.TempDir()
+	writeHealth(t, dir, "ollama", HealthFile{State: "CLOSED", Failures: 0})
+	writeHealth(t, dir, "openclaw", HealthFile{State: "CLOSED", Failures: 0})
+
+	r := NewRouter(dir)
+	dec := r.Recommend("briefing", "high")
+
+	if dec.Skip {
+		t.Fatal("expected a recommendation, got Skip")
+	}
+	if dec.Tier != string(TierSubscription) {
+		t.Fatalf("expected subscription tier for briefing task, got %s", dec.Tier)
+	}
+}
+
+func TestRecommend_ClassificationUsesLocalTier(t *testing.T) {
+	dir := t.TempDir()
+	writeHealth(t, dir, "ollama", HealthFile{State: "CLOSED", Failures: 0})
+	writeHealth(t, dir, "claude-code", HealthFile{State: "CLOSED", Failures: 0})
+
+	r := NewRouter(dir)
+	dec := r.Recommend("classification", "high")
+
+	if dec.Skip {
+		t.Fatal("expected a recommendation, got Skip")
+	}
+	// classification has no minimum tier — local is capable and cheapest
+	if dec.Driver != "ollama" {
+		t.Fatalf("expected ollama (local tier for classification), got %s", dec.Driver)
+	}
+}
+
+func TestRecommend_TaskTypeBudgetConflict(t *testing.T) {
+	dir := t.TempDir()
+	// code-review needs CLI (minTier=cli), but budget is "low" (maxTier=local)
+	writeHealth(t, dir, "ollama", HealthFile{State: "CLOSED", Failures: 0})
+	writeHealth(t, dir, "claude-code", HealthFile{State: "CLOSED", Failures: 0})
+
+	r := NewRouter(dir)
+	dec := r.Recommend("code-review", "low")
+
+	if !dec.Skip {
+		t.Fatalf("expected Skip when minTier(cli) > maxTier(local), got driver=%s", dec.Driver)
+	}
+	if dec.Reason == "" {
+		t.Fatal("expected a reason explaining the budget/capability conflict")
+	}
+}
+
+// ── API tier ───────────────────────────────────────────────────────────────
+
+func TestRecommend_APITierFallback(t *testing.T) {
+	dir := t.TempDir()
+	// All local/subscription/CLI drivers are OPEN — should fall through to API tier.
+	writeHealth(t, dir, "ollama", HealthFile{State: "OPEN", Failures: 5})
+	writeHealth(t, dir, "openclaw", HealthFile{State: "OPEN", Failures: 3})
+	writeHealth(t, dir, "claude-code", HealthFile{State: "OPEN", Failures: 8})
+	writeHealth(t, dir, "anthropic", HealthFile{State: "CLOSED", Failures: 0})
+
+	r := NewRouter(dir)
+	dec := r.Recommend("any-task", "high")
+
+	if dec.Skip {
+		t.Fatal("expected API-tier fallback, got Skip")
+	}
+	if dec.Driver != "anthropic" {
+		t.Fatalf("expected anthropic (only healthy driver at API tier), got %s", dec.Driver)
+	}
+	if dec.Tier != string(TierAPI) {
+		t.Fatalf("expected tier api, got %s", dec.Tier)
+	}
+}
+
+func TestRecommend_APITierNotUsedAtMediumBudget(t *testing.T) {
+	dir := t.TempDir()
+	// CLI driver is OPEN — would cascade to API, but budget is "medium" (cap=cli).
+	writeHealth(t, dir, "claude-code", HealthFile{State: "OPEN", Failures: 5})
+	writeHealth(t, dir, "anthropic", HealthFile{State: "CLOSED", Failures: 0})
+
+	r := NewRouter(dir)
+	dec := r.Recommend("task", "medium")
+
+	if !dec.Skip {
+		t.Fatalf("expected Skip (medium budget forbids API tier), got driver=%s", dec.Driver)
+	}
+}
+
+func TestRecommend_SubscriptionSubDrivers(t *testing.T) {
+	dir := t.TempDir()
+	// Multiple subscription-tier drivers; any one is valid.
+	writeHealth(t, dir, "chatgpt", HealthFile{State: "CLOSED", Failures: 0})
+	writeHealth(t, dir, "notebooklm", HealthFile{State: "CLOSED", Failures: 0})
+	writeHealth(t, dir, "claude-code", HealthFile{State: "CLOSED", Failures: 0})
+
+	r := NewRouter(dir)
+	dec := r.Recommend("task", "high")
+
+	if dec.Skip {
+		t.Fatal("expected a recommendation, got Skip")
+	}
+	// subscription tier is cheaper than CLI — should pick one of the subscription drivers
+	if dec.Tier != string(TierSubscription) {
+		t.Fatalf("expected subscription tier, got %s (driver: %s)", dec.Tier, dec.Driver)
+	}
+}
+
+func TestTaskTypeMinTier(t *testing.T) {
+	cases := []struct {
+		taskType string
+		wantTier CostTier
+	}{
+		{"code-review", TierCLI},
+		{"pr", TierCLI},
+		{"commit", TierCLI},
+		{"coding", TierCLI},
+		{"test", TierCLI},
+		{"refactor", TierCLI},
+		{"debug", TierCLI},
+		{"briefing", TierSubscription},
+		{"research", TierSubscription},
+		{"artifact", TierSubscription},
+		{"document", TierSubscription},
+		{"notebook", TierSubscription},
+		{"api", TierAPI},
+		{"burst", TierAPI},
+		{"programmatic", TierAPI},
+		{"classification", TierLocal},
+		{"triage", TierLocal},
+		{"summarisation", TierLocal},
+		{"simple-task", TierLocal},
+		{"", TierLocal},
+	}
+	for _, tc := range cases {
+		got := taskTypeMinTier(tc.taskType)
+		if got != tc.wantTier {
+			t.Errorf("taskTypeMinTier(%q) = %s, want %s", tc.taskType, got, tc.wantTier)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- **API-tier drivers registered** (`anthropic`, `openai`, `gemini-api`) — the cascade could previously never reach tier 4 because no API drivers existed in `driverTiers`
- **Subscription sub-drivers added** (`chatgpt`, `notebooklm`, `gemini-app`) alongside the existing `openclaw` driver
- **Task-type capability floor** (`taskTypeMinTier`) — routes tasks to the cheapest tier that can actually handle them, not just the cheapest tier overall:
  - `classification`, `triage`, `simple` → local
  - `briefing`, `research`, `artifact`, `document` → subscription
  - `code-review`, `pr`, `commit`, `coding`, `test` → CLI
  - `programmatic`, `burst`, `batch` → API
- **Dual-constraint routing** — `minTier` (capability floor) + `maxTier` (budget ceiling); returns a clear `Skip` with reason when they conflict (e.g., `code-review` at `low` budget)

## Test plan

- [x] `go test ./internal/routing/... -v` — 21 tests, all pass
- [x] `go test ./...` — 99 tests across 10 packages, all pass
- [x] `TestRecommend_CodeReviewSkipsLocalTier` — CLI floor enforced
- [x] `TestRecommend_BriefingSkipsLocalTier` — subscription floor enforced
- [x] `TestRecommend_ClassificationUsesLocalTier` — local used when appropriate
- [x] `TestRecommend_TaskTypeBudgetConflict` — irreconcilable constraint → Skip
- [x] `TestRecommend_APITierFallback` — cascades to API when all other tiers OPEN
- [x] `TestRecommend_APITierNotUsedAtMediumBudget` — budget ceiling respected
- [x] `TestRecommend_SubscriptionSubDrivers` — chatgpt/notebooklm/gemini-app routable
- [x] `TestTaskTypeMinTier` — 19 keyword cases validated

Closes #8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)