### PR TITLE
feat: cost-tier routing cascade — task-type min-tier + expanded driver registry

### DIFF
--- a/internal/routing/router.go
+++ b/internal/routing/router.go
@@ -22,17 +22,61 @@ var tierOrder = []CostTier{TierLocal, TierSubscription, TierCLI, TierAPI}
 
 // driverTiers maps each known driver to its cost tier.
 var driverTiers = map[string]CostTier{
-	// Local ($0)
+	// Local ($0) — Ollama-served models, NemoClaw runtime
 	"ollama":   TierLocal,
 	"nemotron": TierLocal,
-	// Subscription (browser-based)
-	"openclaw": TierSubscription,
-	// CLI (metered)
+	// Subscription (already-paying browser sessions via OpenClaw)
+	"openclaw":   TierSubscription,
+	"chatgpt":    TierSubscription,
+	"notebooklm": TierSubscription,
+	"gemini-app": TierSubscription,
+	// CLI (metered CLI tools, effectively already-paying)
 	"claude-code": TierCLI,
 	"copilot":     TierCLI,
 	"codex":       TierCLI,
 	"gemini":      TierCLI,
 	"goose":       TierCLI,
+	// API (per-token, burst capacity)
+	"anthropic-api": TierAPI,
+	"openai-api":    TierAPI,
+	"gemini-api":    TierAPI,
+}
+
+// taskTypeMinTier maps task-type keywords to the minimum appropriate cost tier.
+// Routing won't start below this tier for a matched task type.
+// Uses substring matching against the lowercase task description.
+var taskTypeMinTier = map[string]CostTier{
+	// Coding tasks require a capable agent with code execution tools (CLI+)
+	"code-review":    TierCLI,
+	"coding":         TierCLI,
+	"commit":         TierCLI,
+	"refactor":       TierCLI,
+	"debug":          TierCLI,
+	"implementation": TierCLI,
+	"pull-request":   TierCLI,
+	// Artifact / document tasks benefit from web-connected subscription models
+	"artifact":  TierSubscription,
+	"briefing":  TierSubscription,
+	"document":  TierSubscription,
+	"notebook":  TierSubscription,
+	"report":    TierSubscription,
+	// Burst / batch workloads require direct API access
+	"burst": TierAPI,
+	"batch": TierAPI,
+}
+
+// minTierForTaskType returns the minimum appropriate cost tier for a task type.
+// Scans the task description for known keywords and returns the highest
+// (most expensive) minimum tier found. Defaults to TierLocal if no keyword matches.
+func minTierForTaskType(taskType string) CostTier {
+	lower := strings.ToLower(taskType)
+	best := TierLocal
+	for keyword, tier := range taskTypeMinTier {
+		if strings.Contains(lower, keyword) && tierIndex(tier) > tierIndex(best) {
+			best = tier
+		}
+	}
+	return best
 }
 
 // DriverHealth represents the runtime health of a single driver.
@@ -70,13 +114,32 @@ func NewRouter(healthDir string) *Router {
 }
 
 // Recommend returns the cheapest healthy driver for the given task.
