### PR TITLE
feat(routing): cost-tier cascade — API tier + task-type affinity

### DIFF
--- a/internal/routing/router.go
+++ b/internal/routing/router.go
@@ -25,14 +25,40 @@ var driverTiers = map[string]CostTier{
 	// Local ($0)
 	"ollama":   TierLocal,
 	"nemotron": TierLocal,
-	// Subscription (browser-based)
+	// Subscription (browser-based, already paying)
 	"openclaw": TierSubscription,
-	// CLI (metered)
+	// CLI (metered, already paying)
 	"claude-code": TierCLI,
 	"copilot":     TierCLI,
 	"codex":       TierCLI,
 	"gemini":      TierCLI,
 	"goose":       TierCLI,
+	// API (per-token, burst capacity)
+	"anthropic-api": TierAPI,
+	"openai-api":    TierAPI,
+	"gemini-api":    TierAPI,
+}
+
+// taskMinTier maps well-known task types to the cheapest tier that can handle them.
+// Tasks requiring richer models skip tiers below their minimum.
+// Unknown task types default to TierLocal (try cheapest first).
+var taskMinTier = map[string]CostTier{
+	// Simple tasks — local models are sufficient
+	"classification": TierLocal,
+	"triage":         TierLocal,
+	"routing":        TierLocal,
+	// Artifact / briefing tasks — need richer models than local
+	"briefing":  TierSubscription,
+	"artifact":  TierSubscription,
+	"summarize": TierSubscription,
+	// Coding tasks — require CLI-grade models
+	"code-review": TierCLI,
+	"pr":          TierCLI,
+	"commit":      TierCLI,
+	"coding":      TierCLI,
+	"refactor":    TierCLI,
+	// Burst / programmatic — skip straight to API tier
+	"burst": TierAPI,
 }
 
 // DriverHealth represents the runtime health of a single driver.
@@ -70,13 +96,18 @@ func NewRouter(healthDir string) *Router {
 }
 
 // Recommend returns the cheapest healthy driver for the given task.
-// The budget parameter controls which cost tiers are considered:
+//
+// Budget controls which cost tiers are considered (upper bound):
 //   - "low"    -> local only
 //   - "medium" -> local + subscription + cli
