### PR TITLE
feat: Slack control plane — Block Kit interactive messages + /slack/actions + ntfy.sh (#9)

### DIFF
--- a/internal/dispatch/ntfy.go
+++ b/internal/dispatch/ntfy.go
@@ -1,0 +1,119 @@
+package dispatch
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net/http"
+	"strconv"
+	"time"
+)
+
+// Ntfy priority levels, matching the ntfy.sh API convention.
+// See: https://docs.ntfy.sh/publish/#message-priority
+const (
+	NtfyPriorityMax     = 5 // Urgent — pops through Do Not Disturb
+	NtfyPriorityHigh    = 4 // High
+	NtfyPriorityDefault = 3 // Default
+	NtfyPriorityLow     = 2 // Low
+	NtfyPriorityMin     = 1 // Minimum — no notification sound
+)
+
+// NtfyNotifier sends push notifications via ntfy.sh (or a self-hosted ntfy server).
+// If baseURL or topic is empty, all Post* methods are no-ops.
+//
+// Usage:
+//
+//	n := NewNtfyNotifier("https://ntfy.sh", "agentguard-cto")
+//	n.Post(ctx, "Budget exhausted", "codex circuit breaker OPEN", NtfyPriorityHigh)
+type NtfyNotifier struct {
+	baseURL string
+	topic   string
+	client  *http.Client
+}
+
+// NewNtfyNotifier creates an NtfyNotifier targeting the given base URL and topic.
+// baseURL can be "https://ntfy.sh" for the hosted service or a self-hosted URL.
+// If either baseURL or topic is empty, the notifier is disabled.
+func NewNtfyNotifier(baseURL, topic string) *NtfyNotifier {
+	return &NtfyNotifier{
+		baseURL: baseURL,
+		topic:   topic,
+		client:  &http.Client{Timeout: 10 * time.Second},
+	}
+}
+
+// Enabled returns true if both baseURL and topic are configured.
+func (n *NtfyNotifier) Enabled() bool {
+	return n.baseURL != "" && n.topic != ""
+}
+
+// Post sends a push notification with a title and message body.
+// priority should be one of the NtfyPriority* constants.
+func (n *NtfyNotifier) Post(ctx context.Context, title, message string, priority int) error {
+	if !n.Enabled() {
+		return nil
+	}
+	return n.send(ctx, title, message, priority, nil)
+}
+
+// PostDriverAlert sends a high-priority notification for a driver circuit open event.
+func (n *NtfyNotifier) PostDriverAlert(ctx context.Context, driverName string, failures int) error {
+	if !n.Enabled() {
+		return nil
+	}
+	title := fmt.Sprintf("Driver Alert: %s", driverName)
+	msg := fmt.Sprintf("Circuit breaker OPEN — %d consecutive failures. Agents rerouting.", failures)
+	return n.send(ctx, title, msg, NtfyPriorityHigh, nil)
+}
+
+// PostPRReadyAlert sends a default-priority notification when a PR is ready to merge.
+func (n *NtfyNotifier) PostPRReadyAlert(ctx context.Context, repo string, prNumber int, title string) error {
+	if !n.Enabled() {
+		return nil
+	}
+	notifTitle := fmt.Sprintf("PR Ready: #%d", prNumber)
+	msg := fmt.Sprintf("%s — %s/pull/%d\nAll checks green.", title, fmt.Sprintf("https://github.com/%s", repo), prNumber)
+	return n.send(ctx, notifTitle, msg, NtfyPriorityDefault, nil)
+}
+
+// PostAllDriversDown sends a max-priority notification when all drivers are exhausted.
+func (n *NtfyNotifier) PostAllDriversDown(ctx context.Context, description string) error {
+	if !n.Enabled() {
+		return nil
+	}
+	return n.send(ctx, "🚨 All Drivers Exhausted", description, NtfyPriorityMax, nil)
+}
+
+// send performs the HTTP POST to the ntfy topic endpoint.
+// extraHeaders are set as additional HTTP headers (e.g., X-Actions for clickable buttons).
+func (n *NtfyNotifier) send(ctx context.Context, title, message string, priority int, extraHeaders map[string]string) error {
+	endpoint := fmt.Sprintf("%s/%s", n.baseURL, n.topic)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewBufferString(message))
+	if err != nil {
+		return fmt.Errorf("create ntfy request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "text/plain")
+	if title != "" {
+		req.Header.Set("X-Title", title)
+	}
+	if priority != NtfyPriorityDefault {
+		req.Header.Set("X-Priority", strconv.Itoa(priority))
+	}
+	for k, v := range extraHeaders {
+		req.Header.Set(k, v)
+	}
+
+	resp, err := n.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("ntfy post: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("ntfy returned %d", resp.StatusCode)
+	}
+	return nil
+}

--- a/internal/dispatch/ntfy_test.go
+++ b/internal/dispatch/ntfy_test.go
@@ -1,0 +1,126 @@
+package dispatch
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestNtfyNotifier_Enabled(t *testing.T) {
+	if NewNtfyNotifier("", "").Enabled() {
+		t.Fatal("empty config should not be enabled")
+	}
+	if NewNtfyNotifier("https://ntfy.sh", "").Enabled() {
+		t.Fatal("missing topic should not be enabled")
+	}
+	if NewNtfyNotifier("", "my-topic").Enabled() {
+		t.Fatal("missing baseURL should not be enabled")
+	}
+	if !NewNtfyNotifier("https://ntfy.sh", "my-topic").Enabled() {
+		t.Fatal("fully configured notifier should be enabled")
+	}
+}
+
+func TestNtfyNotifier_NoopWhenDisabled(t *testing.T) {
+	ctx := context.Background()
+	n := NewNtfyNotifier("", "")
+
+	if err := n.Post(ctx, "title", "msg", NtfyPriorityDefault); err != nil {
+		t.Fatalf("Post on disabled notifier: %v", err)
+	}
+	if err := n.PostDriverAlert(ctx, "codex", 5); err != nil {
+		t.Fatalf("PostDriverAlert on disabled notifier: %v", err)
+	}
+	if err := n.PostAllDriversDown(ctx, "all down"); err != nil {
+		t.Fatalf("PostAllDriversDown on disabled notifier: %v", err)
+	}
+}
+
+func TestNtfyNotifier_Post(t *testing.T) {
+	var gotTitle, gotPriority, gotBody string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotTitle = r.Header.Get("X-Title")
+		gotPriority = r.Header.Get("X-Priority")
+		b, _ := io.ReadAll(r.Body)
+		gotBody = string(b)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	ctx := context.Background()
+	n := NewNtfyNotifier(srv.URL, "test-topic")
+
+	if err := n.Post(ctx, "Alert!", "Something happened", NtfyPriorityHigh); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if gotTitle != "Alert!" {
+		t.Errorf("X-Title = %q, want %q", gotTitle, "Alert!")
+	}
+	if gotPriority != "4" {
+		t.Errorf("X-Priority = %q, want %q", gotPriority, "4")
+	}
+	if gotBody != "Something happened" {
+		t.Errorf("body = %q, want %q", gotBody, "Something happened")
+	}
+}
+
+func TestNtfyNotifier_DefaultPriorityOmitsHeader(t *testing.T) {
+	var gotPriority string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPriority = r.Header.Get("X-Priority")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	ctx := context.Background()
+	n := NewNtfyNotifier(srv.URL, "test-topic")
+	_ = n.Post(ctx, "t", "m", NtfyPriorityDefault)
+
+	if gotPriority != "" {
+		t.Errorf("expected no X-Priority header for default priority, got %q", gotPriority)
+	}
+}
+
+func TestNtfyNotifier_PostDriverAlert(t *testing.T) {
+	var gotTitle, gotBody string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotTitle = r.Header.Get("X-Title")
+		b, _ := io.ReadAll(r.Body)
+		gotBody = string(b)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	ctx := context.Background()
+	n := NewNtfyNotifier(srv.URL, "test-topic")
+
+	if err := n.PostDriverAlert(ctx, "codex", 63); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if gotTitle != "Driver Alert: codex" {
+		t.Errorf("title = %q, want %q", gotTitle, "Driver Alert: codex")
+	}
+	if gotBody == "" {
+		t.Error("expected non-empty body")
+	}
+}
+
+func TestNtfyNotifier_HTTPError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	ctx := context.Background()
+	n := NewNtfyNotifier(srv.URL, "test-topic")
+
+	err := n.Post(ctx, "t", "m", NtfyPriorityDefault)
+	if err == nil {
+		t.Fatal("expected error on 500 response")
+	}
+}

