### PR TITLE
feat: agent leaderboard — rank agents by productivity for hire/fire/promote decisions

### DIFF
--- a/cmd/octi-pulpo/main.go
+++ b/cmd/octi-pulpo/main.go
@@ -87,6 +87,7 @@ func main() {
 	server.SetDispatcher(dispatcher)
 	server.SetSprintStore(sprintStore)
 	server.SetBenchmark(benchmark)
+	server.SetProfileStore(profiles)
 
 	// Optional HTTP mode: run webhook server alongside MCP
 	httpPort := os.Getenv("OCTI_HTTP_PORT")

--- a/internal/dispatch/leaderboard.go
+++ b/internal/dispatch/leaderboard.go
@@ -1,0 +1,158 @@
+package dispatch
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// LeaderboardEntry represents one agent's ranked productivity data.
+type LeaderboardEntry struct {
+	Rank        int     `json:"rank"`
+	Agent       string  `json:"agent"`
+	Score       float64 `json:"score"`
+	Verdict     string  `json:"verdict"` // promote, retain, monitor, fire
+	AvgCommits  float64 `json:"avg_commits"`
+	FailRate    float64 `json:"fail_rate"`
+	AvgDuration float64 `json:"avg_duration_s"`
+	ConsecFails int     `json:"consec_fails"`
+	TriageFlag  bool    `json:"triage_flag"`
+	RunCount    int     `json:"run_count"`
+}
+
+// Score computes a productivity score for an AgentProfile.
+// Higher is better; negative scores indicate a net drain on the swarm.
+//
+// Formula:
+//
+//	output      = avgCommits × 5.0            (commit output quality)
+//	reliability = (1 − failRate) × 3.0        (execution reliability)
+//	effort      = +1.0 if avgDuration > 30s,
+//	              −0.5 if avgDuration < 10s    (sustained effort vs idle)
+//	triagePen   = −10.0 if triageFlag          (needs human review)
+//	failPen     = consecutiveFails × −0.5      (recent failure streak)
+//
+//	score = output + reliability + effort + triagePen + failPen
+func Score(p AgentProfile) float64 {
+	if len(p.RecentResults) == 0 {
+		return 0
+	}
+
+	output := p.AvgCommits * 5.0
+	reliability := (1.0 - p.FailRate) * 3.0
+
+	var effort float64
+	switch {
+	case p.AvgDuration > 30:
+		effort = 1.0
+	case p.AvgDuration < 10:
+		effort = -0.5
+	}
+
+	var triagePen float64
+	if p.TriageFlag {
+		triagePen = -10.0
+	}
+
+	failPen := float64(p.ConsecutiveFails) * -0.5
+
+	return output + reliability + effort + triagePen + failPen
+}
+
+// scoreVerdict maps a productivity score to a hire/fire/promote decision.
+func scoreVerdict(score float64, triageFlag bool) string {
+	if triageFlag {
+		return "fire"
+	}
+	switch {
+	case score >= 6.0:
+		return "promote"
+	case score >= 3.0:
+		return "retain"
+	case score >= 1.0:
+		return "monitor"
+	default:
+		return "fire"
+	}
+}
+
+// Leaderboard ranks all agents with run history by productivity score (highest first).
+// Agents with no recorded runs are omitted.
+func (ps *ProfileStore) Leaderboard(ctx context.Context) ([]LeaderboardEntry, error) {
+	profiles, err := ps.AllProfiles(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("leaderboard: %w", err)
+	}
+
+	entries := make([]LeaderboardEntry, 0, len(profiles))
+	for _, p := range profiles {
+		if len(p.RecentResults) == 0 {
+			continue
+		}
+		s := round2(Score(p))
+		entries = append(entries, LeaderboardEntry{
+			Agent:       p.Name,
+			Score:       s,
+			Verdict:     scoreVerdict(s, p.TriageFlag),
+			AvgCommits:  round2(p.AvgCommits),
+			FailRate:    round2(p.FailRate),
+			AvgDuration: round2(p.AvgDuration),
+			ConsecFails: p.ConsecutiveFails,
+			TriageFlag:  p.TriageFlag,
+			RunCount:    len(p.RecentResults),
+		})
+	}
+
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].Score > entries[j].Score
+	})
+
+	for i := range entries {
+		entries[i].Rank = i + 1
+	}
+
+	return entries, nil
+}
+
+// FormatLeaderboard renders the leaderboard as a human-readable table.
+func FormatLeaderboard(entries []LeaderboardEntry) string {
+	if len(entries) == 0 {
+		return "No agent run data available yet."
+	}
+
+	var b strings.Builder
+	b.WriteString("Agent Leaderboard — ranked by productivity score\n")
+	b.WriteString(strings.Repeat("─", 74) + "\n")
+	b.WriteString(fmt.Sprintf("%-4s %-28s %6s %-8s %7s %6s %5s\n",
+		"Rank", "Agent", "Score", "Verdict", "Commits", "Fails%", "Runs"))
+	b.WriteString(strings.Repeat("─", 74) + "\n")
+	for _, e := range entries {
+		flag := ""
+		if e.TriageFlag {
+			flag = " ⚑"
+		}
+		b.WriteString(fmt.Sprintf("%-4d %-28s %6.2f %-8s %6.0f%% %5.0f%% %5d%s\n",
+			e.Rank,
+			truncate(e.Agent, 28),
+			e.Score,
+			e.Verdict,
+			e.AvgCommits*100,
+			e.FailRate*100,
+			e.RunCount,
+			flag,
+		))
+	}
+	return b.String()
+}
+
+func round2(f float64) float64 {
+	return float64(int(f*100+0.5)) / 100
+}
+
+func truncate(s string, max int) string {
+	if len(s) <= max {
+		return s
+	}
+	return s[:max-1] + "…"
+}

