### PR TITLE
feat: cross-squad request routing — request_work / check_requests / fulfill_request

### DIFF
--- a/internal/coordination/requests.go
+++ b/internal/coordination/requests.go
@@ -1,0 +1,177 @@
+package coordination
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+// RequestType categorises cross-squad requests.
+type RequestType string
+
+const (
+	RequestTypeReport RequestType = "report"
+	RequestTypeQuery  RequestType = "query"
+	RequestTypeReview RequestType = "review"
+	RequestTypeFix    RequestType = "fix"
+	RequestTypeDeploy RequestType = "deploy"
+)
+
+// RequestStatus is the lifecycle state of a cross-squad request.
+type RequestStatus string
+
+const (
+	RequestStatusPending   RequestStatus = "pending"
+	RequestStatusClaimed   RequestStatus = "claimed"
+	RequestStatusFulfilled RequestStatus = "fulfilled"
+	RequestStatusExpired   RequestStatus = "expired"
+)
+
+// defaultRequestTTL is applied when no deadline_minutes is specified.
+const defaultRequestTTL = 24 * time.Hour
+
+// CrossSquadRequest is a unit of cross-squad work.
+type CrossSquadRequest struct {
+	ID              string        `json:"id"`
+	FromAgent       string        `json:"from_agent"`
+	ToSquad         string        `json:"to_squad"`
+	Type            RequestType   `json:"type"`
+	Description     string        `json:"description"`
+	Priority        int           `json:"priority"`         // 0=urgent, 1=high, 2=normal
+	DeadlineMinutes int           `json:"deadline_minutes"` // 0 = default (24h)
+	Status          RequestStatus `json:"status"`
+	SubmittedAt     string        `json:"submitted_at"`
+	FulfilledAt     string        `json:"fulfilled_at,omitempty"`
+	FulfilledBy     string        `json:"fulfilled_by,omitempty"`
+	Result          string        `json:"result,omitempty"`
+	PRNumber        int           `json:"pr_number,omitempty"`
+	AgeMinutes      int           `json:"age_minutes,omitempty"` // computed on read
+}
+
+// SubmitRequest stores a new cross-squad request and returns it.
+func (e *Engine) SubmitRequest(ctx context.Context, fromAgent, toSquad string, reqType RequestType, description string, priority, deadlineMinutes int) (*CrossSquadRequest, error) {
+	now := time.Now().UTC()
+	id := fmt.Sprintf("req-%s-%d", fromAgent, now.UnixMilli())
+
+	ttl := defaultRequestTTL
+	if deadlineMinutes > 0 {
+		ttl = time.Duration(deadlineMinutes) * time.Minute
+	}
+
+	req := &CrossSquadRequest{
+		ID:              id,
+		FromAgent:       fromAgent,
+		ToSquad:         toSquad,
+		Type:            reqType,
+		Description:     description,
+		Priority:        priority,
+		DeadlineMinutes: deadlineMinutes,
+		Status:          RequestStatusPending,
+		SubmittedAt:     now.Format(time.RFC3339),
+	}
+	data, _ := json.Marshal(req)
+
+	pipe := e.rdb.Pipeline()
+	// Store individual request with TTL.
+	pipe.Set(ctx, e.key("request:"+id), data, ttl)
+	// Track in the squad's pending set (score = timestamp for age-based ordering).
+	pipe.ZAdd(ctx, e.key("squad-requests:"+toSquad), redis.Z{
+		Score:  float64(now.UnixMilli()),
+		Member: id,
+	})
+	_, err := pipe.Exec(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return req, nil
+}
+
+// GetPendingRequests returns all non-fulfilled requests for a squad, oldest first.
+func (e *Engine) GetPendingRequests(ctx context.Context, squad string) ([]CrossSquadRequest, error) {
+	ids, err := e.rdb.ZRange(ctx, e.key("squad-requests:"+squad), 0, -1).Result()
+	if err != nil {
+		return nil, err
+	}
+
+	now := time.Now().UTC()
+	var requests []CrossSquadRequest
+	for _, id := range ids {
+		raw, err := e.rdb.Get(ctx, e.key("request:"+id)).Result()
+		if err == redis.Nil {
+			// TTL expired — clean up orphan from set.
+			e.rdb.ZRem(ctx, e.key("squad-requests:"+squad), id)
+			continue
+		}
+		if err != nil {
+			continue
+		}
+
+		var req CrossSquadRequest
+		if err := json.Unmarshal([]byte(raw), &req); err != nil {
+			continue
+		}
+		if req.Status == RequestStatusFulfilled {
+			continue
+		}
+
+		// Compute age.
+		if t, err := time.Parse(time.RFC3339, req.SubmittedAt); err == nil {
+			req.AgeMinutes = int(now.Sub(t).Minutes())
+		}
+		requests = append(requests, req)
+	}
+	return requests, nil
+}
+
+// FulfillRequest marks a request as fulfilled and notifies the requesting agent.
+func (e *Engine) FulfillRequest(ctx context.Context, requestID, agentID, result string, prNumber int) error {
+	raw, err := e.rdb.Get(ctx, e.key("request:"+requestID)).Result()
+	if err == redis.Nil {
+		return fmt.Errorf("request %s not found or expired", requestID)
+	}
+	if err != nil {
+		return err
+	}
+
+	var req CrossSquadRequest
+	if err := json.Unmarshal([]byte(raw), &req); err != nil {
+		return fmt.Errorf("unmarshal request: %w", err)
+	}
+	if req.Status == RequestStatusFulfilled {
+		return fmt.Errorf("request %s is already fulfilled", requestID)
+	}
+
+	req.Status = RequestStatusFulfilled
+	req.FulfilledAt = time.Now().UTC().Format(time.RFC3339)
+	req.FulfilledBy = agentID
+	req.Result = result
+	if prNumber > 0 {
+		req.PRNumber = prNumber
+	}
+
+	data, _ := json.Marshal(req)
+
+	// Preserve remaining TTL when updating.
+	ttl, _ := e.rdb.TTL(ctx, e.key("request:"+requestID)).Result()
+	if ttl <= 0 {
+		ttl = time.Hour
+	}
+
+	pipe := e.rdb.Pipeline()
+	pipe.Set(ctx, e.key("request:"+requestID), data, ttl)
+	pipe.ZRem(ctx, e.key("squad-requests:"+req.ToSquad), requestID)
+	_, err = pipe.Exec(ctx)
+	if err != nil {
+		return err
+	}
+
+	// Notify the requesting agent via coord signal.
+	payload := fmt.Sprintf("request %s fulfilled by %s: %s", requestID, agentID, result)
+	if prNumber > 0 {
+		payload += fmt.Sprintf(" (PR #%d)", prNumber)
+	}
+	return e.Broadcast(ctx, agentID, "completed", payload)
+}

--- a/internal/coordination/requests_test.go
+++ b/internal/coordination/requests_test.go
@@ -1,0 +1,124 @@
+package coordination
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+)
+
+// newTestEngine creates a coordination engine for tests.
+// Skips if Redis is unavailable.
+func newTestEngine(t *testing.T) *Engine {
+	t.Helper()
+	redisURL := os.Getenv("OCTI_REDIS_URL")
+	if redisURL == "" {
+		redisURL = "redis://localhost:6379"
+	}
+	eng, err := New(redisURL, "octi-test-"+strings.ReplaceAll(t.Name(), "/", "-"))
+	if err != nil {
+		t.Skipf("skipping: cannot connect to redis: %v", err)
+	}
+	ctx := context.Background()
+	if err := eng.rdb.Ping(ctx).Err(); err != nil {
+		t.Skipf("skipping: redis not available: %v", err)
+	}
+	t.Cleanup(func() { eng.Close() })
+	return eng
+}
+
+func TestSubmitAndCheckRequests(t *testing.T) {
+	eng := newTestEngine(t)
+	ctx := context.Background()
+
+	req, err := eng.SubmitRequest(ctx, "marketing-em", "analytics", RequestTypeReport,
+		"Need weekly PR velocity report for LinkedIn post", 1, 0)
+	if err != nil {
+		t.Fatalf("SubmitRequest: %v", err)
+	}
+	if req.ID == "" {
+		t.Fatal("expected non-empty request ID")
+	}
+	if req.Status != RequestStatusPending {
+		t.Fatalf("expected pending status, got %s", req.Status)
+	}
+
+	pending, err := eng.GetPendingRequests(ctx, "analytics")
+	if err != nil {
+		t.Fatalf("GetPendingRequests: %v", err)
+	}
+	if len(pending) == 0 {
+		t.Fatal("expected at least one pending request")
+	}
+
+	found := false
+	for _, p := range pending {
+		if p.ID == req.ID {
+			found = true
+			if p.FromAgent != "marketing-em" {
+				t.Errorf("from_agent: want marketing-em, got %s", p.FromAgent)
+			}
+			if p.Type != RequestTypeReport {
+				t.Errorf("type: want report, got %s", p.Type)
+			}
+		}
+	}
+	if !found {
+		t.Errorf("submitted request %s not found in pending list", req.ID)
+	}
+}
+
+func TestFulfillRequest(t *testing.T) {
+	eng := newTestEngine(t)
+	ctx := context.Background()
+
+	req, err := eng.SubmitRequest(ctx, "kernel-sr", "analytics", RequestTypeQuery,
+		"How many PRs merged last week?", 0, 60)
+	if err != nil {
+		t.Fatalf("SubmitRequest: %v", err)
+	}
+
+	err = eng.FulfillRequest(ctx, req.ID, "analytics-sr", "42 PRs merged. See report at reports/week13.md", 0)
+	if err != nil {
+		t.Fatalf("FulfillRequest: %v", err)
+	}
+
+	// Fulfilled request should not appear in pending list.
+	pending, err := eng.GetPendingRequests(ctx, "analytics")
+	if err != nil {
+		t.Fatalf("GetPendingRequests: %v", err)
+	}
+	for _, p := range pending {
+		if p.ID == req.ID {
+			t.Errorf("fulfilled request %s still appears in pending list", req.ID)
+		}
+	}
+}
+
+func TestFulfillRequestNotFound(t *testing.T) {
+	eng := newTestEngine(t)
+	ctx := context.Background()
+
+	err := eng.FulfillRequest(ctx, "req-nonexistent-0", "analytics-sr", "done", 0)
+	if err == nil {
+		t.Fatal("expected error for nonexistent request ID")
+	}
+}
+
+func TestFulfillRequestAlreadyFulfilled(t *testing.T) {
+	eng := newTestEngine(t)
+	ctx := context.Background()
+
+	req, err := eng.SubmitRequest(ctx, "cloud-em", "kernel", RequestTypeFix,
+		"Fix the flaky CI test on PR #1400", 1, 120)
+	if err != nil {
+		t.Fatalf("SubmitRequest: %v", err)
+	}
+
+	if err := eng.FulfillRequest(ctx, req.ID, "kernel-sr", "Fixed in PR #1401", 1401); err != nil {
+		t.Fatalf("first FulfillRequest: %v", err)
+	}
+	if err := eng.FulfillRequest(ctx, req.ID, "kernel-sr", "duplicate", 0); err == nil {
+		t.Fatal("expected error on double-fulfillment")
+	}
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -368,6 +368,66 @@ func (s *Server) handleToolCall(req Request) Response {
 		}
 		return textResult(req.ID, dispatch.FormatLeaderboard(entries))
 
+	case "request_work":
+		var args struct {
+			ToSquad         string `json:"to_squad"`
+			Type            string `json:"type"`
+			Description     string `json:"description"`
+			Priority        int    `json:"priority"`
+			DeadlineMinutes int    `json:"deadline_minutes"`
+		}
+		json.Unmarshal(params.Arguments, &args)
+		if args.ToSquad == "" || args.Description == "" {
+			return errorResp(req.ID, -32602, "to_squad and description are required")
+		}
+		crossReq, err := s.coord.SubmitRequest(ctx, agentID, args.ToSquad,
+			coordination.RequestType(args.Type), args.Description,
+			args.Priority, args.DeadlineMinutes)
+		if err != nil {
+			return errorResp(req.ID, -32000, err.Error())
+		}
+		return textResult(req.ID, fmt.Sprintf(
+			"Request %s submitted to squad %s (type: %s, priority: %d)",
+			crossReq.ID, crossReq.ToSquad, crossReq.Type, crossReq.Priority,
+		))
+
+	case "check_requests":
+		var args struct {
+			Squad string `json:"squad"`
+		}
+		json.Unmarshal(params.Arguments, &args)
+		if args.Squad == "" {
+			return errorResp(req.ID, -32602, "squad is required")
+		}
+		pending, err := s.coord.GetPendingRequests(ctx, args.Squad)
+		if err != nil {
+			return errorResp(req.ID, -32000, err.Error())
+		}
+		if len(pending) == 0 {
+			return textResult(req.ID, fmt.Sprintf("No pending requests for squad %s.", args.Squad))
+		}
+		data, _ := json.Marshal(pending)
+		return textResult(req.ID, string(data))
+
+	case "fulfill_request":
+		var args struct {
+			RequestID string `json:"request_id"`
+			Result    string `json:"result"`
+			PRNumber  int    `json:"pr_number"`
+		}
+		json.Unmarshal(params.Arguments, &args)
+		if args.RequestID == "" || args.Result == "" {
+			return errorResp(req.ID, -32602, "request_id and result are required")
+		}
+		if err := s.coord.FulfillRequest(ctx, args.RequestID, agentID, args.Result, args.PRNumber); err != nil {
+			return errorResp(req.ID, -32000, err.Error())
+		}
+		msg := fmt.Sprintf("Request %s fulfilled.", args.RequestID)
+		if args.PRNumber > 0 {
+			msg += fmt.Sprintf(" PR #%d linked.", args.PRNumber)
+		}
+		return textResult(req.ID, msg)
+
 	default:
 		return errorResp(req.ID, -32601, fmt.Sprintf("unknown tool: %s", params.Name))
 	}
