### PR TITLE
feat: cost-tier routing cascade — API tier, task preferences, cascade reason

### DIFF
--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -429,12 +429,12 @@ func toolDefs() []ToolDef {
 		},
 		{
 			Name:        "route_recommend",
-			Description: "Get the recommended driver for a task based on cost tier and driver health. Returns cheapest healthy driver with fallback options.",
+			Description: "Get the recommended driver for a task using the cost-tier cascade: local ($0) → subscription (already paying) → CLI (already paying) → API (per-token). Returns cheapest healthy driver; when an entire tier has open circuit breakers it cascades to the next tier. Task type influences driver preference within a tier (e.g. 'coding' prefers claude-code over copilot).",
 			InputSchema: map[string]interface{}{
 				"type": "object",
 				"properties": map[string]interface{}{
-					"taskDescription": map[string]string{"type": "string", "description": "Describe the task"},
-					"budget":          map[string]interface{}{"type": "string", "enum": []string{"low", "medium", "high"}, "description": "Budget tier — low (local only), medium (local+subscription+cli), high (all)"},
+					"taskDescription": map[string]string{"type": "string", "description": "Describe the task (e.g. 'coding', 'code-review', 'classification', 'brief', 'summary', 'agentic')"},
+					"budget":          map[string]interface{}{"type": "string", "enum": []string{"low", "medium", "high"}, "description": "Budget ceiling — low (local only), medium (local+subscription+cli), high (all tiers including API)"},
 				},
 				"required": []string{"taskDescription"},
 			},

--- a/internal/routing/router.go
+++ b/internal/routing/router.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 )
 
@@ -22,17 +23,69 @@ var tierOrder = []CostTier{TierLocal, TierSubscription, TierCLI, TierAPI}
 
 // driverTiers maps each known driver to its cost tier.
 var driverTiers = map[string]CostTier{
-	// Local ($0)
+	// Local ($0) — Ollama, NemoClaw-hosted Nemotron
 	"ollama":   TierLocal,
 	"nemotron": TierLocal,
-	// Subscription (browser-based)
+	// Subscription (browser-based, already paying) — OpenClaw browser runtime
 	"openclaw": TierSubscription,
-	// CLI (metered)
+	// CLI (already paying) — local tooling, no per-token cost
 	"claude-code": TierCLI,
 	"copilot":     TierCLI,
 	"codex":       TierCLI,
 	"gemini":      TierCLI,
 	"goose":       TierCLI,
+	// API (per-token) — burst capacity, programmatic access
+	"claude-api": TierAPI,
+	"openai-api": TierAPI,
+	"gemini-api": TierAPI,
+}
+
+// taskPreferences maps task types to drivers in preferred order within a tier.
+// Drivers earlier in the slice are selected first when multiple healthy options exist.
+var taskPreferences = map[string][]string{
+	"coding":         {"claude-code", "codex", "copilot", "gemini"},
+	"code-review":    {"claude-code", "copilot", "codex"},
+	"classification": {"ollama", "nemotron"},
+	"brief":          {"openclaw"},
+	"summary":        {"openclaw", "ollama"},
+	"agentic":        {"goose", "claude-code"},
+}
+
+// candidate is a driver name paired with its current health state.
+type candidate struct {
+	name   string
+	health DriverHealth
+}
+
+// tieredCandidates returns all drivers for a cost tier sorted by task preference then name.
+// Preferred drivers (matching taskType prefs) sort before unpreferred ones.
+func tieredCandidates(healthMap map[string]DriverHealth, tier CostTier, prefs []string) []candidate {
+	prefRank := make(map[string]int, len(prefs))
+	for i, p := range prefs {
+		prefRank[p] = i + 1 // 1-based; 0 means "not preferred"
+	}
+
+	var result []candidate
+	for name, health := range healthMap {
+		if tierFor(name) == tier {
+			result = append(result, candidate{name, health})
+		}
+	}
+
+	sort.Slice(result, func(i, j int) bool {
+		ri, rj := prefRank[result[i].name], prefRank[result[j].name]
+		switch {
+		case ri != 0 && rj != 0:
+			return ri < rj // both preferred: lower rank wins
+		case ri != 0:
+			return true // only i preferred
+		case rj != 0:
+			return false // only j preferred
+		default:
+			return result[i].name < result[j].name // stable tie-break
+		}
+	})
+	return result
 }
 
 // DriverHealth represents the runtime health of a single driver.