--- a/internal/dispatch/leaderboard_test.go
+++ b/internal/dispatch/leaderboard_test.go
@@ -1,0 +1,152 @@
+package dispatch
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestScore(t *testing.T) {
+	tests := []struct {
+		name    string
+		profile AgentProfile
+		wantMin float64
+		wantMax float64
+	}{
+		{
+			name: "high performer — commits every run, long duration, zero failures",
+			profile: AgentProfile{
+				RecentResults:    []RunResult{{ExitCode: 0, Duration: 90, HadCommits: true}},
+				AvgCommits:       1.0,
+				FailRate:         0.0,
+				AvgDuration:      90.0,
+				ConsecutiveFails: 0,
+				TriageFlag:       false,
+			},
+			wantMin: 8.9, // 5 + 3 + 1 = 9
+			wantMax: 9.1,
+		},
+		{
+			name: "idle agent — no commits, short runs, no failures",
+			profile: AgentProfile{
+				RecentResults:    []RunResult{{ExitCode: 0, Duration: 5}},
+				AvgCommits:       0.0,
+				FailRate:         0.0,
+				AvgDuration:      5.0,
+				ConsecutiveFails: 0,
+			},
+			wantMin: 2.4, // 0 + 3 - 0.5 = 2.5
+			wantMax: 2.6,
+		},
+		{
+			name: "failing agent — triage flag, 3 consecutive fails",
+			profile: AgentProfile{
+				RecentResults:    []RunResult{{ExitCode: 1, Duration: 5}},
+				AvgCommits:       0.0,
+				FailRate:         1.0,
+				AvgDuration:      5.0,
+				ConsecutiveFails: 3,
+				TriageFlag:       true,
+			},
+			wantMin: -12.1, // 0 + 0 - 0.5 - 10 - 1.5 = -12
+			wantMax: -11.9,
+		},
+		{
+			name: "mixed performer — some commits, moderate fail rate",
+			profile: AgentProfile{
+				RecentResults:    []RunResult{{ExitCode: 0, Duration: 60, HadCommits: true}},
+				AvgCommits:       0.5,
+				FailRate:         0.2,
+				AvgDuration:      60.0,
+				ConsecutiveFails: 0,
+			},
+			wantMin: 5.8, // 2.5 + 2.4 + 1 = 5.9
+			wantMax: 6.0,
+		},
+		{
+			name: "no history — returns zero",
+			profile: AgentProfile{
+				RecentResults: nil,
+			},
+			wantMin: 0,
+			wantMax: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := Score(tt.profile)
+			if got < tt.wantMin || got > tt.wantMax {
+				t.Errorf("Score() = %v, want [%v, %v]", got, tt.wantMin, tt.wantMax)
+			}
+		})
+	}
+}
+
+func TestScoreVerdict(t *testing.T) {
+	tests := []struct {
+		score      float64
+		triageFlag bool
+		want       string
+	}{
+		{9.0, false, "promote"},
+		{6.0, false, "promote"},
+		{5.9, false, "retain"},
+		{3.0, false, "retain"},
+		{2.9, false, "monitor"},
+		{1.0, false, "monitor"},
+		{0.9, false, "fire"},
+		{-5.0, false, "fire"},
+		{9.0, true, "fire"}, // triage overrides score
+	}
+
+	for _, tt := range tests {
+		got := scoreVerdict(tt.score, tt.triageFlag)
+		if got != tt.want {
+			t.Errorf("scoreVerdict(%v, triage=%v) = %q, want %q", tt.score, tt.triageFlag, got, tt.want)
+		}
+	}
+}
+
+func TestFormatLeaderboard(t *testing.T) {
+	t.Run("empty returns placeholder", func(t *testing.T) {
+		out := FormatLeaderboard(nil)
+		if !strings.Contains(out, "No agent run data") {
+			t.Errorf("unexpected output for empty leaderboard: %q", out)
+		}
+	})
+
+	t.Run("entries render correctly", func(t *testing.T) {
+		entries := []LeaderboardEntry{
+			{Rank: 1, Agent: "kernel-sr", Score: 9.0, Verdict: "promote", AvgCommits: 1.0, FailRate: 0.0, RunCount: 8},
+			{Rank: 2, Agent: "cloud-sr", Score: 3.5, Verdict: "retain", AvgCommits: 0.5, FailRate: 0.1, RunCount: 5},
+			{Rank: 3, Agent: "idle-sr", Score: 0.5, Verdict: "monitor", AvgCommits: 0.0, FailRate: 0.0, RunCount: 3},
+			{Rank: 4, Agent: "broken-sr", Score: -2.0, Verdict: "fire", TriageFlag: true, RunCount: 2},
+		}
+		out := FormatLeaderboard(entries)
+
+		for _, want := range []string{"kernel-sr", "promote", "cloud-sr", "retain", "idle-sr", "monitor", "broken-sr", "fire", "⚑"} {
+			if !strings.Contains(out, want) {
+				t.Errorf("FormatLeaderboard output missing %q\n%s", want, out)
+			}
+		}
+	})
+}
+
+func TestRound2(t *testing.T) {
+	if round2(3.14159) != 3.14 {
+		t.Errorf("round2(3.14159) = %v, want 3.14", round2(3.14159))
+	}
+	if round2(0.005) != 0.01 {
+		t.Errorf("round2(0.005) = %v, want 0.01", round2(0.005))
+	}
+}
+
+func TestTruncate(t *testing.T) {
+	if truncate("short", 10) != "short" {
+		t.Error("truncate should not modify short strings")
+	}
+	got := truncate("very-long-agent-name-here", 10)
+	if len([]rune(got)) > 10 {
+		t.Errorf("truncate result too long: %q", got)
+	}
+}