-//   - "high"   -> all tiers
-//   - ""       -> all tiers (default)
+//   - "high"   -> all tiers (default when empty)
+//
+// TaskType controls which tiers are skipped (lower bound): certain task types
+// require richer models and skip cheaper tiers that can't handle them.
+// For example, "code-review" skips local and starts from CLI tier.
 func (r *Router) Recommend(taskType, budget string) RouteDecision {
 	maxTier := maxTierForBudget(budget)
+	minTier := minTierForTask(taskType)
 	drivers := DiscoverDrivers(r.healthDir)
 
 	// Build health map from discovered drivers.
@@ -89,14 +120,16 @@ func (r *Router) Recommend(taskType, budget string) RouteDecision {
 	var chosen *RouteDecision
 	var fallbacks []string
 
-	// Walk tiers in cost order: cheapest first.
+	// Walk tiers in cost order: cheapest first, bounded by task minimum and budget maximum.
 	for _, tier := range tierOrder {
+		if tierIndex(tier) < tierIndex(minTier) {
+			continue // skip tiers too cheap for this task type
+		}
 		if tierIndex(tier) > tierIndex(maxTier) {
-			break
+			break // stop at budget ceiling
 		}
 		for name, health := range healthMap {
-			driverTier := tierFor(name)
-			if driverTier != tier {
+			if tierFor(name) != tier {
 				continue
 			}
 			if health.CircuitState == "OPEN" {
@@ -113,7 +146,7 @@ func (r *Router) Recommend(taskType, budget string) RouteDecision {
 					Driver:     name,
 					Tier:       string(tier),
 					Confidence: confidence,
-					Reason:     fmt.Sprintf("cheapest healthy driver (tier: %s, state: %s)", tier, health.CircuitState),
+					Reason:     fmt.Sprintf("cheapest eligible driver (tier: %s, state: %s)", tier, health.CircuitState),
 				}
 			} else {
 				fallbacks = append(fallbacks, name)
@@ -149,6 +182,15 @@ func maxTierForBudget(budget string) CostTier {
 	default:
 		return TierAPI
 	}
+}
+
+// minTierForTask returns the cheapest tier that can handle the given task type.
+// Unknown task types default to TierLocal (try cheapest first).
+func minTierForTask(taskType string) CostTier {
+	if t, ok := taskMinTier[strings.ToLower(taskType)]; ok {
+		return t
+	}
+	return TierLocal
 }
 
 // tierFor returns the cost tier for a driver, defaulting to CLI.

--- a/internal/routing/router_test.go
+++ b/internal/routing/router_test.go
@@ -246,3 +246,151 @@ func TestDiscoverDrivers_NonexistentDir(t *testing.T) {
 		t.Fatalf("expected nil for nonexistent dir, got %v", drivers)
 	}
 }
+
+// --- Full 4-tier cascade tests ---
+
+func TestRecommend_APITierDriver(t *testing.T) {
+	dir := t.TempDir()
+	writeHealth(t, dir, "anthropic-api", HealthFile{State: "CLOSED", Failures: 0})
+
+	r := NewRouter(dir)
+	dec := r.Recommend("any-task", "high")
+
+	if dec.Skip {
+		t.Fatal("expected recommendation, got Skip")
+	}
+	if dec.Driver != "anthropic-api" {
+		t.Fatalf("expected anthropic-api, got %s", dec.Driver)
+	}
+	if dec.Tier != string(TierAPI) {
+		t.Fatalf("expected tier api, got %s", dec.Tier)
+	}
+}
+
+func TestRecommend_FullCascade_CLIToAPI(t *testing.T) {
+	dir := t.TempDir()
+	// All CLI drivers OPEN — should cascade to API tier.
+	writeHealth(t, dir, "claude-code", HealthFile{State: "OPEN", Failures: 5})
+	writeHealth(t, dir, "copilot", HealthFile{State: "OPEN", Failures: 3})
+	writeHealth(t, dir, "openai-api", HealthFile{State: "CLOSED", Failures: 0})
+
+	r := NewRouter(dir)
+	dec := r.Recommend("any-task", "high")
+
+	if dec.Skip {
+		t.Fatal("expected fallback to API tier, got Skip")
+	}
+	if dec.Tier != string(TierAPI) {
+		t.Fatalf("expected API tier after CLI exhaustion, got %s", dec.Tier)
+	}
+}
+
+func TestRecommend_FullCascade_AllExhausted(t *testing.T) {
+	dir := t.TempDir()
+	writeHealth(t, dir, "ollama", HealthFile{State: "OPEN"})
+	writeHealth(t, dir, "openclaw", HealthFile{State: "OPEN"})
+	writeHealth(t, dir, "claude-code", HealthFile{State: "OPEN"})
+	writeHealth(t, dir, "anthropic-api", HealthFile{State: "OPEN"})
+
+	r := NewRouter(dir)
+	dec := r.Recommend("any-task", "high")
+
+	if !dec.Skip {
+		t.Fatalf("expected Skip when all 4 tiers exhausted, got driver=%s", dec.Driver)
+	}
+}
+
+// --- Task-type affinity tests ---
+
+func TestRecommend_TaskTypeCode_SkipsLocal(t *testing.T) {
+	dir := t.TempDir()
+	// Both local and CLI drivers are healthy — code-review should skip ollama.
+	writeHealth(t, dir, "ollama", HealthFile{State: "CLOSED", Failures: 0})
+	writeHealth(t, dir, "claude-code", HealthFile{State: "CLOSED", Failures: 0})
+
+	r := NewRouter(dir)
+	dec := r.Recommend("code-review", "high")
+
+	if dec.Skip {
+		t.Fatal("expected CLI recommendation, got Skip")
+	}
+	if dec.Tier != string(TierCLI) {
+		t.Fatalf("code-review should use CLI tier, got %s", dec.Tier)
+	}
+	// ollama must not appear as fallback — it's below min tier for coding tasks
+	for _, fb := range dec.Fallbacks {
+		if fb == "ollama" {
+			t.Fatal("ollama should not be a fallback for code-review (below min tier)")
+		}
+	}
+}
+
+func TestRecommend_TaskTypeBriefing_SkipsLocal(t *testing.T) {
+	dir := t.TempDir()
+	writeHealth(t, dir, "ollama", HealthFile{State: "CLOSED", Failures: 0})
+	writeHealth(t, dir, "openclaw", HealthFile{State: "CLOSED", Failures: 0})
+
+	r := NewRouter(dir)
+	dec := r.Recommend("briefing", "high")
+
+	if dec.Skip {
+		t.Fatal("expected subscription recommendation, got Skip")
+	}
+	if dec.Tier != string(TierSubscription) {
+		t.Fatalf("briefing should use subscription tier, got %s", dec.Tier)
+	}
+}
+
+func TestRecommend_TaskTypeBurst_UsesAPI(t *testing.T) {
+	dir := t.TempDir()
+	writeHealth(t, dir, "ollama", HealthFile{State: "CLOSED", Failures: 0})
+	writeHealth(t, dir, "claude-code", HealthFile{State: "CLOSED", Failures: 0})
+	writeHealth(t, dir, "gemini-api", HealthFile{State: "CLOSED", Failures: 0})
+
+	r := NewRouter(dir)
+	dec := r.Recommend("burst", "high")
+
+	if dec.Skip {
+		t.Fatal("expected API recommendation, got Skip")
+	}
+	if dec.Tier != string(TierAPI) {
+		t.Fatalf("burst task should use API tier, got %s", dec.Tier)
+	}
+}
+
+func TestRecommend_TaskTypeCode_BudgetTooLow(t *testing.T) {
+	dir := t.TempDir()
+	// code-review needs CLI (min tier), but budget is "low" (max tier = local).
+	// Min > max → no eligible tiers → Skip.
+	writeHealth(t, dir, "ollama", HealthFile{State: "CLOSED", Failures: 0})
+	writeHealth(t, dir, "claude-code", HealthFile{State: "CLOSED", Failures: 0})
+
+	r := NewRouter(dir)
+	dec := r.Recommend("code-review", "low")
+
+	if !dec.Skip {
+		t.Fatalf("expected Skip when task min tier exceeds budget, got driver=%s tier=%s", dec.Driver, dec.Tier)
+	}
+}
+
+func TestRecommend_TaskTypeCoding_CLIExhausted_FallsToAPI(t *testing.T) {
+	dir := t.TempDir()
+	// CLI exhausted — coding task should cascade to API, not fall to local.
+	writeHealth(t, dir, "ollama", HealthFile{State: "CLOSED", Failures: 0})
+	writeHealth(t, dir, "claude-code", HealthFile{State: "OPEN", Failures: 5})
+	writeHealth(t, dir, "anthropic-api", HealthFile{State: "CLOSED", Failures: 0})
+
+	r := NewRouter(dir)
+	dec := r.Recommend("coding", "high")
+
+	if dec.Skip {
+		t.Fatal("expected API fallback, got Skip")
+	}
+	if dec.Tier != string(TierAPI) {
+		t.Fatalf("coding task with CLI exhausted should fall to API, got tier=%s", dec.Tier)
+	}
+	// ollama must not be chosen — below min tier for coding
+	if dec.Driver == "ollama" {
+		t.Fatal("ollama must not be chosen for coding task (below min tier)")
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `anthropic-api`, `openai-api`, `gemini-api` to `driverTiers` — completing the 4th tier in the local → subscription → CLI → **API** cascade
- Adds `taskMinTier` map: task types like `code-review` and `coding` have a minimum tier of CLI, so they skip local drivers (ollama) that can't handle them
- `Recommend` now uses both a `minTier` (floor from task type) and `maxTier` (ceiling from budget) — if min > max the router returns `Skip=true` rather than routing to an unsuitable driver
- 8 new tests: full 4-tier cascade, API fallback, task-type affinity, min-tier-exceeds-budget guard

## Test plan

- [x] All 21 tests pass (`go test ./internal/routing/...`)
- [x] `go build ./...` clean
- [x] `TestRecommend_FullCascade_CLIToAPI` — CLI exhausted cascades to API tier
- [x] `TestRecommend_TaskTypeCode_SkipsLocal` — code-review never routes to ollama
- [x] `TestRecommend_TaskTypeCoding_CLIExhausted_FallsToAPI` — cascade goes *up* to API, not *down* to local
- [x] `TestRecommend_TaskTypeCode_BudgetTooLow` — min tier > budget ceiling → Skip

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)