-// The budget parameter controls which cost tiers are considered:
+//
+// Two constraints bound the tier cascade:
+//   - minTier: derived from taskType — coding tasks require CLI+, briefings require Subscription+
+//   - maxTier: derived from budget — "low" caps at local, "medium" caps at cli, "high" allows all
+//
+// If taskType requires a higher tier than budget allows, Skip is returned immediately
+// with a reason describing the conflict. Otherwise the cascade walks from minTier to
+// maxTier and returns the first healthy driver found.
+//
+// Budget values:
 //   - "low"    -> local only
 //   - "medium" -> local + subscription + cli
 //   - "high"   -> all tiers
 //   - ""       -> all tiers (default)
 func (r *Router) Recommend(taskType, budget string) RouteDecision {
 	maxTier := maxTierForBudget(budget)
+	minTier := minTierForTaskType(taskType)
+
+	// Budget conflict: task capability requirement exceeds budget ceiling.
+	if tierIndex(minTier) > tierIndex(maxTier) {
+		return RouteDecision{
+			Skip:   true,
+			Reason: fmt.Sprintf("task %q requires %s tier but budget only allows up to %s", taskType, minTier, maxTier),
+		}
+	}
+
 	drivers := DiscoverDrivers(r.healthDir)
 
 	// Build health map from discovered drivers.
@@ -89,14 +152,16 @@ func (r *Router) Recommend(taskType, budget string) RouteDecision {
 	var chosen *RouteDecision
 	var fallbacks []string
 
-	// Walk tiers in cost order: cheapest first.
+	// Walk tiers in cost order from minTier to maxTier.
 	for _, tier := range tierOrder {
+		if tierIndex(tier) < tierIndex(minTier) {
+			continue // skip tiers below task's capability minimum
+		}
 		if tierIndex(tier) > tierIndex(maxTier) {
 			break
 		}
 		for name, health := range healthMap {
-			driverTier := tierFor(name)
-			if driverTier != tier {
+			if tierFor(name) != tier {
 				continue
 			}
 			if health.CircuitState == "OPEN" {

--- a/internal/routing/router_test.go
+++ b/internal/routing/router_test.go
@@ -246,3 +246,172 @@ func TestDiscoverDrivers_NonexistentDir(t *testing.T) {
 		t.Fatalf("expected nil for nonexistent dir, got %v", drivers)
 	}
 }
+
+// --- Task-type-aware routing tests ---
+
+func TestRecommend_CodingTaskSkipsLocalTier(t *testing.T) {
+	dir := t.TempDir()
+	// Local driver available, but coding task requires CLI minimum
+	writeHealth(t, dir, "ollama", HealthFile{State: "CLOSED", Failures: 0})
+	writeHealth(t, dir, "claude-code", HealthFile{State: "CLOSED", Failures: 0})
+
+	r := NewRouter(dir)
+	dec := r.Recommend("code-review", "high")
+
+	if dec.Skip {
+		t.Fatal("expected a recommendation, got Skip")
+	}
+	if dec.Driver != "claude-code" {
+		t.Fatalf("expected claude-code (coding task requires CLI tier), got %s", dec.Driver)
+	}
+	if dec.Tier != string(TierCLI) {
+		t.Fatalf("expected tier cli, got %s", dec.Tier)
+	}
+	// ollama should NOT appear — it's below the coding task's min tier
+	for _, fb := range dec.Fallbacks {
+		if fb == "ollama" {
+			t.Fatal("ollama should not be a fallback for a coding task")
+		}
+	}
+}
+
+func TestRecommend_CodingTaskBudgetConflict(t *testing.T) {
+	dir := t.TempDir()
+	writeHealth(t, dir, "ollama", HealthFile{State: "CLOSED", Failures: 0})
+	writeHealth(t, dir, "claude-code", HealthFile{State: "CLOSED", Failures: 0})
+
+	r := NewRouter(dir)
+	// code-review requires CLI, but budget "low" caps at local — conflict
+	dec := r.Recommend("code-review", "low")
+
+	if !dec.Skip {
+		t.Fatalf("expected Skip=true for budget conflict (coding task + low budget), got driver=%s", dec.Driver)
+	}
+	if dec.Reason == "" {
+		t.Fatal("expected a reason describing the budget conflict")
+	}
+}
+
+func TestRecommend_CodingTaskFallsBackToAPI(t *testing.T) {
+	dir := t.TempDir()
+	// All CLI drivers exhausted — should cascade to API
+	writeHealth(t, dir, "claude-code", HealthFile{State: "OPEN", Failures: 10})
+	writeHealth(t, dir, "copilot", HealthFile{State: "OPEN", Failures: 8})
+	writeHealth(t, dir, "anthropic-api", HealthFile{State: "CLOSED", Failures: 0})
+
+	r := NewRouter(dir)
+	dec := r.Recommend("coding", "high")
+
+	if dec.Skip {
+		t.Fatal("expected anthropic-api fallback when CLI exhausted, got Skip")
+	}
+	if dec.Driver != "anthropic-api" {
+		t.Fatalf("expected anthropic-api (CLI OPEN, API available), got %s", dec.Driver)
+	}
+	if dec.Tier != string(TierAPI) {
+		t.Fatalf("expected tier api, got %s", dec.Tier)
+	}
+}
+
+func TestRecommend_ArtifactTaskStartsAtSubscription(t *testing.T) {
+	dir := t.TempDir()
+	// Local and subscription drivers both available
+	writeHealth(t, dir, "ollama", HealthFile{State: "CLOSED", Failures: 0})
+	writeHealth(t, dir, "notebooklm", HealthFile{State: "CLOSED", Failures: 0})
+	writeHealth(t, dir, "claude-code", HealthFile{State: "CLOSED", Failures: 0})
+
+	r := NewRouter(dir)
+	dec := r.Recommend("briefing", "high")
+
+	if dec.Skip {
+		t.Fatal("expected recommendation for briefing task, got Skip")
+	}
+	if dec.Tier != string(TierSubscription) {
+		t.Fatalf("expected subscription tier for briefing task, got %s", dec.Tier)
+	}
+	// ollama must not be chosen — briefings require subscription minimum
+	if dec.Driver == "ollama" {
+		t.Fatal("ollama should not be chosen for briefing task (below min tier)")
+	}
+}
+
+func TestRecommend_UnknownTaskTypeDefaultsLocal(t *testing.T) {
+	dir := t.TempDir()
+	writeHealth(t, dir, "ollama", HealthFile{State: "CLOSED", Failures: 0})
+	writeHealth(t, dir, "claude-code", HealthFile{State: "CLOSED", Failures: 0})
+
+	r := NewRouter(dir)
+	// Unknown task type → no keyword match → min tier = local
+	dec := r.Recommend("some-unrecognized-task-xyz", "high")
+
+	if dec.Skip {
+		t.Fatal("expected recommendation for unknown task type, got Skip")
+	}
+	// Should pick ollama (local, cheapest) since min tier defaults to local
+	if dec.Driver != "ollama" {
+		t.Fatalf("expected ollama (local, default min tier), got %s", dec.Driver)
+	}
+}
+
+func TestRecommend_APITierDriver(t *testing.T) {
+	dir := t.TempDir()
+	writeHealth(t, dir, "anthropic-api", HealthFile{State: "CLOSED", Failures: 0})
+	writeHealth(t, dir, "openai-api", HealthFile{State: "CLOSED", Failures: 0})
+
+	r := NewRouter(dir)
+	dec := r.Recommend("batch processing", "high")
+
+	if dec.Skip {
+		t.Fatal("expected recommendation, got Skip")
+	}
+	// "batch" keyword → min tier = API; both api drivers healthy
+	if dec.Tier != string(TierAPI) {
+		t.Fatalf("expected api tier for batch task, got %s", dec.Tier)
+	}
+}
+
+func TestRecommend_SubscriptionDriverChatGPT(t *testing.T) {
+	dir := t.TempDir()
+	writeHealth(t, dir, "chatgpt", HealthFile{State: "CLOSED", Failures: 0})
+	writeHealth(t, dir, "claude-code", HealthFile{State: "CLOSED", Failures: 0})
+
+	r := NewRouter(dir)
+	dec := r.Recommend("document summary", "high")
+
+	if dec.Skip {
+		t.Fatal("expected recommendation, got Skip")
+	}
+	// "document" → min tier = subscription; chatgpt is cheaper than claude-code
+	if dec.Tier != string(TierSubscription) {
+		t.Fatalf("expected subscription tier, got %s", dec.Tier)
+	}
+	if dec.Driver != "chatgpt" {
+		t.Fatalf("expected chatgpt (subscription tier, cheaper than CLI), got %s", dec.Driver)
+	}
+}
+
+func TestMinTierForTaskType(t *testing.T) {
+	cases := []struct {
+		taskType string
+		wantTier CostTier
+	}{
+		{"code-review", TierCLI},
+		{"write a commit message", TierCLI},
+		{"refactor the auth module", TierCLI},
+		{"generate a briefing document", TierSubscription},
+		{"create artifact", TierSubscription},
+		{"triage this issue", TierLocal},
+		{"some unknown task", TierLocal},
+		{"burst load test", TierAPI},
+		{"batch process 10k items", TierAPI},
+		// compound: both coding and document keywords → max wins = CLI
+		{"code-review for the report", TierCLI},
+	}
+
+	for _, tc := range cases {
+		got := minTierForTaskType(tc.taskType)
+		if got != tc.wantTier {
+			t.Errorf("minTierForTaskType(%q) = %s, want %s", tc.taskType, got, tc.wantTier)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Closes #8 — completes the cost-tier routing cascade for `route_recommend`.

- **Task-type min-tier**: routing now enforces a *lower bound* on the cascade derived from the task description. Coding tasks (`code-review`, `commit`, `refactor`, …) start at **CLI** tier — they won't route to a local model that can't run tools. Artifact/briefing tasks start at **Subscription**. Burst/batch start at **API**. Unknown task types default to local (cheapest-first, unchanged).
- **Budget conflict detection**: when task min-tier exceeds the budget ceiling, `Skip=true` is returned immediately with a clear reason (`"task X requires cli tier but budget only allows up to local"`), before any health-file I/O.
- **Expanded driver registry**: added `chatgpt`, `notebooklm`, `gemini-app` (Subscription), and `anthropic-api`, `openai-api`, `gemini-api` (API tier).

## How it works

```
minTier = minTierForTaskType(taskType)   // keyword scan: "code-review" → CLI
maxTier = maxTierForBudget(budget)       // "low"→local, "medium"→cli, "high"→all

if minTier > maxTier → Skip (budget conflict)

cascade from minTier to maxTier, cheapest-first
```

## Test plan

- [x] `TestRecommend_CodingTaskSkipsLocalTier` — ollama + claude-code, coding task → claude-code (skips local)
- [x] `TestRecommend_CodingTaskBudgetConflict` — code-review + budget "low" → Skip
- [x] `TestRecommend_CodingTaskFallsBackToAPI` — all CLI OPEN, coding task → anthropic-api
- [x] `TestRecommend_ArtifactTaskStartsAtSubscription` — briefing task → notebooklm (skips ollama)
- [x] `TestRecommend_UnknownTaskTypeDefaultsLocal` — unknown task → ollama (cheapest)
- [x] `TestRecommend_APITierDriver` — batch task → api tier
- [x] `TestRecommend_SubscriptionDriverChatGPT` — document task → chatgpt
- [x] `TestMinTierForTaskType` — unit tests for keyword matching (10 cases)
- [x] All 13 existing routing tests still pass
- [x] 99/99 across all packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)