### PR TITLE
feat: cost-tier routing cascade — task-type floors + API tier (#8)

### DIFF
--- a/internal/routing/router.go
+++ b/internal/routing/router.go
@@ -25,14 +25,50 @@ var driverTiers = map[string]CostTier{
 	// Local ($0)
 	"ollama":   TierLocal,
 	"nemotron": TierLocal,
-	// Subscription (browser-based)
+	// Subscription (browser-based, already paying)
 	"openclaw": TierSubscription,
-	// CLI (metered)
+	// CLI (metered subscription)
 	"claude-code": TierCLI,
 	"copilot":     TierCLI,
 	"codex":       TierCLI,
 	"gemini":      TierCLI,
 	"goose":       TierCLI,
+	// API (per-token billing)
+	"claude-api": TierAPI,
+	"openai-api": TierAPI,
+	"gemini-api": TierAPI,
+}
+
+// taskTypeFloors maps task-type keywords to the minimum cost tier appropriate
+// for that kind of work. Tiers below the floor are skipped even if healthy.
+//
+// Ordering matters: first match wins. More specific entries should come first.
+var taskTypeFloors = []struct {
+	keywords []string
+	floor    CostTier
+}{
+	// Coding work requires a capable code-aware driver — CLI minimum.
+	{
+		keywords: []string{
+			"code-review", "coding", "refactor", "commit", "pr", "merge",
+			"senior", "qa", "reviewer", "merger", "engineer", "test", "debug",
+		},
+		floor: TierCLI,
+	},
+	// Artifact and research tasks work well with subscription browser drivers.
+	{
+		keywords: []string{
+			"artifact", "briefing", "research", "notebook", "report", "document",
+		},
+		floor: TierSubscription,
+	},
+	// Triage and classification are cheap — local models are sufficient.
+	{
+		keywords: []string{
+			"triage", "classify", "classification", "summarize", "label", "simple",
+		},
+		floor: TierLocal,
+	},
 }
 
 // DriverHealth represents the runtime health of a single driver.
@@ -48,6 +84,7 @@ type DriverHealth struct {
 type RouteDecision struct {
 	Driver     string   `json:"driver"`
 	Tier       string   `json:"tier"`
+	Floor      string   `json:"floor,omitempty"` // minimum tier enforced by task type
 	Confidence float64  `json:"confidence"`
 	Reason     string   `json:"reason"`
 	Fallbacks  []string `json:"fallbacks"`
@@ -69,14 +106,17 @@ func NewRouter(healthDir string) *Router {
 	return &Router{healthDir: healthDir}
 }
 
-// Recommend returns the cheapest healthy driver for the given task.
-// The budget parameter controls which cost tiers are considered:
-//   - "low"    -> local only
-//   - "medium" -> local + subscription + cli
-//   - "high"   -> all tiers
-//   - ""       -> all tiers (default)
+// Recommend returns the cheapest healthy driver for the given task within the
+// allowed tier window [floor, ceiling]:
+//   - floor (from taskType): minimum tier appropriate for the work
+//   - ceiling (from budget): "low" → local, "medium" → cli, "high"/"" → api
+//
+// Example: a "code-review" task with budget "high" uses the window [cli, api].
+// Tiers below the floor are skipped even if healthy — routing ollama to a
+// coding task would produce poor results regardless of availability.
 func (r *Router) Recommend(taskType, budget string) RouteDecision {
-	maxTier := maxTierForBudget(budget)
+	floor := taskFloor(taskType)
+	ceiling := maxTierForBudget(budget)
 	drivers := DiscoverDrivers(r.healthDir)
 
 	// Build health map from discovered drivers.
@@ -89,10 +129,13 @@ func (r *Router) Recommend(taskType, budget string) RouteDecision {
 	var chosen *RouteDecision
 	var fallbacks []string
 
-	// Walk tiers in cost order: cheapest first.
+	// Walk tiers in cost order within the [floor, ceiling] window.
 	for _, tier := range tierOrder {
-		if tierIndex(tier) > tierIndex(maxTier) {
-			break
+		if tierIndex(tier) < tierIndex(floor) {
+			continue // below task-type floor
+		}
+		if tierIndex(tier) > tierIndex(ceiling) {
+			break // above budget ceiling
 		}
 		for name, health := range healthMap {
 			driverTier := tierFor(name)
@@ -112,8 +155,9 @@ func (r *Router) Recommend(taskType, budget string) RouteDecision {
 				chosen = &RouteDecision{
 					Driver:     name,
 					Tier:       string(tier),
+					Floor:      string(floor),
 					Confidence: confidence,
-					Reason:     fmt.Sprintf("cheapest healthy driver (tier: %s, state: %s)", tier, health.CircuitState),
+					Reason:     fmt.Sprintf("cheapest healthy driver in window [%s, %s] (state: %s)", floor, ceiling, health.CircuitState),
 				}
 			} else {
 				fallbacks = append(fallbacks, name)
@@ -124,7 +168,8 @@ func (r *Router) Recommend(taskType, budget string) RouteDecision {
 	if chosen == nil {
 		return RouteDecision{
 			Skip:   true,
-			Reason: "all drivers exhausted — circuit breakers OPEN",
+			Floor:  string(floor),
+			Reason: fmt.Sprintf("all drivers exhausted in window [%s, %s]", floor, ceiling),
 		}
 	}
 
@@ -135,6 +180,21 @@ func (r *Router) Recommend(taskType, budget string) RouteDecision {
 // HealthReport returns current health status for all discovered drivers.
 func (r *Router) HealthReport() []DriverHealth {
 	return ReadAllHealth(r.healthDir)
+}
+
+// taskFloor returns the minimum cost tier appropriate for the given task type.
+// Tiers below the floor produce poor results for the task regardless of health.
+// Unknown task types default to TierLocal so all healthy drivers are candidates.
+func taskFloor(taskType string) CostTier {
+	lower := strings.ToLower(taskType)
+	for _, entry := range taskTypeFloors {
+		for _, kw := range entry.keywords {
+			if strings.Contains(lower, kw) {
+				return entry.floor
+			}
+		}
+	}
+	return TierLocal // default: start from cheapest
 }
 
 // maxTierForBudget returns the highest tier to consider for a budget level.

--- a/internal/routing/router_test.go
+++ b/internal/routing/router_test.go
@@ -246,3 +246,167 @@ func TestDiscoverDrivers_NonexistentDir(t *testing.T) {
 		t.Fatalf("expected nil for nonexistent dir, got %v", drivers)
 	}
 }
+
+// --- Task-type floor tests ---
+
+func TestRecommend_CodingTaskSkipsLocal(t *testing.T) {
+	dir := t.TempDir()
+	// Local driver is healthy, but coding tasks require CLI minimum
+	writeHealth(t, dir, "ollama", HealthFile{State: "CLOSED", Failures: 0})
+	writeHealth(t, dir, "claude-code", HealthFile{State: "CLOSED", Failures: 0})
+
+	r := NewRouter(dir)
+	dec := r.Recommend("code-review", "high")
+
+	if dec.Skip {
+		t.Fatal("expected a recommendation, got Skip")
+	}
+	if dec.Driver == "ollama" {
+		t.Fatal("ollama should be skipped for code-review (below CLI floor)")
+	}
+	if dec.Tier != string(TierCLI) {
+		t.Fatalf("expected CLI tier for code-review, got %s", dec.Tier)
+	}
+	if dec.Floor != string(TierCLI) {
+		t.Fatalf("expected Floor=cli for code-review, got %s", dec.Floor)
+	}
+}
+
+func TestRecommend_CodingTaskCascadesToAPI(t *testing.T) {
+	dir := t.TempDir()
+	// All CLI drivers OPEN — cascade to API tier
+	writeHealth(t, dir, "claude-code", HealthFile{State: "OPEN", Failures: 5})
+	writeHealth(t, dir, "copilot", HealthFile{State: "OPEN", Failures: 3})
+	writeHealth(t, dir, "claude-api", HealthFile{State: "CLOSED", Failures: 0})
+
+	r := NewRouter(dir)
+	dec := r.Recommend("pr-merge", "high")
+
+	if dec.Skip {
+		t.Fatalf("expected cascade to API tier, got Skip")
+	}
+	if dec.Driver != "claude-api" {
+		t.Fatalf("expected claude-api (API tier fallback), got %s", dec.Driver)
+	}
+	if dec.Tier != string(TierAPI) {
+		t.Fatalf("expected tier api, got %s", dec.Tier)
+	}
+}
+
+func TestRecommend_TriageTaskUsesLocal(t *testing.T) {
+	dir := t.TempDir()
+	writeHealth(t, dir, "ollama", HealthFile{State: "CLOSED", Failures: 0})
+	writeHealth(t, dir, "claude-code", HealthFile{State: "CLOSED", Failures: 0})
+
+	r := NewRouter(dir)
+	dec := r.Recommend("triage", "high")
+
+	if dec.Skip {
+		t.Fatal("expected recommendation, got Skip")
+	}
+	// triage floor = local, so ollama is the cheapest healthy option
+	if dec.Driver != "ollama" {
+		t.Fatalf("expected ollama (local tier for triage), got %s", dec.Driver)
+	}
+}
+
+func TestRecommend_APITierDriver(t *testing.T) {
+	dir := t.TempDir()
+	writeHealth(t, dir, "claude-api", HealthFile{State: "CLOSED", Failures: 0})
+	writeHealth(t, dir, "openai-api", HealthFile{State: "CLOSED", Failures: 0})
+
+	r := NewRouter(dir)
+	dec := r.Recommend("burst-task", "high")
+
+	if dec.Skip {
+		t.Fatal("expected recommendation, got Skip")
+	}
+	if dec.Tier != string(TierAPI) {
+		t.Fatalf("expected API tier, got %s", dec.Tier)
+	}
+	// Both are API drivers — either is valid, but one should be fallback
+	if dec.Driver == "" {
+		t.Fatal("expected a driver name, got empty")
+	}
+	if len(dec.Fallbacks) == 0 {
+		t.Fatal("expected the other api driver as fallback")
+	}
+}
+
+func TestRecommend_APITierBudgetCeiling(t *testing.T) {
+	dir := t.TempDir()
+	writeHealth(t, dir, "ollama", HealthFile{State: "CLOSED", Failures: 0})
+	writeHealth(t, dir, "claude-api", HealthFile{State: "CLOSED", Failures: 0})
+
+	r := NewRouter(dir)
+	// low budget: ceiling = local, so API driver should not be reachable
+	dec := r.Recommend("simple-task", "low")
+
+	if dec.Skip {
+		t.Fatal("expected ollama at low budget, got Skip")
+	}
+	if dec.Driver != "ollama" {
+		t.Fatalf("expected ollama (local tier within budget), got %s", dec.Driver)
+	}
+	for _, fb := range dec.Fallbacks {
+		if fb == "claude-api" {
+			t.Fatal("claude-api should not appear as fallback at low budget")
+		}
+	}
+}
+
+func TestRecommend_CodingTaskLowBudget_Skip(t *testing.T) {
+	dir := t.TempDir()
+	writeHealth(t, dir, "ollama", HealthFile{State: "CLOSED", Failures: 0})
+	writeHealth(t, dir, "claude-code", HealthFile{State: "CLOSED", Failures: 0})
+
+	r := NewRouter(dir)
+	// coding floor = cli, but low budget ceiling = local → empty window → skip
+	dec := r.Recommend("code-review", "low")
+
+	if !dec.Skip {
+		t.Fatalf("expected Skip (floor cli > ceiling local), got driver=%s", dec.Driver)
+	}
+}
+
+func TestRecommend_UnknownTaskDefaultsToLocalFloor(t *testing.T) {
+	dir := t.TempDir()
+	writeHealth(t, dir, "ollama", HealthFile{State: "CLOSED", Failures: 0})
+	writeHealth(t, dir, "claude-code", HealthFile{State: "CLOSED", Failures: 0})
+
+	r := NewRouter(dir)
+	dec := r.Recommend("some-unknown-task-type", "high")
+
+	if dec.Skip {
+		t.Fatal("expected recommendation, got Skip")
+	}
+	// Unknown task → default floor = local → ollama wins (cheapest)
+	if dec.Driver != "ollama" {
+		t.Fatalf("expected ollama (default local floor), got %s", dec.Driver)
+	}
+}
+
+func TestTaskFloor(t *testing.T) {
+	cases := []struct {
+		input    string
+		expected CostTier
+	}{
+		{"code-review", TierCLI},
+		{"coding task for PR", TierCLI},
+		{"senior-agent", TierCLI},
+		{"qa-agent", TierCLI},
+		{"pr-merger-agent", TierCLI},
+		{"triage tickets", TierLocal},
+		{"classify issue", TierLocal},
+		{"research briefing", TierSubscription},
+		{"notebook report", TierSubscription},
+		{"unknown-thing", TierLocal},
+		{"", TierLocal},
+	}
+	for _, c := range cases {
+		got := taskFloor(c.input)
+		if got != c.expected {
+			t.Errorf("taskFloor(%q) = %s, want %s", c.input, got, c.expected)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- **Tier window model**: routing is now bounded by `[floor, ceiling]` rather than a single ceiling. The floor comes from task type, the ceiling from budget.
- **Task-type floors**: coding/PR/merge tasks floor at `cli` (skips local/subscription even if healthy); briefings/research at `subscription`; triage/classify at `local` (default).
- **API tier drivers**: `claude-api`, `openai-api`, `gemini-api` — burst capacity fallback when all CLI circuit breakers are open.
- **`RouteDecision.Floor`** field added (omitempty) + improved `Reason` strings show the full `[floor, ceiling]` window.

## Why it matters

Before this, a `code-review` task with a healthy `ollama` driver would route to ollama — poor results. Now it correctly floors at CLI tier, cascading to API if CLI is exhausted.

## Test plan

- [x] `TestRecommend_CodingTaskSkipsLocal` — coding task ignores local driver
- [x] `TestRecommend_CodingTaskCascadesToAPI` — CLI all OPEN → API fallback
- [x] `TestRecommend_TriageTaskUsesLocal` — triage floors at local
- [x] `TestRecommend_APITierDriver` — API drivers are selectable
- [x] `TestRecommend_APITierBudgetCeiling` — low budget excludes API tier
- [x] `TestRecommend_CodingTaskLowBudget_Skip` — floor > ceiling → skip
- [x] `TestRecommend_UnknownTaskDefaultsToLocalFloor` — unknown task = cheapest-first
- [x] `TestTaskFloor` — keyword matching table test
- [x] Full suite: 99 tests pass (`go test ./...`)

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)