### PR TITLE
feat: adaptive cooldown — consecutive-fail triage + driver budget signal

### DIFF
--- a/cmd/octi-pulpo/main.go
+++ b/cmd/octi-pulpo/main.go
@@ -60,8 +60,21 @@ func main() {
 	eventRouter := dispatch.NewEventRouter(dispatch.DefaultRules())
 	dispatcher := dispatch.NewDispatcher(rdb, router, coord, eventRouter, queueFile, namespace)
 
-	// Set up adaptive cooldown profiles
+	// Set up adaptive cooldown profiles with live driver-health signal.
 	profiles := dispatch.NewProfileStore(rdb, namespace, eventRouter.CooldownFor)
+	profiles.SetBudgetHealthFn(func() float64 {
+		health := router.HealthReport()
+		if len(health) == 0 {
+			return 1.0 // no drivers discovered — assume healthy
+		}
+		var closed int
+		for _, h := range health {
+			if h.CircuitState != "OPEN" {
+				closed++
+			}
+		}
+		return float64(closed) / float64(len(health))
+	})
 	dispatcher.SetProfiles(profiles)
 
 	// Set up sprint store

--- a/internal/dispatch/profiles.go
+++ b/internal/dispatch/profiles.go
@@ -12,12 +12,16 @@ import (
 // AgentProfile tracks an agent's recent execution history for adaptive cooldown tuning.
 type AgentProfile struct {
 	Name             string        `json:"name"`
-	RecentResults    []RunResult   `json:"recent_results"`    // last 10
+	RecentResults    []RunResult   `json:"recent_results"`   // last 10
 	AvgDuration      float64       `json:"avg_duration_s"`
 	AvgCommits       float64       `json:"avg_commits"`
 	FailRate         float64       `json:"fail_rate"`
 	CurrentCooldown  time.Duration `json:"current_cooldown"`
 	ConsecutiveIdles int           `json:"consecutive_idles"`
+	ConsecutiveFails int           `json:"consecutive_fails"`
+	// TriageFlag is set when the agent accumulates 3+ consecutive failures and
+	// needs human review before being dispatched aggressively again.
+	TriageFlag bool `json:"triage_flag,omitempty"`
 }
 
 // RunResult is a single agent execution record.
@@ -30,10 +34,13 @@ type RunResult struct {
 
 // ProfileStore manages agent execution profiles in Redis.
 type ProfileStore struct {
-	rdb       *redis.Client
-	namespace string
-	// staticCooldown provides the fallback cooldown from event rules
+	rdb            *redis.Client
+	namespace      string
 	staticCooldown func(agent string) time.Duration
+	// budgetHealthFn returns the fraction of drivers that are healthy (0.0–1.0).
+	// 1.0 = all drivers CLOSED; 0.0 = all drivers OPEN (budget exhausted).
+	// Optional — if nil, budget signal is ignored.
+	budgetHealthFn func() float64
 }
 
 // NewProfileStore creates a profile store.
@@ -43,6 +50,13 @@ func NewProfileStore(rdb *redis.Client, namespace string, staticCooldown func(st
 		namespace:      namespace,
 		staticCooldown: staticCooldown,
 	}
+}
+
+// SetBudgetHealthFn wires a live driver-health signal into adaptive cooldown.
+// fn should return the fraction of drivers with CLOSED circuits (0.0–1.0).
+// The dispatcher in main.go provides this via router.HealthReport().
+func (ps *ProfileStore) SetBudgetHealthFn(fn func() float64) {
+	ps.budgetHealthFn = fn
 }
 
 // RecordRun appends a run result to the agent's profile, keeping the last 10.
@@ -61,11 +75,22 @@ func (ps *ProfileStore) RecordRun(ctx context.Context, agent string, result RunR
 	// Recompute aggregates
 	ps.recompute(&profile)
 
-	// Track consecutive idles
+	// Track consecutive idles (short runs with no output)
 	if result.Duration < 10 && !result.HadCommits {
 		profile.ConsecutiveIdles++
 	} else {
 		profile.ConsecutiveIdles = 0
+	}
+
+	// Track consecutive failures; set triage flag at threshold
+	if result.ExitCode != 0 {
+		profile.ConsecutiveFails++
+		if profile.ConsecutiveFails >= 3 {
+			profile.TriageFlag = true
+		}
+	} else {
+		profile.ConsecutiveFails = 0
+		profile.TriageFlag = false
 	}
 
 	data, err := json.Marshal(profile)
@@ -90,28 +115,29 @@ func (ps *ProfileStore) GetProfile(ctx context.Context, agent string) (AgentProf
 	return profile, nil
 }
 
-// AdaptiveCooldown computes the optimal cooldown for an agent based on recent performance.
+// AdaptiveCooldown computes the optimal cooldown for an agent based on recent performance
+// and global driver health.
 //
 // Rules (checked in order):
-//   - Productive (commits > 0, duration > 30s): 5 min
-//   - Idle (<10s, 0 commits): double current, max 6h
-//   - Failing (>50% fail rate): double current, max 2h
-//   - Default: use the static cooldown from event rules
+//  1. Triage: 3+ consecutive failures → 12h (needs human review)
+//  2. Productive (commits > 0, duration > 30s) → 5 min, possibly 2.5 min if budget healthy
+//  3. Idle (<10s, 0 commits) → double current, max 6h; if budget tight → triple, max 6h
+//  4. Failing (>50% fail rate) → double current, max 2h
+//  5. Budget tight (<30% healthy drivers) → 3× static cooldown
+//  6. Default → static cooldown from event rules
 func (ps *ProfileStore) AdaptiveCooldown(ctx context.Context, agent string) time.Duration {
 	profile, err := ps.GetProfile(ctx, agent)
 	if err != nil || len(profile.RecentResults) == 0 {
-		return ps.staticCooldown(agent)
+		// No history: apply budget multiplier to static cooldown if budget is tight
+		return ps.applyBudgetMultiplier(ps.staticCooldown(agent))
 	}
 
-	// Look at the most recent result for immediate signals
-	latest := profile.RecentResults[len(profile.RecentResults)-1]
-
-	// Productive: commits and meaningful duration
-	if latest.HadCommits && latest.Duration > 30 {
-		return 5 * time.Minute
+	// 1. Triage: agent needs human review — back off hard
+	if profile.TriageFlag {
+		return 12 * time.Hour
 	}
 
-	// Current cooldown baseline
+	// Current cooldown baseline (for multiplier calculations)
 	current := profile.CurrentCooldown
 	if current == 0 {
 		current = ps.staticCooldown(agent)
@@ -120,16 +146,33 @@ func (ps *ProfileStore) AdaptiveCooldown(ctx context.Context, agent string) time
 		current = 10 * time.Minute // absolute fallback
 	}
 
-	// Idle: short runs with no output
-	if latest.Duration < 10 && !latest.HadCommits {
-		doubled := current * 2
-		if doubled > 6*time.Hour {
-			doubled = 6 * time.Hour
+	// Look at the most recent result for immediate signals
+	latest := profile.RecentResults[len(profile.RecentResults)-1]
+
+	// 2. Productive: commits and meaningful duration
+	if latest.HadCommits && latest.Duration > 30 {
+		d := 5 * time.Minute
+		// Healthy budget (only when health fn configured): reward hot streaks
+		if ps.budgetHealthFn != nil && ps.budgetHealth() > 0.8 {
+			d = 150 * time.Second // ~2.5 min
 		}
-		return doubled
+		return d
 	}
 
-	// Failing: high failure rate
+	// 3. Idle: short runs with no output
+	if latest.Duration < 10 && !latest.HadCommits {
+		multiplier := time.Duration(2)
+		if ps.budgetHealthFn != nil && ps.budgetHealth() < 0.3 {
+			multiplier = 3 // conserve budget when drivers are stressed
+		}
+		result := current * multiplier
+		if result > 6*time.Hour {
+			result = 6 * time.Hour
+		}
+		return result
+	}
+
+	// 4. Failing: high failure rate
 	if profile.FailRate > 0.5 {
 		doubled := current * 2
 		if doubled > 2*time.Hour {
@@ -138,7 +181,27 @@ func (ps *ProfileStore) AdaptiveCooldown(ctx context.Context, agent string) time
 		return doubled
 	}
 
-	return ps.staticCooldown(agent)
+	// 5. Default: static cooldown, adjusted for budget health
+	return ps.applyBudgetMultiplier(ps.staticCooldown(agent))
+}
+
+// budgetHealth returns the fraction of healthy drivers via budgetHealthFn.
+// Returns 1.0 (fully healthy) when no health function is configured.
+func (ps *ProfileStore) budgetHealth() float64 {
+	if ps.budgetHealthFn == nil {
+		return 1.0
+	}
+	return ps.budgetHealthFn()
+}
+
+// applyBudgetMultiplier scales a cooldown based on driver health.
+// Budget tight (<30% healthy): 3× cooldown. Normal: unchanged.
+// No-ops when budgetHealthFn is not configured.
+func (ps *ProfileStore) applyBudgetMultiplier(d time.Duration) time.Duration {
+	if ps.budgetHealthFn != nil && ps.budgetHealth() < 0.3 {
+		return d * 3
+	}
+	return d
 }
 
 // recompute recalculates aggregate metrics from recent results.

--- a/internal/dispatch/profiles_test.go
+++ b/internal/dispatch/profiles_test.go
@@ -181,17 +181,148 @@ func TestAdaptiveCooldown_FailMaxCap(t *testing.T) {
 	static := func(string) time.Duration { return 90 * time.Minute }
 	ps := NewProfileStore(d.rdb, d.namespace, static)
 
-	for i := 0; i < 5; i++ {
-		ps.RecordRun(ctx, "fail-cap-agent", RunResult{
+	// Use alternating fail/success so fail rate stays high (80%) but
+	// ConsecutiveFails never reaches 3 (no triage flag).
+	// Pattern: fail, success, fail, success, fail → ConsecutiveFails=1
+	runs := []RunResult{
+		{ExitCode: 1, Duration: 30.0},
+		{ExitCode: 0, Duration: 30.0},
+		{ExitCode: 1, Duration: 30.0},
+		{ExitCode: 0, Duration: 30.0},
+		{ExitCode: 1, Duration: 30.0},
+	}
+	for _, r := range runs {
+		ps.RecordRun(ctx, "fail-cap-agent", r)
+	}
+
+	cooldown := ps.AdaptiveCooldown(ctx, "fail-cap-agent")
+	// fail rate=60% > 50%, ConsecutiveFails=1 (no triage),
+	// doubling 90m → 180m → capped at 2h
+	if cooldown != 2*time.Hour {
+		t.Fatalf("expected 2h cap for failing agent, got %s", cooldown)
+	}
+}
+
+func TestProfileStore_ConsecutiveFails(t *testing.T) {
+	d, ctx := testSetup(t)
+	ps := NewProfileStore(d.rdb, d.namespace, d.events.CooldownFor)
+
+	// Three failures in a row
+	for i := 0; i < 3; i++ {
+		ps.RecordRun(ctx, "flaky-agent", RunResult{
 			ExitCode: 1,
 			Duration: 30.0,
 		})
 	}
 
-	cooldown := ps.AdaptiveCooldown(ctx, "fail-cap-agent")
-	// Doubling 90m would be 180m = 3h, but fail cap is 2h
-	if cooldown != 2*time.Hour {
-		t.Fatalf("expected 2h cap for failing agent, got %s", cooldown)
+	profile, _ := ps.GetProfile(ctx, "flaky-agent")
+	if profile.ConsecutiveFails != 3 {
+		t.Fatalf("expected ConsecutiveFails=3, got %d", profile.ConsecutiveFails)
+	}
+	if !profile.TriageFlag {
+		t.Fatal("expected TriageFlag=true after 3 consecutive failures")
+	}
+
+	// A success clears both counters
+	ps.RecordRun(ctx, "flaky-agent", RunResult{
+		ExitCode:   0,
+		Duration:   60.0,
+		HadCommits: true,
+	})
+
+	profile, _ = ps.GetProfile(ctx, "flaky-agent")
+	if profile.ConsecutiveFails != 0 {
+		t.Fatalf("expected ConsecutiveFails=0 after success, got %d", profile.ConsecutiveFails)
+	}
+	if profile.TriageFlag {
+		t.Fatal("expected TriageFlag=false after successful run")
+	}
+}
+
+func TestProfileStore_TriageFlagAtThreshold(t *testing.T) {
+	d, ctx := testSetup(t)
+	ps := NewProfileStore(d.rdb, d.namespace, d.events.CooldownFor)
+
+	// Two failures should NOT set triage flag
+	for i := 0; i < 2; i++ {
+		ps.RecordRun(ctx, "borderline-agent", RunResult{ExitCode: 1, Duration: 30.0})
+	}
+	profile, _ := ps.GetProfile(ctx, "borderline-agent")
+	if profile.TriageFlag {
+		t.Fatal("expected TriageFlag=false after only 2 consecutive failures")
+	}
+
+	// Third failure sets it
+	ps.RecordRun(ctx, "borderline-agent", RunResult{ExitCode: 1, Duration: 30.0})
+	profile, _ = ps.GetProfile(ctx, "borderline-agent")
+	if !profile.TriageFlag {
+		t.Fatal("expected TriageFlag=true after 3rd consecutive failure")
+	}
+}
+
+func TestAdaptiveCooldown_TriageFlag(t *testing.T) {
+	d, ctx := testSetup(t)
+	ps := NewProfileStore(d.rdb, d.namespace, d.events.CooldownFor)
+
+	for i := 0; i < 3; i++ {
+		ps.RecordRun(ctx, "stuck-agent", RunResult{ExitCode: 1, Duration: 30.0})
+	}
+
+	cooldown := ps.AdaptiveCooldown(ctx, "stuck-agent")
+	if cooldown != 12*time.Hour {
+		t.Fatalf("expected 12h triage cooldown, got %s", cooldown)
+	}
+}
+
+func TestAdaptiveCooldown_BudgetTightIdle(t *testing.T) {
+	d, ctx := testSetup(t)
+	static := func(string) time.Duration { return 10 * time.Minute }
+	ps := NewProfileStore(d.rdb, d.namespace, static)
+	// Budget at 20% health → tight
+	ps.SetBudgetHealthFn(func() float64 { return 0.2 })
+
+	ps.RecordRun(ctx, "budget-idle", RunResult{
+		ExitCode:   0,
+		Duration:   5.0,
+		HadCommits: false,
+	})
+
+	cooldown := ps.AdaptiveCooldown(ctx, "budget-idle")
+	// Budget tight multiplier: 3× instead of 2× → 30m
+	if cooldown != 30*time.Minute {
+		t.Fatalf("expected 30m (3× idle under tight budget), got %s", cooldown)
+	}
+}
+
+func TestAdaptiveCooldown_BudgetHealthyHotStreak(t *testing.T) {
+	d, ctx := testSetup(t)
+	ps := NewProfileStore(d.rdb, d.namespace, d.events.CooldownFor)
+	// Budget at 90% health → healthy
+	ps.SetBudgetHealthFn(func() float64 { return 0.9 })
+
+	ps.RecordRun(ctx, "hot-agent", RunResult{
+		ExitCode:   0,
+		Duration:   120.0,
+		HadCommits: true,
+	})
+
+	cooldown := ps.AdaptiveCooldown(ctx, "hot-agent")
+	// Hot streak + healthy budget → 2.5 min
+	if cooldown != 150*time.Second {
+		t.Fatalf("expected 150s for hot streak with healthy budget, got %s", cooldown)
+	}
+}
+
+func TestAdaptiveCooldown_BudgetTightNoHistory(t *testing.T) {
+	d, ctx := testSetup(t)
+	static := func(string) time.Duration { return 10 * time.Minute }
+	ps := NewProfileStore(d.rdb, d.namespace, static)
+	ps.SetBudgetHealthFn(func() float64 { return 0.1 }) // all drivers exhausted
+
+	// No run history — should get 3× static cooldown
+	cooldown := ps.AdaptiveCooldown(ctx, "new-agent")
+	if cooldown != 30*time.Minute {
+		t.Fatalf("expected 30m (3× static under tight budget), got %s", cooldown)
 	}
 }
 


### PR DESCRIPTION
## Summary

Completes the remaining pieces of issue #20 (self-tuning cooldowns) that weren't covered by the initial adaptive-cooldown implementation:

- **ConsecutiveFails + TriageFlag**: 3+ consecutive failures set `TriageFlag=true` on `AgentProfile`. `AdaptiveCooldown` returns 12h when this flag is set — agent needs human review before being dispatched aggressively again. A single successful run clears both fields.
- **Driver budget health signal**: `ProfileStore.SetBudgetHealthFn(func() float64)` accepts a live health fraction (0.0=all OPEN, 1.0=all CLOSED). When budget is tight (<30% healthy drivers): idle-agent backoff triples instead of doubles, and static-cooldown fallbacks triple. When budget is healthy (>80%) and the agent is on a hot streak: cooldown shortens to 2.5 min.
- **main.go wiring**: closes over `router.HealthReport()` to feed circuit-breaker state into the profile store — no new imports needed in profiles.go.

## Behavior summary

| Condition | Cooldown before | Cooldown after |
|-----------|----------------|----------------|
| 3+ consecutive failures | 2× (fail rate rule) | **12h triage** |
| Idle + budget tight (<30% healthy) | 2× static | **3× static** |
| Hot streak + budget healthy (>80%) | 5 min | **2.5 min** |
| No history + budget tight | static | **3× static** |

## Test plan

- [x] `TestProfileStore_ConsecutiveFails` — 3 failures sets TriageFlag; success clears it
- [x] `TestProfileStore_TriageFlagAtThreshold` — flag not set at 2, set at 3
- [x] `TestAdaptiveCooldown_TriageFlag` — triage → 12h
- [x] `TestAdaptiveCooldown_BudgetTightIdle` — idle + tight budget → 3× (30m)
- [x] `TestAdaptiveCooldown_BudgetHealthyHotStreak` — hot streak + healthy → 2.5m
- [x] `TestAdaptiveCooldown_BudgetTightNoHistory` — no history + tight budget → 3× static
- [x] All existing tests pass (updated `TestAdaptiveCooldown_FailMaxCap` to use alternating runs so it tests high-fail-rate without triggering triage)
- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] 108/108 tests pass

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)