--- a/internal/dispatch/profiles.go
+++ b/internal/dispatch/profiles.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/redis/go-redis/v9"
@@ -232,4 +233,44 @@ func (ps *ProfileStore) recompute(p *AgentProfile) {
 
 func (ps *ProfileStore) profileKey(agent string) string {
 	return ps.namespace + ":profile:" + agent
+}
+
+// AllProfiles returns every agent profile stored in this namespace.
+// Uses Redis SCAN to enumerate profile keys without blocking.
+func (ps *ProfileStore) AllProfiles(ctx context.Context) ([]AgentProfile, error) {
+	pattern := ps.namespace + ":profile:*"
+	prefix := ps.namespace + ":profile:"
+
+	var keys []string
+	iter := ps.rdb.Scan(ctx, 0, pattern, 100).Iterator()
+	for iter.Next(ctx) {
+		keys = append(keys, iter.Val())
+	}
+	if err := iter.Err(); err != nil {
+		return nil, fmt.Errorf("scan profiles: %w", err)
+	}
+	if len(keys) == 0 {
+		return nil, nil
+	}
+
+	values, err := ps.rdb.MGet(ctx, keys...).Result()
+	if err != nil {
+		return nil, fmt.Errorf("mget profiles: %w", err)
+	}
+
+	profiles := make([]AgentProfile, 0, len(keys))
+	for i, v := range values {
+		if v == nil {
+			continue
+		}
+		var p AgentProfile
+		if err := json.Unmarshal([]byte(v.(string)), &p); err != nil {
+			continue
+		}
+		if p.Name == "" {
+			p.Name = strings.TrimPrefix(keys[i], prefix)
+		}
+		profiles = append(profiles, p)
+	}
+	return profiles, nil
 }

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -53,6 +53,7 @@ type Server struct {
 	dispatcher  *dispatch.Dispatcher
 	sprintStore *sprint.Store
 	benchmark   *dispatch.BenchmarkTracker
+	profiles    *dispatch.ProfileStore
 }
 
 // New creates an MCP server backed by the given memory and coordination engines.
@@ -73,6 +74,11 @@ func (s *Server) SetSprintStore(ss *sprint.Store) {
 // SetBenchmark enables throughput metrics MCP tools.
 func (s *Server) SetBenchmark(bt *dispatch.BenchmarkTracker) {
 	s.benchmark = bt
+}
+
+// SetProfileStore enables the agent leaderboard MCP tool.
+func (s *Server) SetProfileStore(ps *dispatch.ProfileStore) {
+	s.profiles = ps
 }
 
 // Serve runs the MCP server on stdio (stdin/stdout JSON-RPC).
@@ -352,6 +358,16 @@ func (s *Server) handleToolCall(req Request) Response {
 		data, _ := json.Marshal(metrics)
 		return textResult(req.ID, string(data))
 
+	case "agent_leaderboard":
+		if s.profiles == nil {
+			return errorResp(req.ID, -32000, "profile store not initialized")
+		}
+		entries, err := s.profiles.Leaderboard(ctx)
+		if err != nil {
+			return errorResp(req.ID, -32000, err.Error())
+		}
+		return textResult(req.ID, dispatch.FormatLeaderboard(entries))
+
 	default:
 		return errorResp(req.ID, -32601, fmt.Sprintf("unknown tool: %s", params.Name))
 	}
@@ -551,6 +567,14 @@ func toolDefs() []ToolDef {
 		{
 			Name:        "benchmark_status",
 			Description: "Return swarm throughput metrics: PRs/hour, commits/run, waste %, budget efficiency, active agents, queue depth, pass rate.",
+			InputSchema: map[string]interface{}{
+				"type":       "object",
+				"properties": map[string]interface{}{},
+			},
+		},
+		{
+			Name:        "agent_leaderboard",
+			Description: "Rank all agents by productivity score. Returns a scored, sorted list with verdicts (promote/retain/monitor/fire) derived from commit output, reliability, and execution duration. Agents with no run history are omitted.",
 			InputSchema: map[string]interface{}{
 				"type":       "object",
 				"properties": map[string]interface{}{},


### PR DESCRIPTION
## Summary

Closes #29

- **`AllProfiles()`** — non-blocking Redis SCAN + MGET enumerates all agent profiles in one round-trip
- **`Score()`** — composite formula: commit output (×5) + reliability (×3) + effort bonus/penalty, minus triage and consecutive-fail penalties
- **`Leaderboard()`** — ranks all agents with run history, attaches verdict: `promote` / `retain` / `monitor` / `fire`
- **MCP tool `agent_leaderboard`** — exposed on the stdio server alongside existing tools; no args required

## Score formula

```
score = avgCommits × 5.0
      + (1 − failRate) × 3.0
      + effort  (+1.0 if avgDuration > 30s, −0.5 if < 10s)
      − 10.0    if triageFlag
      − consecutiveFails × 0.5
```

Verdict thresholds: `promote` ≥ 6.0 · `retain` ≥ 3.0 · `monitor` ≥ 1.0 · `fire` < 1.0 (or triage).

## Test plan

- [ ] `go test ./internal/dispatch/...` — 90 tests pass (Score, scoreVerdict, FormatLeaderboard, round2, truncate)
- [ ] `go vet ./...` — zero issues
- [ ] `go build ./...` — clean build
- [ ] Call `agent_leaderboard` via MCP client against a live Redis instance with seeded profiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)