### PR TITLE
feat: cost-tier routing cascade — API tier, task-type min-tier, CascadeTrace

### DIFF
--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -429,12 +429,12 @@ func toolDefs() []ToolDef {
 		},
 		{
 			Name:        "route_recommend",
-			Description: "Get the recommended driver for a task based on cost tier and driver health. Returns cheapest healthy driver with fallback options.",
+			Description: "Get the recommended driver for a task via the cost-tier cascade: local→subscription→CLI→API. Returns cheapest healthy driver that meets the task's capability requirement. Includes cascade_trace showing why tiers were skipped.",
 			InputSchema: map[string]interface{}{
 				"type": "object",
 				"properties": map[string]interface{}{
-					"taskDescription": map[string]string{"type": "string", "description": "Describe the task"},
-					"budget":          map[string]interface{}{"type": "string", "enum": []string{"low", "medium", "high"}, "description": "Budget tier — low (local only), medium (local+subscription+cli), high (all)"},
+					"taskDescription": map[string]string{"type": "string", "description": "Describe the task — used to infer minimum capable tier (e.g. 'code-review' skips local, 'triage' stays local)"},
+					"budget":          map[string]interface{}{"type": "string", "enum": []string{"low", "medium", "high"}, "description": "Budget ceiling — low (local only), medium (local+subscription+cli), high/omit (all tiers including API)"},
 				},
 				"required": []string{"taskDescription"},
 			},

--- a/internal/routing/router.go
+++ b/internal/routing/router.go
@@ -22,17 +22,22 @@ var tierOrder = []CostTier{TierLocal, TierSubscription, TierCLI, TierAPI}
 
 // driverTiers maps each known driver to its cost tier.
 var driverTiers = map[string]CostTier{
-	// Local ($0)
-	"ollama":   TierLocal,
-	"nemotron": TierLocal,
-	// Subscription (browser-based)
+	// Local ($0) — Ollama / Nemotron via NemoClaw
+	"ollama":    TierLocal,
+	"nemotron":  TierLocal,
+	"nemoclaw":  TierLocal,
+	// Subscription (browser-based) — OpenClaw → ChatGPT / NotebookLM / Gemini apps
 	"openclaw": TierSubscription,
-	// CLI (metered)
+	// CLI (already paying) — Claude Code / Codex / Copilot / Gemini CLI
 	"claude-code": TierCLI,
 	"copilot":     TierCLI,
 	"codex":       TierCLI,
 	"gemini":      TierCLI,
 	"goose":       TierCLI,
+	// API (per-token) — direct API calls for burst / programmatic access
+	"anthropic":  TierAPI,
+	"openai":     TierAPI,
+	"gemini-api": TierAPI,
 }
 
 // DriverHealth represents the runtime health of a single driver.
@@ -46,12 +51,44 @@ type DriverHealth struct {
 
 // RouteDecision is the output of the routing engine.
 type RouteDecision struct {
-	Driver     string   `json:"driver"`
-	Tier       string   `json:"tier"`
-	Confidence float64  `json:"confidence"`
-	Reason     string   `json:"reason"`
-	Fallbacks  []string `json:"fallbacks"`
-	Skip       bool     `json:"skip"`
+	Driver       string   `json:"driver"`
+	Tier         string   `json:"tier"`
+	MinTier      string   `json:"min_tier,omitempty"` // task-type minimum tier applied
+	Confidence   float64  `json:"confidence"`
+	Reason       string   `json:"reason"`
+	Fallbacks    []string `json:"fallbacks"`
+	CascadeTrace []string `json:"cascade_trace,omitempty"` // why each tier was skipped
+	Skip         bool     `json:"skip"`
+}
+
+// taskMinTiers maps task-type keywords to the minimum acceptable cost tier.
+// Tasks requiring real coding capability skip the local tier; tasks requiring
+// per-token burst skip straight to API.
+var taskMinTiers = map[string]CostTier{
+	// Local-capable: triage, classification, summarisation
+	"triage":         TierLocal,
+	"classification": TierLocal,
+	"summarize":      TierLocal,
+	"summarise":      TierLocal,
+	"simple":         TierLocal,
+	// Subscription-capable: artifact generation, research, briefings
+	"research":   TierSubscription,
+	"briefing":   TierSubscription,
+	"artifact":   TierSubscription,
+	"notebooklm": TierSubscription,
+	// CLI-capable: coding, PR, commit, review
+	"code":          TierCLI,
+	"code-review":   TierCLI,
+	"commit":        TierCLI,
+	"pr":            TierCLI,
+	"pull-request":  TierCLI,
+	"review":        TierCLI,
+	"refactor":      TierCLI,
+	"test":          TierCLI,
+	// API-only: programmatic burst, batch processing
+	"api":         TierAPI,
+	"batch":       TierAPI,
+	"programmatic": TierAPI,
 }
 
 // Router makes budget-aware driver routing decisions.
@@ -70,17 +107,23 @@ func NewRouter(healthDir string) *Router {
 }
 
 // Recommend returns the cheapest healthy driver for the given task.
-// The budget parameter controls which cost tiers are considered:
+//
+// Budget controls the maximum cost tier:
 //   - "low"    -> local only
 //   - "medium" -> local + subscription + cli
-//   - "high"   -> all tiers
-//   - ""       -> all tiers (default)
+//   - "high"   -> all tiers (default)
+//
+// TaskType influences the minimum cost tier — capability-gating:
+//   - triage / classification / simple → local is fine
+//   - code-review / commit / pr        → skip to CLI (local can't do it)
+//   - batch / programmatic             → skip to API
+//   - unrecognised                     → local (cheapest)
 func (r *Router) Recommend(taskType, budget string) RouteDecision {
 	maxTier := maxTierForBudget(budget)
+	minTier := minTierForTask(taskType)
 	drivers := DiscoverDrivers(r.healthDir)
 
-	// Build health map from discovered drivers.
-	// Only drivers with health files on disk are candidates.
+	// Build health map. Only drivers with health files on disk are candidates.
 	healthMap := make(map[string]DriverHealth)
 	for _, d := range drivers {
 		healthMap[d] = ReadDriverHealth(r.healthDir, d)
@@ -88,19 +131,29 @@ func (r *Router) Recommend(taskType, budget string) RouteDecision {
 
 	var chosen *RouteDecision
 	var fallbacks []string
+	var trace []string
 
-	// Walk tiers in cost order: cheapest first.
+	// Walk tiers cheapest-first, cascading upward until we find a healthy driver.
 	for _, tier := range tierOrder {
-		if tierIndex(tier) > tierIndex(maxTier) {
+		idx := tierIndex(tier)
+
+		if idx < tierIndex(minTier) {
+			trace = append(trace, fmt.Sprintf("skip tier %s: below task minimum (%s)", tier, minTier))
+			continue
+		}
+		if idx > tierIndex(maxTier) {
+			trace = append(trace, fmt.Sprintf("stop: tier %s exceeds budget ceiling (%s)", tier, maxTier))
 			break
 		}
+
+		var openInTier []string
 		for name, health := range healthMap {
-			driverTier := tierFor(name)
-			if driverTier != tier {
+			if tierFor(name) != tier {
 				continue
 			}
 			if health.CircuitState == "OPEN" {
-				continue // skip exhausted drivers
+				openInTier = append(openInTier, name)
+				continue
 			}
 
 			confidence := 1.0
@@ -113,22 +166,34 @@ func (r *Router) Recommend(taskType, budget string) RouteDecision {
 					Driver:     name,
 					Tier:       string(tier),
 					Confidence: confidence,
-					Reason:     fmt.Sprintf("cheapest healthy driver (tier: %s, state: %s)", tier, health.CircuitState),
+					Reason:     fmt.Sprintf("cheapest healthy driver in cascade (tier: %s, state: %s)", tier, health.CircuitState),
 				}
 			} else {
 				fallbacks = append(fallbacks, name)
 			}
 		}
+
+		if len(openInTier) > 0 && chosen == nil {
+			trace = append(trace, fmt.Sprintf("skip tier %s: all drivers OPEN (%s)", tier, strings.Join(openInTier, ", ")))
+		}
+
+		// Once we've found a primary pick in this tier, remaining tiers are fallbacks only.
+		// Continue walking to collect cross-tier fallbacks.
 	}
 
 	if chosen == nil {
 		return RouteDecision{
-			Skip:   true,
-			Reason: "all drivers exhausted — circuit breakers OPEN",
+			Skip:         true,
+			Reason:       "all drivers exhausted — circuit breakers OPEN or no drivers available",
+			CascadeTrace: trace,
 		}
 	}
 
+	if minTier != TierLocal {
+		chosen.MinTier = string(minTier)
+	}
 	chosen.Fallbacks = fallbacks
+	chosen.CascadeTrace = trace
 	return *chosen
 }
 
@@ -149,6 +214,26 @@ func maxTierForBudget(budget string) CostTier {
 	default:
 		return TierAPI
 	}
+}
+
+// minTierForTask returns the cheapest tier capable of handling the given task type.
+// Unrecognised task types default to local (cheapest — no assumption made).
+func minTierForTask(taskType string) CostTier {
+	if taskType == "" {
+		return TierLocal
+	}
+	// Exact match first.
+	if tier, ok := taskMinTiers[strings.ToLower(taskType)]; ok {
+		return tier
+	}
+	// Substring match: "pr-review" contains "review" → CLI, etc.
+	lower := strings.ToLower(taskType)
+	for keyword, tier := range taskMinTiers {
+		if strings.Contains(lower, keyword) {
+			return tier
+		}
+	}
+	return TierLocal
 }
 
 // tierFor returns the cost tier for a driver, defaulting to CLI.

--- a/internal/routing/router_test.go
+++ b/internal/routing/router_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -244,5 +245,179 @@ func TestDiscoverDrivers_NonexistentDir(t *testing.T) {
 	drivers := DiscoverDrivers("/nonexistent/path/that/does/not/exist")
 	if drivers != nil {
 		t.Fatalf("expected nil for nonexistent dir, got %v", drivers)
+	}
+}
+
+// --- Issue #8: cost-tier cascade ---
+
+func TestRecommend_APITierFallback(t *testing.T) {
+	dir := t.TempDir()
+	// All CLI drivers OPEN — should cascade to API tier
+	writeHealth(t, dir, "claude-code", HealthFile{State: "OPEN", Failures: 5})
+	writeHealth(t, dir, "copilot", HealthFile{State: "OPEN", Failures: 5})
+	writeHealth(t, dir, "anthropic", HealthFile{State: "CLOSED", Failures: 0})
+
+	r := NewRouter(dir)
+	dec := r.Recommend("burst", "high")
+
+	if dec.Skip {
+		t.Fatal("expected anthropic recommendation via API cascade, got Skip")
+	}
+	if dec.Driver != "anthropic" {
+		t.Fatalf("expected anthropic (API tier fallback), got %s", dec.Driver)
+	}
+	if dec.Tier != string(TierAPI) {
+		t.Fatalf("expected tier api, got %s", dec.Tier)
+	}
+}
+
+func TestRecommend_CascadeTrace_TiersSkipped(t *testing.T) {
+	dir := t.TempDir()
+	// Local OPEN, no subscription, CLI healthy
+	writeHealth(t, dir, "ollama", HealthFile{State: "OPEN", Failures: 3})
+	writeHealth(t, dir, "claude-code", HealthFile{State: "CLOSED", Failures: 0})
+
+	r := NewRouter(dir)
+	dec := r.Recommend("code-review", "high")
+
+	if dec.Skip {
+		t.Fatal("expected claude-code recommendation, got Skip")
+	}
+	if dec.Driver != "claude-code" {
+		t.Fatalf("expected claude-code, got %s", dec.Driver)
+	}
+	if len(dec.CascadeTrace) == 0 {
+		t.Fatal("expected non-empty CascadeTrace")
+	}
+	// Should mention that local tier was skipped due to task minimum
+	found := false
+	for _, entry := range dec.CascadeTrace {
+		if strings.Contains(entry, "below task minimum") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("CascadeTrace should mention min-tier skip, got: %v", dec.CascadeTrace)
+	}
+}
+
+func TestRecommend_TaskTypeCodeReview_SkipsLocal(t *testing.T) {
+	dir := t.TempDir()
+	// Healthy local AND CLI
+	writeHealth(t, dir, "ollama", HealthFile{State: "CLOSED", Failures: 0})
+	writeHealth(t, dir, "claude-code", HealthFile{State: "CLOSED", Failures: 0})
+
+	r := NewRouter(dir)
+	dec := r.Recommend("code-review", "high")
+
+	if dec.Skip {
+		t.Fatal("expected recommendation, got Skip")
+	}
+	// code-review min tier = CLI — ollama must be skipped
+	if dec.Driver == "ollama" {
+		t.Fatal("ollama should be skipped for code-review (below min tier CLI)")
+	}
+	if dec.Tier != string(TierCLI) {
+		t.Fatalf("expected CLI tier for code-review, got %s", dec.Tier)
+	}
+	if dec.MinTier != string(TierCLI) {
+		t.Fatalf("expected MinTier=cli, got %q", dec.MinTier)
+	}
+}
+
+func TestRecommend_TaskTypeTriageUsesLocal(t *testing.T) {
+	dir := t.TempDir()
+	writeHealth(t, dir, "ollama", HealthFile{State: "CLOSED", Failures: 0})
+	writeHealth(t, dir, "claude-code", HealthFile{State: "CLOSED", Failures: 0})
+
+	r := NewRouter(dir)
+	dec := r.Recommend("triage", "high")
+
+	if dec.Skip {
+		t.Fatal("expected recommendation, got Skip")
+	}
+	// triage min tier = local — should pick ollama (cheapest)
+	if dec.Driver != "ollama" {
+		t.Fatalf("expected ollama for triage (local capable), got %s", dec.Driver)
+	}
+	if dec.MinTier != "" {
+		t.Fatalf("MinTier should be omitted for local min tier, got %q", dec.MinTier)
+	}
+}
+
+func TestRecommend_TaskTypePRSubstringMatch(t *testing.T) {
+	dir := t.TempDir()
+	writeHealth(t, dir, "ollama", HealthFile{State: "CLOSED", Failures: 0})
+	writeHealth(t, dir, "claude-code", HealthFile{State: "CLOSED", Failures: 0})
+
+	r := NewRouter(dir)
+	// "open-pr-for-feature" contains "pr" → min tier CLI
+	dec := r.Recommend("open-pr-for-feature", "high")
+
+	if dec.Skip {
+		t.Fatal("expected recommendation, got Skip")
+	}
+	if dec.Tier != string(TierCLI) {
+		t.Fatalf("expected CLI tier for pr-related task, got %s", dec.Tier)
+	}
+}
+
+func TestRecommend_APIDriversRecognised(t *testing.T) {
+	dir := t.TempDir()
+	writeHealth(t, dir, "anthropic", HealthFile{State: "CLOSED", Failures: 0})
+	writeHealth(t, dir, "openai", HealthFile{State: "CLOSED", Failures: 0})
+	writeHealth(t, dir, "gemini-api", HealthFile{State: "CLOSED", Failures: 0})
+
+	r := NewRouter(dir)
+	dec := r.Recommend("any", "high")
+
+	// All three are API-tier. With no cheaper drivers present, should pick one.
+	if dec.Skip {
+		t.Fatal("expected a recommendation from API-tier drivers, got Skip")
+	}
+	if dec.Tier != string(TierAPI) {
+		t.Fatalf("expected tier api, got %s", dec.Tier)
+	}
+}
+
+func TestRecommend_NemoclawIsLocalTier(t *testing.T) {
+	dir := t.TempDir()
+	writeHealth(t, dir, "nemoclaw", HealthFile{State: "CLOSED", Failures: 0})
+	writeHealth(t, dir, "claude-code", HealthFile{State: "CLOSED", Failures: 0})
+
+	r := NewRouter(dir)
+	dec := r.Recommend("triage", "high")
+
+	if dec.Skip {
+		t.Fatal("expected recommendation, got Skip")
+	}
+	// nemoclaw is local tier — should be preferred over CLI
+	if dec.Tier != string(TierLocal) {
+		t.Fatalf("expected tier local (nemoclaw), got %s", dec.Tier)
+	}
+}
+
+func TestRecommend_BudgetCeilingBlocksMinTier(t *testing.T) {
+	dir := t.TempDir()
+	// Only API driver available, but budget=low → should skip
+	writeHealth(t, dir, "anthropic", HealthFile{State: "CLOSED", Failures: 0})
+
+	r := NewRouter(dir)
+	dec := r.Recommend("any", "low")
+
+	if !dec.Skip {
+		t.Fatalf("expected Skip (API driver not allowed at low budget), got driver=%s", dec.Driver)
+	}
+	// CascadeTrace should mention the budget ceiling stop
+	found := false
+	for _, entry := range dec.CascadeTrace {
+		if strings.Contains(entry, "exceeds budget ceiling") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("CascadeTrace should mention budget ceiling, got: %v", dec.CascadeTrace)
 	}
 }


### PR DESCRIPTION
## Summary

- **API-tier drivers** (`anthropic`, `openai`, `gemini-api`) added to `driverTiers` — the cascade can now fall through CLI to API when all CLI circuit breakers are OPEN
- **`nemoclaw`** registered as a local-tier driver (NemoClaw wraps Ollama/Nemotron for $0)
- **Task-type capability-gating** via `taskMinTiers` map: `triage` stays local, `code-review`/`commit`/`pr` skip straight to CLI (Ollama can't do real coding), `batch`/`programmatic` require API tier
- **`CascadeTrace []string`** added to `RouteDecision` — each skipped tier logs *why* (below task min, OPEN circuit, budget ceiling hit). Transparent routing, loggable by agents.
- **`MinTier string`** field added to `RouteDecision` — omitted when local (default), set when task-type forces a higher minimum
- `minTierForTask` does exact-match then substring-match, so `"open-pr-for-feature"` correctly maps to CLI tier via `"pr"` keyword
- `route_recommend` tool description updated to document both axes (budget ceiling + task-type floor)

## Test plan

- [x] `TestRecommend_APITierFallback` — CLI all OPEN → cascades to `anthropic`
- [x] `TestRecommend_CascadeTrace_TiersSkipped` — trace contains "below task minimum"
- [x] `TestRecommend_TaskTypeCodeReview_SkipsLocal` — ollama not chosen for code-review
- [x] `TestRecommend_TaskTypeTriageUsesLocal` — ollama chosen for triage, MinTier omitted
- [x] `TestRecommend_TaskTypePRSubstringMatch` — "open-pr-for-feature" → CLI tier
- [x] `TestRecommend_APIDriversRecognised` — anthropic/openai/gemini-api all route as TierAPI
- [x] `TestRecommend_NemoclawIsLocalTier` — nemoclaw preferred over claude-code for triage
- [x] `TestRecommend_BudgetCeilingBlocksMinTier` — API driver + low budget → Skip with trace
- [x] `go test ./...` — 99 pass (8 new, 91 existing)

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)