### PR TITLE
feat: cost-tier routing cascade — full driver table + task-type capability floors

### DIFF
--- a/internal/routing/router.go
+++ b/internal/routing/router.go
@@ -22,17 +22,54 @@ var tierOrder = []CostTier{TierLocal, TierSubscription, TierCLI, TierAPI}
 
 // driverTiers maps each known driver to its cost tier.
 var driverTiers = map[string]CostTier{
-	// Local ($0)
-	"ollama":   TierLocal,
-	"nemotron": TierLocal,
-	// Subscription (browser-based)
-	"openclaw": TierSubscription,
-	// CLI (metered)
+	// Local ($0) — Ollama and NemoClaw/Nemotron
+	"ollama":    TierLocal,
+	"nemotron":  TierLocal,
+	"nemoclaw":  TierLocal,
+	// Subscription — OpenClaw browser runtime driving web apps
+	"openclaw":    TierSubscription,
+	"chatgpt":     TierSubscription, // OpenClaw → ChatGPT web
+	"notebooklm":  TierSubscription, // OpenClaw → NotebookLM
+	"gemini-app":  TierSubscription, // OpenClaw → Gemini web app
+	// CLI — metered tools running locally
 	"claude-code": TierCLI,
 	"copilot":     TierCLI,
 	"codex":       TierCLI,
-	"gemini":      TierCLI,
+	"gemini":      TierCLI, // Gemini CLI
 	"goose":       TierCLI,
+	// API — direct per-token calls, burst capacity
+	"anthropic-api": TierAPI,
+	"openai-api":    TierAPI,
+	"gemini-api":    TierAPI,
+}
+
+// taskTypeMinTier maps task type keywords to the minimum capable tier.
+// Tasks requiring strong reasoning or code generation should not be routed
+// to local models that may lack the capability.
+var taskTypeMinTier = map[string]CostTier{
+	// Local-capable: triage, classification, simple summarization
+	"triage":   TierLocal,
+	"classify": TierLocal,
+	"simple":   TierLocal,
+	"label":    TierLocal,
+	// Subscription-capable: briefings, artifacts, research reports
+	"briefing":  TierSubscription,
+	"artifact":  TierSubscription,
+	"report":    TierSubscription,
+	"research":  TierSubscription,
+	"summarize": TierSubscription,
+	// CLI-capable: code generation, PRs, commits, reviews
+	"code":         TierCLI,
+	"code-review":  TierCLI,
+	"pr":           TierCLI,
+	"commit":       TierCLI,
+	"review":       TierCLI,
+	"refactor":     TierCLI,
+	"test":         TierCLI,
+	"debug":        TierCLI,
+	// API-only: burst/programmatic access
+	"burst": TierAPI,
+	"api":   TierAPI,
 }
 
 // DriverHealth represents the runtime health of a single driver.
@@ -69,14 +106,20 @@ func NewRouter(healthDir string) *Router {
 	return &Router{healthDir: healthDir}
 }
 
-// Recommend returns the cheapest healthy driver for the given task.
-// The budget parameter controls which cost tiers are considered:
+// Recommend returns the cheapest capable healthy driver for the given task.
+//
+// The budget parameter controls the maximum cost tier:
 //   - "low"    -> local only
 //   - "medium" -> local + subscription + cli
