### PR TITLE
feat: cost-tier routing cascade — API tier fallback + deterministic selection

### DIFF
--- a/internal/routing/router.go
+++ b/internal/routing/router.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 )
 
@@ -33,6 +34,9 @@ var driverTiers = map[string]CostTier{
 	"codex":       TierCLI,
 	"gemini":      TierCLI,
 	"goose":       TierCLI,
+	// API (direct, per-token — always reachable, no health file required)
+	"anthropic-api": TierAPI,
+	"openai-api":    TierAPI,
 }
 
 // DriverHealth represents the runtime health of a single driver.
@@ -77,13 +81,31 @@ func NewRouter(healthDir string) *Router {
 //   - ""       -> all tiers (default)
 func (r *Router) Recommend(taskType, budget string) RouteDecision {
 	maxTier := maxTierForBudget(budget)
-	drivers := DiscoverDrivers(r.healthDir)
 
-	// Build health map from discovered drivers.
-	// Only drivers with health files on disk are candidates.
+	// Build health map from discovered drivers (those with health files on disk).
 	healthMap := make(map[string]DriverHealth)
-	for _, d := range drivers {
+	for _, d := range DiscoverDrivers(r.healthDir) {
 		healthMap[d] = ReadDriverHealth(r.healthDir, d)
+	}
+
+	// API tier drivers are always seeded as candidates — direct API calls need
+	// no local registration. A health file can still mark them OPEN to skip them.
+	for name, tier := range driverTiers {
+		if tier == TierAPI {
+			if _, ok := healthMap[name]; !ok {
+				healthMap[name] = ReadDriverHealth(r.healthDir, name)
+			}
+		}
+	}
+
+	// Build sorted driver lists per tier for deterministic selection.
+	tierDrivers := make(map[CostTier][]string)
+	for name := range healthMap {
+		t := tierFor(name)
+		tierDrivers[t] = append(tierDrivers[t], name)
+	}
+	for t := range tierDrivers {
+		sort.Strings(tierDrivers[t])
 	}
 
 	var chosen *RouteDecision
@@ -94,11 +116,8 @@ func (r *Router) Recommend(taskType, budget string) RouteDecision {
 		if tierIndex(tier) > tierIndex(maxTier) {
 			break
 		}
-		for name, health := range healthMap {
-			driverTier := tierFor(name)
-			if driverTier != tier {
-				continue
-			}
+		for _, name := range tierDrivers[tier] {
+			health := healthMap[name]
 			if health.CircuitState == "OPEN" {
 				continue // skip exhausted drivers
 			}

--- a/internal/routing/router_test.go
+++ b/internal/routing/router_test.go
@@ -55,7 +55,7 @@ func TestRecommend_SkipsOpenDrivers(t *testing.T) {
 	}
 }
 
-func TestRecommend_AllDriversOpen(t *testing.T) {
+func TestRecommend_CLIDriversOpen_FallsToAPI(t *testing.T) {
 	dir := t.TempDir()
 	writeHealth(t, dir, "claude-code", HealthFile{State: "OPEN", Failures: 10})
 	writeHealth(t, dir, "copilot", HealthFile{State: "OPEN", Failures: 8})
@@ -63,8 +63,26 @@ func TestRecommend_AllDriversOpen(t *testing.T) {
 	r := NewRouter(dir)
 	dec := r.Recommend("anything", "high")
 
+	// CLI drivers OPEN — cascade must fall through to API tier.
+	if dec.Skip {
+		t.Fatal("expected API tier fallback when CLI drivers OPEN, got Skip")
+	}
+	if dec.Tier != string(TierAPI) {
+		t.Fatalf("expected API tier fallback, got tier=%s driver=%s", dec.Tier, dec.Driver)
+	}
+}
+
+func TestRecommend_AllTiersExhausted_Skip(t *testing.T) {
+	dir := t.TempDir()
+	writeHealth(t, dir, "claude-code", HealthFile{State: "OPEN", Failures: 10})
+	writeHealth(t, dir, "anthropic-api", HealthFile{State: "OPEN", Failures: 5})
+	writeHealth(t, dir, "openai-api", HealthFile{State: "OPEN", Failures: 3})
+
+	r := NewRouter(dir)
+	dec := r.Recommend("anything", "high")
+
 	if !dec.Skip {
-		t.Fatalf("expected Skip=true when all drivers OPEN, got driver=%s", dec.Driver)
+		t.Fatalf("expected Skip when all tiers exhausted, got driver=%s tier=%s", dec.Driver, dec.Tier)
 	}
 	if dec.Reason == "" {
 		t.Fatal("expected a reason when skipping")
@@ -116,15 +134,19 @@ func TestRecommend_MissingHealthFileDefaultsClosed(t *testing.T) {
 	}
 }
 
-func TestRecommend_NoDriversAvailable(t *testing.T) {
+func TestRecommend_NoLocalCLIDrivers_FallsToAPI(t *testing.T) {
 	dir := t.TempDir()
-	// Empty directory — no drivers discovered
+	// No health files for local/subscription/CLI drivers —
+	// API tier is always seeded and should be the last-resort fallback.
 
 	r := NewRouter(dir)
 	dec := r.Recommend("any-task", "high")
 
-	if !dec.Skip {
-		t.Fatalf("expected Skip=true with no drivers, got driver=%s", dec.Driver)
+	if dec.Skip {
+		t.Fatal("expected API tier fallback when no other drivers registered, got Skip")
+	}
+	if dec.Tier != string(TierAPI) {
+		t.Fatalf("expected API tier fallback, got tier=%s driver=%s", dec.Tier, dec.Driver)
 	}
 }
 
@@ -244,5 +266,67 @@ func TestDiscoverDrivers_NonexistentDir(t *testing.T) {
 	drivers := DiscoverDrivers("/nonexistent/path/that/does/not/exist")
 	if drivers != nil {
 		t.Fatalf("expected nil for nonexistent dir, got %v", drivers)
+	}
+}
+
+// TestRecommend_APITierAlwaysAvailable verifies that API drivers are candidates
+// even when they have no health file on disk, enabling the cascade to reach API
+// tier without requiring an explicit registration step.
+func TestRecommend_APITierAlwaysAvailable(t *testing.T) {
+	dir := t.TempDir()
+	// Only a CLI driver health file — no API health files written.
+	writeHealth(t, dir, "claude-code", HealthFile{State: "OPEN", Failures: 3})
+
+	r := NewRouter(dir)
+	dec := r.Recommend("task", "high")
+
+	if dec.Skip {
+		t.Fatal("expected API tier fallback even without API health files, got Skip")
+	}
+	if dec.Tier != string(TierAPI) {
+		t.Fatalf("expected API tier, got tier=%s driver=%s", dec.Tier, dec.Driver)
+	}
+}
+
+// TestRecommend_DeterministicSelection verifies that repeated calls with identical
+// state always return the same driver (no map-iteration randomness).
+func TestRecommend_DeterministicSelection(t *testing.T) {
+	dir := t.TempDir()
+	writeHealth(t, dir, "claude-code", HealthFile{State: "CLOSED"})
+	writeHealth(t, dir, "copilot", HealthFile{State: "CLOSED"})
+	// Suppress cheaper tiers so selection stays in CLI.
+	writeHealth(t, dir, "ollama", HealthFile{State: "OPEN"})
+	writeHealth(t, dir, "nemotron", HealthFile{State: "OPEN"})
+	writeHealth(t, dir, "openclaw", HealthFile{State: "OPEN"})
+
+	r := NewRouter(dir)
+	first := r.Recommend("task", "medium") // medium budget: local+subscription+cli, no API
+	second := r.Recommend("task", "medium")
+
+	if first.Driver != second.Driver {
+		t.Fatalf("non-deterministic: got %s then %s", first.Driver, second.Driver)
+	}
+	// Alphabetically first healthy CLI driver is claude-code.
+	if first.Driver != "claude-code" {
+		t.Fatalf("expected claude-code (alphabetically first in CLI tier), got %s", first.Driver)
+	}
+}
+
+// TestRecommend_APIDriverMarkedOpen verifies that an API driver with an OPEN
+// health file is correctly skipped during the cascade.
+func TestRecommend_APIDriverMarkedOpen(t *testing.T) {
+	dir := t.TempDir()
+	writeHealth(t, dir, "claude-code", HealthFile{State: "OPEN"})
+	writeHealth(t, dir, "anthropic-api", HealthFile{State: "OPEN"})
+	// openai-api has no health file — defaults to CLOSED.
+
+	r := NewRouter(dir)
+	dec := r.Recommend("task", "high")
+
+	if dec.Skip {
+		t.Fatal("expected openai-api as fallback, got Skip")
+	}
+	if dec.Driver != "openai-api" {
+		t.Fatalf("expected openai-api (only healthy API driver), got %s", dec.Driver)
 	}
 }


### PR DESCRIPTION
## Summary

- Adds `anthropic-api` and `openai-api` as `TierAPI` drivers in `driverTiers`
- API tier drivers are always seeded into the health map without requiring a health file on disk — direct API calls are always reachable and need no registration step
- Refactors the inner routing loop from non-deterministic map iteration to sorted per-tier slices, making driver selection stable across repeated calls
- Updates 2 existing tests whose expectations changed (CLI-OPEN now correctly falls to API tier instead of Skip), and adds 4 new tests

## Cascade behavior after this PR

```
local (ollama/nemotron) → subscription (openclaw) → cli (claude-code/copilot/…) → api (anthropic-api/openai-api)
```

When a tier is exhausted (all drivers OPEN), the router falls through to the next tier. API tier is always available as last resort. `Skip=true` only when *all* tiers — including API — have OPEN circuit breakers.

## Test plan

- [x] `go test ./internal/routing/...` — 17 tests pass
- [x] `go build ./...` — clean build
- [x] `TestRecommend_CLIDriversOpen_FallsToAPI` — CLI OPEN → API selected
- [x] `TestRecommend_AllTiersExhausted_Skip` — API OPEN too → Skip
- [x] `TestRecommend_APITierAlwaysAvailable` — no API health file → still a candidate
- [x] `TestRecommend_DeterministicSelection` — same input, same driver every time
- [x] `TestRecommend_APIDriverMarkedOpen` — OPEN API driver is skipped, healthy one used

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)