### PR TITLE
feat: cost-tier routing cascade with task-type affinity (#8)

### DIFF
--- a/internal/routing/router.go
+++ b/internal/routing/router.go
@@ -25,14 +25,17 @@ var driverTiers = map[string]CostTier{
 	// Local ($0)
 	"ollama":   TierLocal,
 	"nemotron": TierLocal,
-	// Subscription (browser-based)
+	// Subscription (browser-based, already-paying seat)
 	"openclaw": TierSubscription,
-	// CLI (metered)
+	// CLI (already-paying seat: coding, PRs, commits)
 	"claude-code": TierCLI,
 	"copilot":     TierCLI,
 	"codex":       TierCLI,
 	"gemini":      TierCLI,
 	"goose":       TierCLI,
+	// API (per-token: burst capacity, programmatic access)
+	"anthropic-api": TierAPI,
+	"openai-api":    TierAPI,
 }
 
 // DriverHealth represents the runtime health of a single driver.
@@ -70,13 +73,24 @@ func NewRouter(healthDir string) *Router {
 }
 
 // Recommend returns the cheapest healthy driver for the given task.
-// The budget parameter controls which cost tiers are considered:
-//   - "low"    -> local only
-//   - "medium" -> local + subscription + cli
-//   - "high"   -> all tiers
-//   - ""       -> all tiers (default)
+//
+// Two constraints bound the tier search:
+//   - minTier (from taskType affinity): coding tasks won't route to local models
+//   - maxTier (from budget): high-cost tiers are excluded when budget is constrained
+//
+// If minTier > maxTier, returns Skip with an explanatory reason.
+// Budget values: "low" (local only), "medium" (up to cli), "high"/"" (all tiers).
 func (r *Router) Recommend(taskType, budget string) RouteDecision {
+	minTier := taskAffinityTier(taskType)
 	maxTier := maxTierForBudget(budget)
+
+	if tierIndex(minTier) > tierIndex(maxTier) {
+		return RouteDecision{
+			Skip:   true,
+			Reason: fmt.Sprintf("task type requires %s tier minimum, but budget allows %s maximum", minTier, maxTier),
+		}
+	}
+
 	drivers := DiscoverDrivers(r.healthDir)
 
 	// Build health map from discovered drivers.
@@ -89,14 +103,16 @@ func (r *Router) Recommend(taskType, budget string) RouteDecision {
 	var chosen *RouteDecision
 	var fallbacks []string
 
-	// Walk tiers in cost order: cheapest first.
+	// Walk tiers in cost order: cheapest first, bounded by [minTier, maxTier].
 	for _, tier := range tierOrder {
+		if tierIndex(tier) < tierIndex(minTier) {
+			continue // below task affinity minimum
+		}
 		if tierIndex(tier) > tierIndex(maxTier) {
 			break
 		}
 		for name, health := range healthMap {
-			driverTier := tierFor(name)
-			if driverTier != tier {
+			if tierFor(name) != tier {
 				continue
 			}
 			if health.CircuitState == "OPEN" {
@@ -113,7 +129,7 @@ func (r *Router) Recommend(taskType, budget string) RouteDecision {
 					Driver:     name,
 					Tier:       string(tier),
 					Confidence: confidence,
-					Reason:     fmt.Sprintf("cheapest healthy driver (tier: %s, state: %s)", tier, health.CircuitState),
+					Reason:     fmt.Sprintf("cheapest healthy driver in allowed range (tier: %s, state: %s)", tier, health.CircuitState),
 				}
 			} else {
 				fallbacks = append(fallbacks, name)
@@ -149,6 +165,37 @@ func maxTierForBudget(budget string) CostTier {
 	default:
 		return TierAPI
 	}
+}
+
+// taskAffinityTier returns the minimum cost tier suitable for a given task type.
+// Local models handle triage/classification; coding tasks need CLI-grade models;
+// briefings and artifacts work well with subscription browser drivers.
+func taskAffinityTier(taskType string) CostTier {
+	lower := strings.ToLower(taskType)
+
+	codingKeywords := []string{
+		"code", "coding", "pr", "pull request", "commit", "review",
+		"refactor", "debug", "implement", "fix bug", "test", "build",
+		"deploy", "migration", "schema",
+	}
+	for _, kw := range codingKeywords {
+		if strings.Contains(lower, kw) {
+			return TierCLI
+		}
+	}
+
+	briefingKeywords := []string{
+		"briefing", "artifact", "summary", "document", "research",
+		"report", "analysis", "notebooklm", "chatgpt",
+	}
+	for _, kw := range briefingKeywords {
+		if strings.Contains(lower, kw) {
+			return TierSubscription
+		}
+	}
+
+	// Default: no minimum — cheapest available driver wins.
+	return TierLocal
 }
 
 // tierFor returns the cost tier for a driver, defaulting to CLI.

--- a/internal/routing/router_test.go
+++ b/internal/routing/router_test.go
@@ -246,3 +246,156 @@ func TestDiscoverDrivers_NonexistentDir(t *testing.T) {
 		t.Fatalf("expected nil for nonexistent dir, got %v", drivers)
 	}
 }
+
+// --- Task-type affinity routing tests (issue #8) ---
+
+func TestRecommend_CodingTaskSkipsLocalDriver(t *testing.T) {
+	dir := t.TempDir()
+	writeHealth(t, dir, "ollama", HealthFile{State: "CLOSED", Failures: 0})
+	writeHealth(t, dir, "claude-code", HealthFile{State: "CLOSED", Failures: 0})
+
+	r := NewRouter(dir)
+	dec := r.Recommend("code review for PR #42", "high")
+
+	if dec.Skip {
+		t.Fatal("expected a driver recommendation, got Skip")
+	}
+	// Coding task: min tier is CLI — ollama (local) must be skipped
+	if dec.Driver == "ollama" {
+		t.Fatal("coding task should not route to local driver (ollama)")
+	}
+	if dec.Tier != string(TierCLI) {
+		t.Fatalf("expected cli tier for coding task, got %s", dec.Tier)
+	}
+}
+
+func TestRecommend_CodingTaskLowBudgetSkips(t *testing.T) {
+	dir := t.TempDir()
+	writeHealth(t, dir, "ollama", HealthFile{State: "CLOSED", Failures: 0})
+	writeHealth(t, dir, "claude-code", HealthFile{State: "CLOSED", Failures: 0})
+
+	r := NewRouter(dir)
+	dec := r.Recommend("implement new feature", "low")
+
+	// Coding needs CLI (min), but low budget caps at local (max) — conflict → Skip
+	if !dec.Skip {
+		t.Fatalf("expected Skip when coding task conflicts with low budget, got driver=%s", dec.Driver)
+	}
+	if dec.Reason == "" {
+		t.Fatal("expected a reason for the skip")
+	}
+}
+
+func TestRecommend_BriefingTaskUsesSubscription(t *testing.T) {
+	dir := t.TempDir()
+	writeHealth(t, dir, "ollama", HealthFile{State: "CLOSED", Failures: 0})
+	writeHealth(t, dir, "openclaw", HealthFile{State: "CLOSED", Failures: 0})
+	writeHealth(t, dir, "claude-code", HealthFile{State: "CLOSED", Failures: 0})
+
+	r := NewRouter(dir)
+	dec := r.Recommend("generate CTO briefing document", "high")
+
+	if dec.Skip {
+		t.Fatal("expected a driver recommendation, got Skip")
+	}
+	// Briefing affinity: min tier is subscription — ollama (local) must be skipped
+	if dec.Driver == "ollama" {
+		t.Fatal("briefing task should not route to local driver")
+	}
+	if dec.Tier != string(TierSubscription) {
+		t.Fatalf("expected subscription tier for briefing task, got %s", dec.Tier)
+	}
+}
+
+func TestRecommend_TriageTaskCanUseLocal(t *testing.T) {
+	dir := t.TempDir()
+	writeHealth(t, dir, "ollama", HealthFile{State: "CLOSED", Failures: 0})
+	writeHealth(t, dir, "claude-code", HealthFile{State: "CLOSED", Failures: 0})
+
+	r := NewRouter(dir)
+	dec := r.Recommend("triage incoming issues", "high")
+
+	if dec.Skip {
+		t.Fatal("expected a driver recommendation, got Skip")
+	}
+	// Triage is local-capable — cheapest (local) should win
+	if dec.Tier != string(TierLocal) {
+		t.Fatalf("expected local tier for triage task, got %s", dec.Tier)
+	}
+}
+
+func TestRecommend_APITierDriverSelectedAsLastResort(t *testing.T) {
+	dir := t.TempDir()
+	writeHealth(t, dir, "ollama", HealthFile{State: "OPEN", Failures: 5})
+	writeHealth(t, dir, "openclaw", HealthFile{State: "OPEN", Failures: 3})
+	writeHealth(t, dir, "claude-code", HealthFile{State: "OPEN", Failures: 8})
+	writeHealth(t, dir, "anthropic-api", HealthFile{State: "CLOSED", Failures: 0})
+
+	r := NewRouter(dir)
+	dec := r.Recommend("any task", "high")
+
+	if dec.Skip {
+		t.Fatal("expected anthropic-api as last-resort, got Skip")
+	}
+	if dec.Driver != "anthropic-api" {
+		t.Fatalf("expected anthropic-api (only healthy driver), got %s", dec.Driver)
+	}
+	if dec.Tier != string(TierAPI) {
+		t.Fatalf("expected api tier, got %s", dec.Tier)
+	}
+}
+
+func TestRecommend_APITierNotUsedWhenBudgetMedium(t *testing.T) {
+	dir := t.TempDir()
+	writeHealth(t, dir, "claude-code", HealthFile{State: "CLOSED", Failures: 0})
+	writeHealth(t, dir, "anthropic-api", HealthFile{State: "CLOSED", Failures: 0})
+
+	r := NewRouter(dir)
+	dec := r.Recommend("general task", "medium")
+
+	if dec.Skip {
+		t.Fatal("expected cli driver for medium budget, got Skip")
+	}
+	// medium budget caps at CLI — API tier must not be selected
+	if dec.Tier == string(TierAPI) {
+		t.Fatal("API tier should not be used when budget is medium")
+	}
+}
+
+func TestTaskAffinityTier_CodingKeywords(t *testing.T) {
+	codingTasks := []string{
+		"code review", "PR review", "commit changes", "implement feature",
+		"fix bug in auth", "refactor database layer", "write tests", "debug crash",
+	}
+	for _, task := range codingTasks {
+		tier := taskAffinityTier(task)
+		if tier != TierCLI {
+			t.Errorf("task %q: expected cli tier, got %s", task, tier)
+		}
+	}
+}
+
+func TestTaskAffinityTier_BriefingKeywords(t *testing.T) {
+	briefingTasks := []string{
+		"generate briefing", "write summary", "create report", "research competitors",
+		"document architecture", "analysis of Q1 results",
+	}
+	for _, task := range briefingTasks {
+		tier := taskAffinityTier(task)
+		if tier != TierSubscription {
+			t.Errorf("task %q: expected subscription tier, got %s", task, tier)
+		}
+	}
+}
+
+func TestTaskAffinityTier_DefaultsToLocal(t *testing.T) {
+	genericTasks := []string{
+		"triage issues", "classify tickets", "label open issues", "quick check",
+	}
+	for _, task := range genericTasks {
+		tier := taskAffinityTier(task)
+		if tier != TierLocal {
+			t.Errorf("task %q: expected local tier default, got %s", task, tier)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- **Dual-bound routing**: `Recommend()` now enforces both a min-tier (from task affinity) and max-tier (from budget). Coding tasks won't silently route to Ollama; budget constraints still cap the ceiling.
- **`taskAffinityTier()`**: Keyword-based inference — `code/pr/commit/review/debug` → CLI minimum, `briefing/summary/document/research` → subscription minimum, anything else → local (cheapest wins).
- **API tier drivers**: `anthropic-api` and `openai-api` registered to `TierAPI` — the 4th cascade tier was previously unreachable (no known drivers).
- **Conflict skip**: When min-tier > max-tier (e.g. coding task with `budget=low`), returns `Skip=true` with a human-readable reason instead of wrong recommendation.

## Test plan

- [x] All 13 existing tests still pass (no regressions)
- [x] `TestRecommend_CodingTaskSkipsLocalDriver` — coding task routes to CLI, not ollama
- [x] `TestRecommend_CodingTaskLowBudgetSkips` — coding+low budget → Skip with reason
- [x] `TestRecommend_BriefingTaskUsesSubscription` — briefing task routes to openclaw, skips ollama
- [x] `TestRecommend_TriageTaskCanUseLocal` — triage task uses cheapest (local)
- [x] `TestRecommend_APITierDriverSelectedAsLastResort` — anthropic-api selected when all lower tiers OPEN
- [x] `TestRecommend_APITierNotUsedWhenBudgetMedium` — API tier excluded at medium budget
- [x] `TestTaskAffinityTier_*` — keyword classification unit tests
- [x] Full suite: `go test ./...` passes (22 routing tests, all packages green)

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)