-//   - "high"   -> all tiers
-//   - ""       -> all tiers (default)
+//   - "high"   -> all tiers (default)
+//
+// The taskType parameter sets the minimum capable tier — routing will not
+// go below it even if cheaper drivers are available. For example, "code-review"
+// requires at least a CLI-tier driver; routing to local is skipped.
+// If taskType is empty or unrecognized, routing starts from the cheapest tier.
 func (r *Router) Recommend(taskType, budget string) RouteDecision {
 	maxTier := maxTierForBudget(budget)
+	minTier := minTierForTask(taskType)
 	drivers := DiscoverDrivers(r.healthDir)
 
 	// Build health map from discovered drivers.
@@ -89,14 +132,16 @@ func (r *Router) Recommend(taskType, budget string) RouteDecision {
 	var chosen *RouteDecision
 	var fallbacks []string
 
-	// Walk tiers in cost order: cheapest first.
+	// Walk tiers in cost order: cheapest capable first.
 	for _, tier := range tierOrder {
+		if tierIndex(tier) < tierIndex(minTier) {
+			continue // below task capability floor
+		}
 		if tierIndex(tier) > tierIndex(maxTier) {
-			break
+			break // above budget ceiling
 		}
 		for name, health := range healthMap {
-			driverTier := tierFor(name)
-			if driverTier != tier {
+			if tierFor(name) != tier {
 				continue
 			}
 			if health.CircuitState == "OPEN" {
@@ -109,11 +154,15 @@ func (r *Router) Recommend(taskType, budget string) RouteDecision {
 			}
 
 			if chosen == nil {
+				reason := fmt.Sprintf("cheapest capable driver (tier: %s, state: %s)", tier, health.CircuitState)
+				if taskType != "" {
+					reason = fmt.Sprintf("cheapest capable driver for %q (tier: %s, state: %s)", taskType, tier, health.CircuitState)
+				}
 				chosen = &RouteDecision{
 					Driver:     name,
 					Tier:       string(tier),
 					Confidence: confidence,
-					Reason:     fmt.Sprintf("cheapest healthy driver (tier: %s, state: %s)", tier, health.CircuitState),
+					Reason:     reason,
 				}
 			} else {
 				fallbacks = append(fallbacks, name)
@@ -122,9 +171,13 @@ func (r *Router) Recommend(taskType, budget string) RouteDecision {
 	}
 
 	if chosen == nil {
+		reason := "all drivers exhausted — circuit breakers OPEN"
+		if taskType != "" && minTier != TierLocal {
+			reason = fmt.Sprintf("all capable drivers for %q exhausted (min tier: %s)", taskType, minTier)
+		}
 		return RouteDecision{
 			Skip:   true,
-			Reason: "all drivers exhausted — circuit breakers OPEN",
+			Reason: reason,
 		}
 	}
 
@@ -149,6 +202,15 @@ func maxTierForBudget(budget string) CostTier {
 	default:
 		return TierAPI
 	}
+}
+
+// minTierForTask returns the minimum capable tier for a task type.
+// Unrecognized task types default to TierLocal (no floor — cheapest wins).
+func minTierForTask(taskType string) CostTier {
+	if t, ok := taskTypeMinTier[strings.ToLower(taskType)]; ok {
+		return t
+	}
+	return TierLocal
 }
 
 // tierFor returns the cost tier for a driver, defaulting to CLI.

--- a/internal/routing/router_test.go
+++ b/internal/routing/router_test.go
@@ -232,6 +232,194 @@ func TestHealthReport(t *testing.T) {
 	}
 }
 
+// ── Task-type minimum tier tests ──────────────────────────────────────────────
+
+func TestRecommend_CodeTaskSkipsLocal(t *testing.T) {
+	dir := t.TempDir()
+	writeHealth(t, dir, "ollama", HealthFile{State: "CLOSED", Failures: 0})
+	writeHealth(t, dir, "claude-code", HealthFile{State: "CLOSED", Failures: 0})
+
+	r := NewRouter(dir)
+	dec := r.Recommend("code-review", "high")
+
+	if dec.Skip {
+		t.Fatal("expected recommendation, got Skip")
+	}
+	// code-review requires CLI tier minimum — ollama must be skipped
+	if dec.Driver != "claude-code" {
+		t.Fatalf("expected claude-code (CLI tier, code-review min), got %s", dec.Driver)
+	}
+	if dec.Tier != string(TierCLI) {
+		t.Fatalf("expected cli tier, got %s", dec.Tier)
+	}
+}
+
+func TestRecommend_CodeTaskAllCLIOpenCascadesToAPI(t *testing.T) {
+	dir := t.TempDir()
+	writeHealth(t, dir, "ollama", HealthFile{State: "CLOSED", Failures: 0})
+	writeHealth(t, dir, "claude-code", HealthFile{State: "OPEN", Failures: 5})
+	writeHealth(t, dir, "anthropic-api", HealthFile{State: "CLOSED", Failures: 0})
+
+	r := NewRouter(dir)
+	dec := r.Recommend("code", "high")
+
+	if dec.Skip {
+		t.Fatal("expected fallback to API tier, got Skip")
+	}
+	// CLI exhausted — should escalate to API, not descend to local
+	if dec.Driver != "anthropic-api" {
+		t.Fatalf("expected anthropic-api (API fallback for code task), got %s", dec.Driver)
+	}
+	if dec.Tier != string(TierAPI) {
+		t.Fatalf("expected api tier, got %s", dec.Tier)
+	}
+}
+
+func TestRecommend_CodeTaskNoAPIDriversSkips(t *testing.T) {
+	dir := t.TempDir()
+	writeHealth(t, dir, "ollama", HealthFile{State: "CLOSED", Failures: 0})
+	writeHealth(t, dir, "claude-code", HealthFile{State: "OPEN", Failures: 5})
+
+	r := NewRouter(dir)
+	dec := r.Recommend("code", "high")
+
+	// CLI is OPEN, ollama is below min tier, no API driver — must skip
+	if !dec.Skip {
+		t.Fatalf("expected Skip (code task, CLI exhausted, no API), got driver=%s", dec.Driver)
+	}
+}
+
+func TestRecommend_TriageTaskUsesLocal(t *testing.T) {
+	dir := t.TempDir()
+	writeHealth(t, dir, "ollama", HealthFile{State: "CLOSED", Failures: 0})
+	writeHealth(t, dir, "claude-code", HealthFile{State: "CLOSED", Failures: 0})
+
+	r := NewRouter(dir)
+	dec := r.Recommend("triage", "high")
+
+	if dec.Skip {
+		t.Fatal("expected recommendation, got Skip")
+	}
+	// triage is local-capable — should use ollama (cheapest)
+	if dec.Driver != "ollama" {
+		t.Fatalf("expected ollama for triage task, got %s", dec.Driver)
+	}
+	if dec.Tier != string(TierLocal) {
+		t.Fatalf("expected local tier, got %s", dec.Tier)
+	}
+}
+
+func TestRecommend_UnknownTaskTypeDefaultsToLocal(t *testing.T) {
+	dir := t.TempDir()
+	writeHealth(t, dir, "ollama", HealthFile{State: "CLOSED", Failures: 0})
+	writeHealth(t, dir, "claude-code", HealthFile{State: "CLOSED", Failures: 0})
+
+	r := NewRouter(dir)
+	dec := r.Recommend("some-future-task-type", "high")
+
+	if dec.Skip {
+		t.Fatal("expected recommendation for unknown task type, got Skip")
+	}
+	// Unknown task types have no floor — cheapest (local) wins
+	if dec.Tier != string(TierLocal) {
+		t.Fatalf("expected local tier for unknown task type, got %s", dec.Tier)
+	}
+}
+
+func TestRecommend_EmptyTaskTypeDefaultsToLocal(t *testing.T) {
+	dir := t.TempDir()
+	writeHealth(t, dir, "ollama", HealthFile{State: "CLOSED", Failures: 0})
+	writeHealth(t, dir, "claude-code", HealthFile{State: "CLOSED", Failures: 0})
+
+	r := NewRouter(dir)
+	dec := r.Recommend("", "high")
+
+	if dec.Skip {
+		t.Fatal("expected recommendation for empty task type, got Skip")
+	}
+	if dec.Tier != string(TierLocal) {
+		t.Fatalf("expected local tier for empty task type, got %s", dec.Tier)
+	}
+}
+
+// ── New driver registration tests ─────────────────────────────────────────────
+
+func TestRecommend_SubscriptionDriversChatGPTNotebookLM(t *testing.T) {
+	dir := t.TempDir()
+	writeHealth(t, dir, "chatgpt", HealthFile{State: "CLOSED", Failures: 0})
+	writeHealth(t, dir, "notebooklm", HealthFile{State: "CLOSED", Failures: 0})
+	writeHealth(t, dir, "claude-code", HealthFile{State: "CLOSED", Failures: 0})
+
+	r := NewRouter(dir)
+	dec := r.Recommend("briefing", "high")
+
+	if dec.Skip {
+		t.Fatal("expected recommendation, got Skip")
+	}
+	// briefing min tier is subscription — chatgpt/notebooklm should be chosen over claude-code
+	if dec.Tier != string(TierSubscription) {
+		t.Fatalf("expected subscription tier for briefing task, got %s", dec.Tier)
+	}
+}
+
+func TestRecommend_APITierDrivers(t *testing.T) {
+	dir := t.TempDir()
+	writeHealth(t, dir, "anthropic-api", HealthFile{State: "CLOSED", Failures: 0})
+	writeHealth(t, dir, "openai-api", HealthFile{State: "CLOSED", Failures: 0})
+	writeHealth(t, dir, "gemini-api", HealthFile{State: "CLOSED", Failures: 0})
+
+	r := NewRouter(dir)
+	dec := r.Recommend("burst", "high")
+
+	if dec.Skip {
+		t.Fatal("expected recommendation, got Skip")
+	}
+	// burst requires API tier
+	if dec.Tier != string(TierAPI) {
+		t.Fatalf("expected api tier for burst task, got %s", dec.Tier)
+	}
+	// All three are API tier — one chosen, two fallbacks
+	if len(dec.Fallbacks) != 2 {
+		t.Fatalf("expected 2 fallbacks for 3 API drivers, got %d", len(dec.Fallbacks))
+	}
+}
+
+func TestRecommend_GeminiAppIsSubscriptionTier(t *testing.T) {
+	dir := t.TempDir()
+	writeHealth(t, dir, "gemini-app", HealthFile{State: "CLOSED", Failures: 0})
+	writeHealth(t, dir, "gemini", HealthFile{State: "CLOSED", Failures: 0}) // CLI tier Gemini
+
+	r := NewRouter(dir)
+	dec := r.Recommend("task", "high")
+
+	if dec.Skip {
+		t.Fatal("expected recommendation, got Skip")
+	}
+	// gemini-app (subscription) is cheaper than gemini CLI
+	if dec.Driver != "gemini-app" {
+		t.Fatalf("expected gemini-app (subscription, cheaper), got %s", dec.Driver)
+	}
+	if dec.Tier != string(TierSubscription) {
+		t.Fatalf("expected subscription tier, got %s", dec.Tier)
+	}
+}
+
+func TestRecommend_NemoclawIsLocalTier(t *testing.T) {
+	dir := t.TempDir()
+	writeHealth(t, dir, "nemoclaw", HealthFile{State: "CLOSED", Failures: 0})
+	writeHealth(t, dir, "claude-code", HealthFile{State: "CLOSED", Failures: 0})
+
+	r := NewRouter(dir)
+	dec := r.Recommend("triage", "high")
+
+	if dec.Skip {
+		t.Fatal("expected recommendation, got Skip")
+	}
+	if dec.Tier != string(TierLocal) {
+		t.Fatalf("expected local tier for nemoclaw, got %s", dec.Tier)
+	}
+}
+
 func TestDiscoverDrivers_EmptyDir(t *testing.T) {
 	dir := t.TempDir()
 	drivers := DiscoverDrivers(dir)


### PR DESCRIPTION
## Summary

Completes issue #8: the full routing cascade was wired but two gaps remained — the driver table was incomplete and `taskType` was accepted but never used.

- **New drivers registered** in `driverTiers`:
  - Subscription: `chatgpt`, `notebooklm`, `gemini-app` (OpenClaw browser targets from issue table)
  - API: `anthropic-api`, `openai-api`, `gemini-api` (API tier was completely empty)
  - Local: `nemoclaw` (NemoClaw runtime for Nemotron)
- **Task-type capability floors** via `minTierForTask()`:
  - `code`, `pr`, `review`, `refactor`, `test`, `debug` → minimum CLI tier (local models skipped)
  - `briefing`, `artifact`, `report`, `research`, `summarize` → minimum subscription
  - `triage`, `classify`, `label`, `simple` → local OK
  - `burst`, `api` → API tier only
  - Unknown/empty task type → no floor (cheapest wins, existing behavior)
- Cascade direction unchanged: when preferred-tier drivers are exhausted, routing escalates upward (never descends below capability floor)
- Skip reason now includes task type and min-tier when relevant for observability

## Test plan

- [x] `TestRecommend_CodeTaskSkipsLocal` — code-review never routes to ollama
- [x] `TestRecommend_CodeTaskAllCLIOpenCascadesToAPI` — CLI exhausted → API, not local
- [x] `TestRecommend_CodeTaskNoAPIDriversSkips` — no capable drivers → Skip
- [x] `TestRecommend_TriageTaskUsesLocal` — triage still hits ollama
- [x] `TestRecommend_UnknownTaskTypeDefaultsToLocal` — no regression for unknown types
- [x] `TestRecommend_SubscriptionDriversChatGPTNotebookLM` — new sub-tier drivers route correctly
- [x] `TestRecommend_APITierDrivers` — API tier drivers and fallbacks
- [x] `TestRecommend_GeminiAppIsSubscriptionTier` — gemini-app cheaper than gemini CLI
- [x] `TestRecommend_NemoclawIsLocalTier` — nemoclaw local registration
- [x] All 101 existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)