@@ -578,6 +638,45 @@ func toolDefs() []ToolDef {
 			InputSchema: map[string]interface{}{
 				"type":       "object",
 				"properties": map[string]interface{}{},
+			},
+		},
+		{
+			Name:        "request_work",
+			Description: "Request work from another squad. The request is stored and routed to the target squad's agents on their next tick. Use when you need a report, query, review, fix, or deploy from a different squad's domain.",
+			InputSchema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"to_squad":         map[string]string{"type": "string", "description": "Target squad name (e.g. 'analytics', 'kernel', 'shellforge')"},
+					"type":             map[string]interface{}{"type": "string", "enum": []string{"report", "query", "review", "fix", "deploy"}, "description": "Work type"},
+					"description":      map[string]string{"type": "string", "description": "What you need done"},
+					"priority":         map[string]interface{}{"type": "number", "description": "0=urgent, 1=high, 2=normal (default 2)"},
+					"deadline_minutes": map[string]interface{}{"type": "number", "description": "How soon you need this (in minutes). Default: 1440 (24h)"},
+				},
+				"required": []string{"to_squad", "description"},
+			},
+		},
+		{
+			Name:        "check_requests",
+			Description: "Check for incoming cross-squad work requests targeting your squad. Returns pending requests with age, priority, and description. Call at the start of each run to pick up delegated work.",
+			InputSchema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"squad": map[string]string{"type": "string", "description": "Your squad name (e.g. 'analytics', 'kernel')"},
+				},
+				"required": []string{"squad"},
+			},
+		},
+		{
+			Name:        "fulfill_request",
+			Description: "Mark a cross-squad request as complete. Notifies the requesting agent via coord_signal and removes the request from the pending queue.",
+			InputSchema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"request_id": map[string]string{"type": "string", "description": "Request ID returned by request_work or check_requests"},
+					"result":     map[string]string{"type": "string", "description": "Summary of the work done / where to find the output"},
+					"pr_number":  map[string]interface{}{"type": "number", "description": "PR number if the work resulted in a pull request (optional)"},
+				},
+				"required": []string{"request_id", "result"},
 			},
 		},
 	}


### PR DESCRIPTION
## Summary

- **`request_work`** — any agent can request a report/query/review/fix/deploy from another squad, stored in Redis with TTL and priority
- **`check_requests`** — target-squad agents call this at run start to pick up delegated work
- **`fulfill_request`** — marks the request done, broadcasts a `coord_signal` back to the requester, and removes it from the pending queue

## Motivation

Before this, cross-squad coordination was prose no one acted on. Now an agent can say `request_work(to: analytics, type: report, description: "PR velocity for LinkedIn post")` and the analytics squad picks it up on their next tick.

## Architecture

```
Redis layout:
  {ns}:request:{id}            — full CrossSquadRequest JSON, TTL = deadline (default 24h)
  {ns}:squad-requests:{squad}  — sorted set of pending request IDs (score = submit timestamp)
```

Follows the same pipeline + sorted-set patterns as the existing claims/signals infrastructure in `internal/coordination/engine.go`.

## Test plan

- [x] `go build ./...` and `go vet ./...` pass
- [x] 4 new integration tests in `internal/coordination/requests_test.go` — all pass against live Redis
  - submit + check pending
  - fulfill removes from pending
  - fulfillment of nonexistent ID returns error
  - double-fulfillment returns error

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)