@@ -75,49 +128,69 @@ func NewRouter(healthDir string) *Router {
 //   - "medium" -> local + subscription + cli
 //   - "high"   -> all tiers
 //   - ""       -> all tiers (default)
+//
+// Within a tier, drivers are ordered by taskType preference (see taskPreferences).
+// When all drivers in a tier have OPEN circuit breakers the cascade continues to the
+// next more-expensive tier and that skip is recorded in the returned Reason.
 func (r *Router) Recommend(taskType, budget string) RouteDecision {
 	maxTier := maxTierForBudget(budget)
-	drivers := DiscoverDrivers(r.healthDir)
 
-	// Build health map from discovered drivers.
-	// Only drivers with health files on disk are candidates.
-	healthMap := make(map[string]DriverHealth)
+	// Build health map from discovered drivers only.
+	// A health file on disk is the registration signal for a driver.
+	drivers := DiscoverDrivers(r.healthDir)
+	healthMap := make(map[string]DriverHealth, len(drivers))
 	for _, d := range drivers {
 		healthMap[d] = ReadDriverHealth(r.healthDir, d)
 	}
 
+	prefs := taskPreferences[taskType]
+
 	var chosen *RouteDecision
 	var fallbacks []string
+	var skippedTiers []string
 
-	// Walk tiers in cost order: cheapest first.
+	// Walk tiers cheapest-first; collect fallbacks across all healthy drivers.
 	for _, tier := range tierOrder {
 		if tierIndex(tier) > tierIndex(maxTier) {
 			break
 		}
-		for name, health := range healthMap {
-			driverTier := tierFor(name)
-			if driverTier != tier {
+		candidates := tieredCandidates(healthMap, tier, prefs)
+		if len(candidates) == 0 {
+			continue // no registered drivers for this tier
+		}
+
+		tierSkipped := true
+		for _, c := range candidates {
+			if c.health.CircuitState == "OPEN" {
 				continue
 			}
-			if health.CircuitState == "OPEN" {
-				continue // skip exhausted drivers
-			}
+			tierSkipped = false
 
 			confidence := 1.0
-			if health.CircuitState == "HALF" {
+			if c.health.CircuitState == "HALF" {
 				confidence = 0.5
 			}
 
 			if chosen == nil {
+				reason := fmt.Sprintf("cheapest healthy driver (tier: %s, circuit: %s)", tier, c.health.CircuitState)
+				if len(skippedTiers) > 0 {
+					reason += fmt.Sprintf("; cascaded past: %s", strings.Join(skippedTiers, ", "))
+				}
 				chosen = &RouteDecision{
-					Driver:     name,
+					Driver:     c.name,
 					Tier:       string(tier),
 					Confidence: confidence,
-					Reason:     fmt.Sprintf("cheapest healthy driver (tier: %s, state: %s)", tier, health.CircuitState),
+					Reason:     reason,
 				}
 			} else {
-				fallbacks = append(fallbacks, name)
+				fallbacks = append(fallbacks, c.name)
 			}
+		}
+
+		// Record tiers where every registered driver was OPEN (so the caller can
+		// understand why a more-expensive tier was chosen).
+		if tierSkipped && chosen == nil {
+			skippedTiers = append(skippedTiers, string(tier))
 		}
 	}
 

--- a/internal/routing/router_test.go
+++ b/internal/routing/router_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -244,5 +245,149 @@ func TestDiscoverDrivers_NonexistentDir(t *testing.T) {
 	drivers := DiscoverDrivers("/nonexistent/path/that/does/not/exist")
 	if drivers != nil {
 		t.Fatalf("expected nil for nonexistent dir, got %v", drivers)
+	}
+}
+
+// --- Cost-tier cascade tests (issue #8) ---
+
+func TestRecommend_APITierInCatalog(t *testing.T) {
+	dir := t.TempDir()
+	// Register an API-tier driver; it should be routable.
+	writeHealth(t, dir, "claude-api", HealthFile{State: "CLOSED", Failures: 0})
+
+	r := NewRouter(dir)
+	dec := r.Recommend("any", "high")
+
+	if dec.Skip {
+		t.Fatal("expected recommendation for claude-api, got Skip")
+	}
+	if dec.Driver != "claude-api" {
+		t.Fatalf("expected claude-api, got %s", dec.Driver)
+	}
+	if dec.Tier != string(TierAPI) {
+		t.Fatalf("expected tier api, got %s", dec.Tier)
+	}
+}
+
+func TestRecommend_FullCascade_AllLowerTiersOpen(t *testing.T) {
+	dir := t.TempDir()
+	// Local and subscription tiers all OPEN; CLI all OPEN; API healthy.
+	writeHealth(t, dir, "ollama", HealthFile{State: "OPEN", Failures: 5})
+	writeHealth(t, dir, "openclaw", HealthFile{State: "OPEN", Failures: 3})
+	writeHealth(t, dir, "claude-code", HealthFile{State: "OPEN", Failures: 2})
+	writeHealth(t, dir, "claude-api", HealthFile{State: "CLOSED", Failures: 0})
+
+	r := NewRouter(dir)
+	dec := r.Recommend("any", "high")
+
+	if dec.Skip {
+		t.Fatal("expected API-tier fallback, got Skip")
+	}
+	if dec.Driver != "claude-api" {
+		t.Fatalf("expected claude-api (only healthy driver), got %s", dec.Driver)
+	}
+	if dec.Tier != string(TierAPI) {
+		t.Fatalf("expected tier api, got %s", dec.Tier)
+	}
+	// Cascade reason should mention the skipped tiers.
+	if !strings.Contains(dec.Reason, "cascaded past") {
+		t.Fatalf("expected cascade reason, got: %s", dec.Reason)
+	}
+}
+
+func TestRecommend_CascadeReason_MentionsSkippedTiers(t *testing.T) {
+	dir := t.TempDir()
+	writeHealth(t, dir, "ollama", HealthFile{State: "OPEN", Failures: 5})
+	writeHealth(t, dir, "claude-code", HealthFile{State: "CLOSED", Failures: 0})
+
+	r := NewRouter(dir)
+	dec := r.Recommend("any", "high")
+
+	if dec.Skip {
+		t.Fatal("expected recommendation, got Skip")
+	}
+	if dec.Tier != string(TierCLI) {
+		t.Fatalf("expected CLI tier after local cascade, got %s", dec.Tier)
+	}
+	if !strings.Contains(dec.Reason, "local") {
+		t.Fatalf("cascade reason should mention skipped local tier, got: %s", dec.Reason)
+	}
+}
+
+func TestRecommend_TaskTypePreference_Coding(t *testing.T) {
+	dir := t.TempDir()
+	// Both are CLI tier; "coding" preference puts claude-code first.
+	writeHealth(t, dir, "copilot", HealthFile{State: "CLOSED", Failures: 0})
+	writeHealth(t, dir, "claude-code", HealthFile{State: "CLOSED", Failures: 0})
+
+	r := NewRouter(dir)
+	dec := r.Recommend("coding", "high")
+
+	if dec.Skip {
+		t.Fatal("expected recommendation, got Skip")
+	}
+	if dec.Driver != "claude-code" {
+		t.Fatalf("expected claude-code (preferred for coding), got %s", dec.Driver)
+	}
+}
+
+func TestRecommend_TaskTypePreference_Classification(t *testing.T) {
+	dir := t.TempDir()
+	// Both are local tier; "classification" preference puts ollama first.
+	writeHealth(t, dir, "nemotron", HealthFile{State: "CLOSED", Failures: 0})
+	writeHealth(t, dir, "ollama", HealthFile{State: "CLOSED", Failures: 0})
+
+	r := NewRouter(dir)
+	dec := r.Recommend("classification", "high")
+
+	if dec.Skip {
+		t.Fatal("expected recommendation, got Skip")
+	}
+	if dec.Driver != "ollama" {
+		t.Fatalf("expected ollama (preferred for classification), got %s", dec.Driver)
+	}
+}
+
+func TestRecommend_TaskTypePreference_SkipsOPENPreferred(t *testing.T) {
+	dir := t.TempDir()
+	// claude-code is preferred for coding but OPEN; copilot should be chosen.
+	writeHealth(t, dir, "claude-code", HealthFile{State: "OPEN", Failures: 4})
+	writeHealth(t, dir, "copilot", HealthFile{State: "CLOSED", Failures: 0})
+
+	r := NewRouter(dir)
+	dec := r.Recommend("coding", "high")
+
+	if dec.Skip {
+		t.Fatal("expected recommendation, got Skip")
+	}
+	if dec.Driver != "copilot" {
+		t.Fatalf("expected copilot (preferred but claude-code OPEN), got %s", dec.Driver)
+	}
+}
+
+func TestRecommend_MediumBudgetIncludesSubscription(t *testing.T) {
+	dir := t.TempDir()
+	// All local drivers OPEN; openclaw healthy; medium budget should reach subscription tier.
+	writeHealth(t, dir, "ollama", HealthFile{State: "OPEN", Failures: 3})
+	writeHealth(t, dir, "openclaw", HealthFile{State: "CLOSED", Failures: 0})
+	writeHealth(t, dir, "claude-api", HealthFile{State: "CLOSED", Failures: 0}) // API should be excluded
+
+	r := NewRouter(dir)
+	dec := r.Recommend("any", "medium")
+
+	if dec.Skip {
+		t.Fatal("expected openclaw recommendation at medium budget, got Skip")
+	}
+	if dec.Driver != "openclaw" {
+		t.Fatalf("expected openclaw, got %s", dec.Driver)
+	}
+	if dec.Tier != string(TierSubscription) {
+		t.Fatalf("expected subscription tier, got %s", dec.Tier)
+	}
+	// API driver must not appear in fallbacks for medium budget.
+	for _, fb := range dec.Fallbacks {
+		if fb == "claude-api" {
+			t.Fatal("claude-api (API tier) should not appear in fallbacks for medium budget")
+		}
 	}
 }


### PR DESCRIPTION
## Summary

- **API-tier drivers** added to catalog: `claude-api`, `openai-api`, `gemini-api` — completes the four-tier table from the issue
- **Task-type preferences** — `route_recommend` now orders candidates within a tier by task type (`coding` → `claude-code` first; `classification` → `ollama` first; `agentic` → `goose` first; etc.)
- **Cascade reason** — when all drivers in a tier are OPEN the `Reason` field now explains which tiers were skipped (e.g. `"cascaded past: local, subscription"`)
- **`tieredCandidates` helper** — replaces non-deterministic map iteration with a stable preference-rank + alphabetic sort
- **7 new tests** (20 total, was 13): API tier routing, full 4-tier cascade, cascade reason content, task-type preference ordering, preferred-but-OPEN fallback, medium-budget API exclusion

## Test plan

- [x] `go test ./internal/routing/...` — 20/20 pass
- [x] `go test ./...` — 98/98 pass
- [x] `go build ./...` — clean

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)