--- a/internal/dispatch/slack.go
+++ b/internal/dispatch/slack.go
@@ -13,7 +13,9 @@ import (
 )
 
 // Notifier posts structured notifications to a Slack incoming webhook.
-// If no webhook URL is configured, all Post* methods are no-ops.
+// It supports both plain-text messages and interactive Block Kit messages
+// with action buttons. If no webhook URL is configured, all Post* methods
+// are no-ops.
 type Notifier struct {
 	webhookURL string
 	client     *http.Client
@@ -83,6 +85,82 @@ func (n *Notifier) PostDriversRecovered(ctx context.Context) error {
 	return n.post(ctx, map[string]interface{}{"text": "✅ *Drivers Recovered* — dispatch resumed"})
 }
 
+// PostDriverAlert sends an interactive Block Kit message for a single driver circuit alert.
+// It includes [Pause Squad], [Switch Tier], and [Ignore] action buttons.
+// Button clicks are routed back to the /slack/actions endpoint.
+func (n *Notifier) PostDriverAlert(ctx context.Context, driverName string, failures int) error {
+	if !n.Enabled() {
+		return nil
+	}
+
+	msg := fmt.Sprintf(
+		"🔴 *Driver Alert: `%s`*\nCircuit breaker OPEN — %d consecutive failures.\nAgents are being rerouted to available drivers.",
+		driverName, failures,
+	)
+
+	blocks := []map[string]interface{}{
+		blockSection(msg),
+		blockActions(
+			slackButton("pause_squad", driverName, "Pause Squad", "danger"),
+			slackButton("switch_tier", driverName, "Switch Tier", "primary"),
+			slackButton("ignore_alert", driverName, "Ignore", ""),
+		),
+	}
+
+	return n.postBlocks(ctx, blocks)
+}
+
+// PostPRReadyAlert sends an interactive Block Kit message for a PR ready to merge.
+// It includes [Merge], [Review], and [Skip] action buttons.
+func (n *Notifier) PostPRReadyAlert(ctx context.Context, repo string, prNumber int, title string) error {
+	if !n.Enabled() {
+		return nil
+	}
+
+	prURL := fmt.Sprintf("https://github.com/%s/pull/%d", repo, prNumber)
+	msg := fmt.Sprintf(
+		"🟡 *PR Ready to Merge*\n<%s|#%d: %s>\nAll checks green — awaiting merge decision.",
+		prURL, prNumber, title,
+	)
+	prKey := fmt.Sprintf("%s/%d", repo, prNumber)
+
+	blocks := []map[string]interface{}{
+		blockSection(msg),
+		blockActions(
+			slackButton("merge_pr", prKey, "Merge", "primary"),
+			slackButton("review_pr", prKey, "Review", ""),
+			slackButton("skip_pr", prKey, "Skip", ""),
+		),
+	}
+
+	return n.postBlocks(ctx, blocks)
+}
+
+// PostSprintGoalAlert sends an interactive Block Kit message when a sprint goal is delivered.
+// It includes [Accept] and [Request Changes] action buttons.
+func (n *Notifier) PostSprintGoalAlert(ctx context.Context, squad, goal string) error {
+	if !n.Enabled() {
+		return nil
+	}
+
+	msg := fmt.Sprintf("🟢 *Sprint Goal Delivered*\nSquad: `%s`\nGoal: %s", squad, goal)
+
+	blocks := []map[string]interface{}{
+		blockSection(msg),
+		blockActions(
+			slackButton("accept_goal", squad, "Accept", "primary"),
+			slackButton("request_changes", squad, "Request Changes", ""),
+		),
+	}
+
+	return n.postBlocks(ctx, blocks)
+}
+
+// postBlocks sends a Slack Block Kit payload to the webhook URL.
+func (n *Notifier) postBlocks(ctx context.Context, blocks []map[string]interface{}) error {
+	return n.post(ctx, map[string]interface{}{"blocks": blocks})
+}
+
 // post marshals the payload and POSTs it to the Slack incoming webhook URL.
 func (n *Notifier) post(ctx context.Context, payload map[string]interface{}) error {
 	body, err := json.Marshal(payload)
@@ -106,4 +184,37 @@ func (n *Notifier) post(ctx context.Context, payload map[string]interface{}) err
 		return fmt.Errorf("slack webhook returned %d", resp.StatusCode)
 	}
 	return nil
+}
+
+// blockSection returns a Slack Block Kit section block with mrkdwn text.
+func blockSection(text string) map[string]interface{} {
+	return map[string]interface{}{
+		"type": "section",
+		"text": map[string]string{"type": "mrkdwn", "text": text},
+	}
+}
+
+// blockActions returns a Slack Block Kit actions block containing the given buttons.
+func blockActions(buttons ...map[string]interface{}) map[string]interface{} {
+	elements := make([]map[string]interface{}, len(buttons))
+	copy(elements, buttons)
+	return map[string]interface{}{
+		"type":     "actions",
+		"elements": elements,
+	}
+}
+
+// slackButton creates a Slack Block Kit button element.
+// style can be "primary", "danger", or "" (default/secondary).
+func slackButton(actionID, value, text, style string) map[string]interface{} {
+	btn := map[string]interface{}{
+		"type":      "button",
+		"text":      map[string]string{"type": "plain_text", "text": text},
+		"action_id": actionID,
+		"value":     value,
+	}
+	if style != "" {
+		btn["style"] = style
+	}
+	return btn
 }

--- a/internal/dispatch/slack_actions_test.go
+++ b/internal/dispatch/slack_actions_test.go
@@ -1,0 +1,356 @@
+package dispatch
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+// --- Block Kit message tests ---
+
+func TestNotifier_PostDriverAlert(t *testing.T) {
+	var received []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		received, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	ctx := context.Background()
+	n := NewNotifier(srv.URL)
+
+	if err := n.PostDriverAlert(ctx, "codex", 63); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var payload map[string]interface{}
+	if err := json.Unmarshal(received, &payload); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+
+	// Must contain blocks, not plain text
+	if _, ok := payload["blocks"]; !ok {
+		t.Fatal("expected 'blocks' key in payload")
+	}
+	// blocks must be an array
+	blocks, ok := payload["blocks"].([]interface{})
+	if !ok || len(blocks) == 0 {
+		t.Fatal("expected non-empty blocks array")
+	}
+}
+
+func TestNotifier_PostDriverAlert_ContainsButtons(t *testing.T) {
+	var received []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		received, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	ctx := context.Background()
+	n := NewNotifier(srv.URL)
+	_ = n.PostDriverAlert(ctx, "copilot", 5)
+
+	raw := string(received)
+	for _, actionID := range []string{"pause_squad", "switch_tier", "ignore_alert"} {
+		if !strings.Contains(raw, actionID) {
+			t.Errorf("expected action_id %q in payload", actionID)
+		}
+	}
+	// driver name should appear as value
+	if !strings.Contains(raw, "copilot") {
+		t.Error("expected driver name in payload")
+	}
+}
+
+func TestNotifier_PostPRReadyAlert(t *testing.T) {
+	var received []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		received, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	ctx := context.Background()
+	n := NewNotifier(srv.URL)
+
+	if err := n.PostPRReadyAlert(ctx, "AgentGuardHQ/octi-pulpo", 42, "feat: my change"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	raw := string(received)
+	if !strings.Contains(raw, "merge_pr") {
+		t.Error("expected merge_pr action_id in payload")
+	}
+	if !strings.Contains(raw, "review_pr") {
+		t.Error("expected review_pr action_id in payload")
+	}
+	if !strings.Contains(raw, "skip_pr") {
+		t.Error("expected skip_pr action_id in payload")
+	}
+	if !strings.Contains(raw, "42") {
+		t.Error("expected PR number in payload")
+	}
+}
+
+func TestNotifier_PostSprintGoalAlert(t *testing.T) {
+	var received []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		received, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	ctx := context.Background()
+	n := NewNotifier(srv.URL)
+
+	if err := n.PostSprintGoalAlert(ctx, "octi-pulpo", "ship Slack control plane"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	raw := string(received)
+	if !strings.Contains(raw, "accept_goal") {
+		t.Error("expected accept_goal action_id in payload")
+	}
+	if !strings.Contains(raw, "request_changes") {
+		t.Error("expected request_changes action_id in payload")
+	}
+	if !strings.Contains(raw, "octi-pulpo") {
+		t.Error("expected squad name in payload")
+	}
+}
+
+func TestNotifier_BlockKit_NoopWhenDisabled(t *testing.T) {
+	ctx := context.Background()
+	n := NewNotifier("")
+
+	if err := n.PostDriverAlert(ctx, "codex", 1); err != nil {
+		t.Fatalf("PostDriverAlert: %v", err)
+	}
+	if err := n.PostPRReadyAlert(ctx, "org/repo", 1, "title"); err != nil {
+		t.Fatalf("PostPRReadyAlert: %v", err)
+	}
+	if err := n.PostSprintGoalAlert(ctx, "squad", "goal"); err != nil {
+		t.Fatalf("PostSprintGoalAlert: %v", err)
+	}
+}
+
+// --- Slack actions endpoint tests ---
+
+// makeSlackPayload builds the URL-encoded body that Slack sends for interactive callbacks.
+func makeSlackPayload(actionID, value, user string) string {
+	inner, _ := json.Marshal(map[string]interface{}{
+		"type": "block_actions",
+		"actions": []map[string]interface{}{
+			{"action_id": actionID, "value": value},
+		},
+		"user": map[string]string{"name": user},
+	})
+	return url.Values{"payload": {string(inner)}}.Encode()
+}
+
+// makeSlackSig computes the v0 Slack request signature.
+func makeSlackSig(secret []byte, timestamp, body string) string {
+	mac := hmac.New(sha256.New, secret)
+	fmt.Fprintf(mac, "v0:%s:%s", timestamp, body)
+	return "v0=" + hex.EncodeToString(mac.Sum(nil))
+}
+
+func TestWebhookServer_SlackActions_IgnoreAck(t *testing.T) {
+	d, _ := testSetup(t)
+	ws := NewWebhookServer(d, "")
+	secret := []byte("test-signing-secret")
+	ws.SetSlackSigningSecret(secret)
+
+	body := makeSlackPayload("ignore_alert", "codex", "jared")
+	ts := "1234567890"
+	sig := makeSlackSig(secret, ts, body)
+
+	req := httptest.NewRequest(http.MethodPost, "/slack/actions", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("X-Slack-Request-Timestamp", ts)
+	req.Header.Set("X-Slack-Signature", sig)
+	rr := httptest.NewRecorder()
+
+	ws.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	var resp map[string]string
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatalf("invalid response JSON: %v", err)
+	}
+	if !strings.Contains(resp["text"], "Acknowledged") {
+		t.Errorf("expected acknowledgement text, got: %q", resp["text"])
+	}
+}
+
+func TestWebhookServer_SlackActions_BadSignature(t *testing.T) {
+	d, _ := testSetup(t)
+	ws := NewWebhookServer(d, "")
+	ws.SetSlackSigningSecret([]byte("correct-secret"))
+
+	body := makeSlackPayload("ignore_alert", "codex", "jared")
+	ts := "1234567890"
+	wrongSig := makeSlackSig([]byte("wrong-secret"), ts, body)
+
+	req := httptest.NewRequest(http.MethodPost, "/slack/actions", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("X-Slack-Request-Timestamp", ts)
+	req.Header.Set("X-Slack-Signature", wrongSig)
+	rr := httptest.NewRecorder()
+
+	ws.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 on bad signature, got %d", rr.Code)
+	}
+}
+
+func TestWebhookServer_SlackActions_NoSignatureCheck_WhenSecretEmpty(t *testing.T) {
+	d, _ := testSetup(t)
+	ws := NewWebhookServer(d, "")
+	// No signing secret set — should accept any request (useful for local dev)
+
+	body := makeSlackPayload("skip_pr", "AgentGuardHQ/octi-pulpo/42", "jared")
+	req := httptest.NewRequest(http.MethodPost, "/slack/actions", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rr := httptest.NewRecorder()
+
+	ws.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200 without signing secret, got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestWebhookServer_SlackActions_MethodNotAllowed(t *testing.T) {
+	d, _ := testSetup(t)
+	ws := NewWebhookServer(d, "")
+
+	req := httptest.NewRequest(http.MethodGet, "/slack/actions", nil)
+	rr := httptest.NewRecorder()
+
+	ws.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("expected 405, got %d", rr.Code)
+	}
+}
+
+func TestWebhookServer_SlackActions_MissingPayload(t *testing.T) {
+	d, _ := testSetup(t)
+	ws := NewWebhookServer(d, "")
+
+	req := httptest.NewRequest(http.MethodPost, "/slack/actions", strings.NewReader("not-a-payload"))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rr := httptest.NewRecorder()
+
+	ws.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 on missing payload, got %d", rr.Code)
+	}
+}
+
+func TestWebhookServer_SlackActions_UnknownAction(t *testing.T) {
+	d, _ := testSetup(t)
+	ws := NewWebhookServer(d, "")
+
+	body := makeSlackPayload("unknown_action", "somevalue", "jared")
+	req := httptest.NewRequest(http.MethodPost, "/slack/actions", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rr := httptest.NewRecorder()
+
+	ws.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200 for unknown action (graceful), got %d", rr.Code)
+	}
+}
+
+func TestVerifySlackSignature(t *testing.T) {
+	d, _ := testSetup(t)
+	ws := NewWebhookServer(d, "")
+	secret := []byte("8f742231b10e8888abcd99yyyzzz85a5")
+	ws.SetSlackSigningSecret(secret)
+
+	body := []byte("v=test&body=data")
+	ts := "1531420618"
+	sig := makeSlackSig(secret, ts, string(body))
+
+	if !ws.verifySlackSignature(body, ts, sig) {
+		t.Fatal("expected valid signature to pass verification")
+	}
+
+	// Tampered body
+	if ws.verifySlackSignature([]byte("tampered"), ts, sig) {
+		t.Fatal("tampered body should fail verification")
+	}
+
+	// Bad sig format
+	if ws.verifySlackSignature(body, ts, "sha256=invalidsig") {
+		t.Fatal("wrong prefix should fail")
+	}
+}
+
+// TestNotifier_UpdateSlackMessage_FireAndForget verifies that updateSlackMessage
+// does not panic when the response URL is unreachable.
+func TestNotifier_UpdateSlackMessage_FireAndForget(t *testing.T) {
+	d, _ := testSetup(t)
+	ws := NewWebhookServer(d, "")
+
+	// Should not panic even with an unreachable URL
+	ws.updateSlackMessage("http://127.0.0.1:1", "test message")
+}
+
+// TestWebhookServer_SlackActions_EmptyActions verifies graceful handling
+// when Slack sends a valid payload with no actions (edge case).
+func TestWebhookServer_SlackActions_EmptyActions(t *testing.T) {
+	d, _ := testSetup(t)
+	ws := NewWebhookServer(d, "")
+
+	inner, _ := json.Marshal(map[string]interface{}{
+		"type":    "block_actions",
+		"actions": []interface{}{},
+		"user":    map[string]string{"name": "jared"},
+	})
+	body := url.Values{"payload": {string(inner)}}.Encode()
+
+	req := httptest.NewRequest(http.MethodPost, "/slack/actions", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rr := httptest.NewRecorder()
+
+	ws.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200 for empty actions, got %d", rr.Code)
+	}
+}
+
+func TestRouteSlackAction_Context(t *testing.T) {
+	d, ctx := testSetup(t)
+	ws := NewWebhookServer(d, "")
+
+	// ignore_alert, review_pr, skip_pr should all return ack without Redis ops
+	for _, actionID := range []string{"ignore_alert", "review_pr", "skip_pr"} {
+		ack, err := ws.routeSlackAction(ctx, actionID, "somevalue", "testuser")
+		if err != nil {
+			t.Errorf("routeSlackAction(%q): %v", actionID, err)
+		}
+		if !strings.Contains(ack, "testuser") {
+			t.Errorf("routeSlackAction(%q) ack missing actor: %q", actionID, ack)
+		}
+	}
+}

--- a/internal/dispatch/webhook.go
+++ b/internal/dispatch/webhook.go
@@ -1,6 +1,7 @@
 package dispatch
 
 import (
+	"bytes"
 	"context"
 	"crypto/hmac"
 	"crypto/sha256"
@@ -9,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -17,14 +19,16 @@ import (
 	"github.com/AgentGuardHQ/octi-pulpo/internal/sprint"
 )
 
-// WebhookServer is a lightweight HTTP server for receiving GitHub webhooks.
+// WebhookServer is a lightweight HTTP server for receiving GitHub webhooks
+// and Slack interactive action callbacks.
 // It replaces webhook-listener.py with coordinated dispatch.
 type WebhookServer struct {
-	dispatcher  *Dispatcher
-	secret      []byte
-	mux         *http.ServeMux
-	sprintStore *sprint.Store
-	benchmark   *BenchmarkTracker
+	dispatcher         *Dispatcher
+	secret             []byte // GitHub HMAC-SHA256 webhook secret
+	slackSigningSecret []byte // Slack signing secret for action callbacks
+	mux                *http.ServeMux
+	sprintStore        *sprint.Store
+	benchmark          *BenchmarkTracker
 }
 
 // NewWebhookServer creates a webhook handler backed by the dispatcher.
@@ -53,6 +57,7 @@ func NewWebhookServer(dispatcher *Dispatcher, secretFile string) *WebhookServer 
 	ws.mux.HandleFunc("/sprint/status", ws.handleSprintStatus)
 	ws.mux.HandleFunc("/sprint/sync", ws.handleSprintSync)
 	ws.mux.HandleFunc("/benchmark", ws.handleBenchmark)
+	ws.mux.HandleFunc("/slack/actions", ws.handleSlackActions)
 	return ws
 }
 
@@ -312,6 +317,207 @@ func (ws *WebhookServer) handleBenchmark(w http.ResponseWriter, r *http.Request)
 
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(metrics)
+}
+
+// SetSlackSigningSecret configures the Slack signing secret used to verify
+// interactive action callbacks at /slack/actions.
+func (ws *WebhookServer) SetSlackSigningSecret(secret []byte) {
+	ws.slackSigningSecret = secret
+}
+
+// handleSlackActions receives interactive action callbacks from Slack (Block Kit buttons).
+// Slack POSTs application/x-www-form-urlencoded with a "payload" field containing JSON.
+//
+// Supported action_ids and their effects:
+//   - pause_squad    — publishes a "pause-squad:<driver>" coord signal to Redis
+//   - switch_tier    — dispatches the routing recalculation agent
+//   - ignore_alert   — no-op, acknowledges the alert
+//   - merge_pr       — triggers pr-merger-agent for the given repo/pr
+//   - review_pr      — no-op, acknowledges
+//   - skip_pr        — no-op, acknowledges
+//   - accept_goal    — publishes a "goal-accepted:<squad>" coord signal
+//   - request_changes — publishes a "goal-rejected:<squad>" coord signal
+func (ws *WebhookServer) handleSlackActions(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		http.Error(w, "read body failed", http.StatusBadRequest)
+		return
+	}
+	defer r.Body.Close()
+
+	// Verify Slack request signature when signing secret is configured.
+	if len(ws.slackSigningSecret) > 0 {
+		ts := r.Header.Get("X-Slack-Request-Timestamp")
+		sig := r.Header.Get("X-Slack-Signature")
+		if !ws.verifySlackSignature(body, ts, sig) {
+			http.Error(w, "invalid signature", http.StatusForbidden)
+			return
+		}
+	}
+
+	// Slack sends payload as URL-encoded form: payload=<json>
+	values, err := url.ParseQuery(string(body))
+	if err != nil {
+		http.Error(w, "invalid form body", http.StatusBadRequest)
+		return
+	}
+	rawPayload := values.Get("payload")
+	if rawPayload == "" {
+		http.Error(w, "missing payload field", http.StatusBadRequest)
+		return
+	}
+
+	var slackPayload struct {
+		Type    string `json:"type"`
+		Actions []struct {
+			ActionID string `json:"action_id"`
+			Value    string `json:"value"`
+		} `json:"actions"`
+		ResponseURL string `json:"response_url"`
+		User        struct {
+			Name string `json:"name"`
+		} `json:"user"`
+	}
+	if err := json.Unmarshal([]byte(rawPayload), &slackPayload); err != nil {
+		http.Error(w, "invalid payload JSON", http.StatusBadRequest)
+		return
+	}
+	if len(slackPayload.Actions) == 0 {
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+
+	action := slackPayload.Actions[0]
+	ctx := r.Context()
+	actor := slackPayload.User.Name
+
+	ack, err := ws.routeSlackAction(ctx, action.ActionID, action.Value, actor)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	// Respond immediately to Slack with an acknowledgement message.
+	// This replaces the original interactive message so it can't be double-clicked.
+	if slackPayload.ResponseURL != "" {
+		go ws.updateSlackMessage(slackPayload.ResponseURL, ack)
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(map[string]string{"text": ack})
+}
+
+// routeSlackAction performs the work triggered by a Slack button click.
+// It returns a human-readable acknowledgement string for the Slack message update.
+func (ws *WebhookServer) routeSlackAction(ctx context.Context, actionID, value, actor string) (string, error) {
+	switch actionID {
+	case "pause_squad":
+		// Publish a pause signal to Redis for this driver.
+		ch := ws.dispatcher.Namespace() + ":signal-stream"
+		sig := fmt.Sprintf(`{"agent_id":"slack:%s","type":"directive","payload":"pause-squad:%s","timestamp":"%s"}`,
+			actor, value, time.Now().UTC().Format(time.RFC3339))
+		if err := ws.dispatcher.RedisClient().Publish(ctx, ch, sig).Err(); err != nil {
+			return "", fmt.Errorf("publish pause signal: %w", err)
+		}
+		return fmt.Sprintf("⏸ Squad paused for driver `%s` by @%s", value, actor), nil
+
+	case "switch_tier":
+		// Trigger the routing recalculation by dispatching the senior agent.
+		event := Event{
+			Type:    EventSignal,
+			Source:  "slack",
+			Payload: map[string]string{"action": "switch_tier", "driver": value, "actor": actor},
+		}
+		_, err := ws.dispatcher.Dispatch(ctx, event, "octi-pulpo-sr", 1)
+		if err != nil {
+			return "", fmt.Errorf("dispatch switch-tier: %w", err)
+		}
+		return fmt.Sprintf("🔀 Tier switch initiated for driver `%s` by @%s", value, actor), nil
+
+	case "merge_pr":
+		// Trigger the PR merger agent.
+		event := Event{
+			Type:    EventSignal,
+			Source:  "slack",
+			Payload: map[string]string{"action": "merge_pr", "pr": value, "actor": actor},
+		}
+		_, err := ws.dispatcher.Dispatch(ctx, event, "pr-merger-agent", 1)
+		if err != nil {
+			return "", fmt.Errorf("dispatch merge: %w", err)
+		}
+		return fmt.Sprintf("🔀 Merge triggered for PR `%s` by @%s", value, actor), nil
+
+	case "accept_goal":
+		ch := ws.dispatcher.Namespace() + ":signal-stream"
+		sig := fmt.Sprintf(`{"agent_id":"slack:%s","type":"directive","payload":"goal-accepted:%s","timestamp":"%s"}`,
+			actor, value, time.Now().UTC().Format(time.RFC3339))
+		if err := ws.dispatcher.RedisClient().Publish(ctx, ch, sig).Err(); err != nil {
+			return "", fmt.Errorf("publish goal-accepted signal: %w", err)
+		}
+		return fmt.Sprintf("✅ Sprint goal accepted for `%s` by @%s", value, actor), nil
+
+	case "request_changes":
+		ch := ws.dispatcher.Namespace() + ":signal-stream"
+		sig := fmt.Sprintf(`{"agent_id":"slack:%s","type":"directive","payload":"goal-rejected:%s","timestamp":"%s"}`,
+			actor, value, time.Now().UTC().Format(time.RFC3339))
+		if err := ws.dispatcher.RedisClient().Publish(ctx, ch, sig).Err(); err != nil {
+			return "", fmt.Errorf("publish goal-rejected signal: %w", err)
+		}
+		return fmt.Sprintf("🔄 Changes requested for `%s` by @%s", value, actor), nil
+
+	case "ignore_alert", "review_pr", "skip_pr":
+		// Acknowledged — no further action needed.
+		return fmt.Sprintf("👍 Acknowledged by @%s", actor), nil
+
+	default:
+		return fmt.Sprintf("⚠️ Unknown action `%s` by @%s", actionID, actor), nil
+	}
+}
+
+// updateSlackMessage POSTs an updated message to Slack's response_url to replace
+// the original interactive message with an acknowledgement. Fire-and-forget.
+func (ws *WebhookServer) updateSlackMessage(responseURL, text string) {
+	payload, _ := json.Marshal(map[string]interface{}{
+		"replace_original": true,
+		"text":             text,
+	})
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, responseURL, bytes.NewReader(payload))
+	if err != nil {
+		return
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return
+	}
+	resp.Body.Close()
+}
+
+// verifySlackSignature validates a Slack request using the v0 signing scheme:
+//
+//	sig_basestring = "v0:" + timestamp + ":" + body
+//	expected = "v0=" + hex(hmac-sha256(signing_secret, sig_basestring))
+func (ws *WebhookServer) verifySlackSignature(body []byte, timestamp, signature string) bool {
+	if !strings.HasPrefix(signature, "v0=") {
+		return false
+	}
+	sigBytes, err := hex.DecodeString(strings.TrimPrefix(signature, "v0="))
+	if err != nil {
+		return false
+	}
+	mac := hmac.New(sha256.New, ws.slackSigningSecret)
+	fmt.Fprintf(mac, "v0:%s:", timestamp)
+	mac.Write(body)
+	expected := mac.Sum(nil)
+	return hmac.Equal(sigBytes, expected)
 }
 
 func (ws *WebhookServer) parseGitHubEvent(eventType, action, repo string, payload map[string]interface{}) *Event {


### PR DESCRIPTION
## Summary

- **Block Kit interactive messages**: `PostDriverAlert`, `PostPRReadyAlert`, `PostSprintGoalAlert` on the existing `Notifier` — each sends a rich Block Kit message with action buttons ([Pause Squad]/[Merge]/[Accept] etc.) via the existing Slack incoming webhook URL
- **`/slack/actions` endpoint**: Receives Slack interactive action callbacks (button clicks), verifies the Slack v0 HMAC-SHA256 signing secret, and routes actions to either Redis coord signals (`pause_squad`, `accept_goal`, `request_changes`) or direct agent dispatch (`switch_tier`, `merge_pr`); updates the original Slack message via `response_url`
- **`NtfyNotifier`**: Lightweight phone push notifier via ntfy.sh — single HTTP POST, self-hostable, no Apple/Google auth; `PostDriverAlert`, `PostPRReadyAlert`, `PostAllDriversDown` methods; `NtfyPriorityMax` (5) breaks through Do Not Disturb

## Architecture

```
Button clicked in Slack
  → POST /slack/actions (URL-encoded payload=<json>)
    → verifySlackSignature (v0: HMAC-SHA256)
      → routeSlackAction(action_id, value, actor)
        → pause_squad/accept_goal/request_changes → Redis pub/sub coord signal
        → switch_tier/merge_pr → dispatcher.Dispatch(event, agent, priority)
        → ignore_alert/review_pr/skip_pr → ack only
      → updateSlackMessage(response_url, ack) [async, fire-and-forget]
```

## Configuration

| Env var | Purpose |
|---|---|
| `SLACK_WEBHOOK_URL` | Existing webhook URL (sends interactive messages) |
| `SLACK_SIGNING_SECRET` | New — verifies button click authenticity |
| `NTFY_BASE_URL` | e.g. `https://ntfy.sh` or self-hosted |
| `NTFY_TOPIC` | e.g. `agentguard-cto` |

Call `ws.SetSlackSigningSecret([]byte(os.Getenv("SLACK_SIGNING_SECRET")))` in `main.go` after constructing the webhook server.

## Test plan

- [x] All 111 dispatch package tests pass (`go test ./internal/dispatch/`)
- [x] `go vet ./...` clean
- [x] `TestNotifier_PostDriverAlert_ContainsButtons` — verifies pause_squad/switch_tier/ignore_alert in payload
- [x] `TestWebhookServer_SlackActions_BadSignature` — 403 on wrong HMAC
- [x] `TestWebhookServer_SlackActions_NoSignatureCheck_WhenSecretEmpty` — dev-mode passthrough
- [x] `TestVerifySlackSignature` — tampered body and wrong prefix both rejected
- [x] ntfy: priority header omitted at default level, set at non-default levels

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)