### PR TITLE
feat: Slack control plane — interactive buttons for swarm governance (#9)

### DIFF
--- a/cmd/octi-pulpo/main.go
+++ b/cmd/octi-pulpo/main.go
@@ -127,6 +127,10 @@ func main() {
 			if slackURL := os.Getenv("SLACK_WEBHOOK_URL"); slackURL != "" {
 				brain.SetNotifier(dispatch.NewNotifier(slackURL))
 			}
+			if secret := os.Getenv("SLACK_SIGNING_SECRET"); secret != "" {
+				handler := dispatch.NewSlackInteractionHandler(secret, dispatcher, "octi-pulpo-daemon")
+				ws.SetSlackInteractions(handler)
+			}
 			go func() {
 				if err := brain.Run(ctx); err != nil && ctx.Err() == nil {
 					fmt.Fprintf(os.Stderr, "brain: %v\n", err)

--- a/internal/dispatch/brain.go
+++ b/internal/dispatch/brain.go
@@ -274,7 +274,13 @@ func (b *Brain) maybeNotifyConstraintChange(ctx context.Context, constraint Cons
 	nowDown := constraint.Type == "all_drivers_down"
 	if nowDown && !b.driversWereDown {
 		b.driversWereDown = true
-		if err := b.notifier.PostDriversDown(ctx, constraint.Description); err != nil {
+		buttons := []ActionButton{
+			{Text: "Pause Squad", ActionID: "pause_squad", Value: "pause_squad", Style: "danger"},
+			{Text: "Switch Tier", ActionID: "switch_tier", Value: "switch_tier"},
+			{Text: "Ignore",      ActionID: "ignore_alert", Value: "ignore"},
+		}
+		body := constraint.Description + "\nDispatch is paused until at least one driver recovers."
+		if err := b.notifier.PostActionableAlert(ctx, "🚨", "All Drivers Exhausted", body, buttons); err != nil {
 			b.log.Printf("slack drivers-down: %v", err)
 		}
 	} else if !nowDown && b.driversWereDown {

--- a/internal/dispatch/slack.go
+++ b/internal/dispatch/slack.go
@@ -83,6 +83,61 @@ func (n *Notifier) PostDriversRecovered(ctx context.Context) error {
 	return n.post(ctx, map[string]interface{}{"text": "✅ *Drivers Recovered* — dispatch resumed"})
 }
 
+// ActionButton describes a Slack Block Kit interactive button.
+// It is used with PostActionableAlert to add clickable actions to a notification.
+type ActionButton struct {
+	Text     string // visible button label
+	ActionID string // identifier sent back to the /slack/actions endpoint on click
+	Value    string // opaque data payload returned with the callback
+	Style    string // "primary" (green), "danger" (red), or "" (default gray)
+}
+
+// PostActionableAlert sends a Slack Block Kit message with interactive buttons.
+// Unlike PostDriversDown, which sends plain text, this embeds the message as a
+// Block Kit section + actions block — enabling users to act directly from Slack.
+//
+// Requires a Slack App (not just an incoming webhook) to receive button callbacks.
+// Wire up /slack/actions on the WebhookServer to receive action callbacks.
+func (n *Notifier) PostActionableAlert(ctx context.Context, emoji, title, body string, buttons []ActionButton) error {
+	if !n.Enabled() {
+		return nil
+	}
+
+	mdText := fmt.Sprintf("%s *%s*\n%s", emoji, title, body)
+
+	blocks := []map[string]interface{}{
+		{
+			"type": "section",
+			"text": map[string]interface{}{"type": "mrkdwn", "text": mdText},
+		},
+	}
+
+	if len(buttons) > 0 {
+		elements := make([]map[string]interface{}, 0, len(buttons))
+		for _, btn := range buttons {
+			el := map[string]interface{}{
+				"type":      "button",
+				"text":      map[string]interface{}{"type": "plain_text", "text": btn.Text, "emoji": true},
+				"action_id": btn.ActionID,
+				"value":     btn.Value,
+			}
+			if btn.Style != "" {
+				el["style"] = btn.Style
+			}
+			elements = append(elements, el)
+		}
+		blocks = append(blocks, map[string]interface{}{
+			"type":     "actions",
+			"elements": elements,
+		})
+	}
+
+	return n.post(ctx, map[string]interface{}{
+		"text":   mdText, // fallback for clients that don't render Block Kit
+		"blocks": blocks,
+	})
+}
+
 // post marshals the payload and POSTs it to the Slack incoming webhook URL.
 func (n *Notifier) post(ctx context.Context, payload map[string]interface{}) error {
 	body, err := json.Marshal(payload)

--- a/internal/dispatch/slack_interactions.go
+++ b/internal/dispatch/slack_interactions.go
@@ -1,0 +1,183 @@
+package dispatch
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// SlackInteractionHandler processes Slack interactive component callbacks.
+//
+// When a user clicks a button embedded in a Slack Block Kit message, Slack
+// POSTs to the /slack/actions endpoint as application/x-www-form-urlencoded
+// with a "payload" field containing the action JSON.
+//
+// This handler verifies the X-Slack-Signature, parses the block_actions
+// payload, and converts the button's action_id into a coord signal or
+// dispatch event so the swarm can react without the CTO lifting a finger.
+type SlackInteractionHandler struct {
+	signingSecret []byte
+	dispatcher    *Dispatcher
+	agentID       string
+}
+
+// NewSlackInteractionHandler creates a handler for Slack button callbacks.
+// signingSecret is read from SLACK_SIGNING_SECRET and used to verify the
+// X-Slack-Signature header. agentID is the identity used when broadcasting
+// coord signals (e.g. "octi-pulpo-daemon").
+func NewSlackInteractionHandler(signingSecret string, dispatcher *Dispatcher, agentID string) *SlackInteractionHandler {
+	return &SlackInteractionHandler{
+		signingSecret: []byte(signingSecret),
+		dispatcher:    dispatcher,
+		agentID:       agentID,
+	}
+}
+
+// slackActionPayload is the minimal subset of the Slack block_actions payload.
+type slackActionPayload struct {
+	Type string `json:"type"`
+	User struct {
+		ID       string `json:"id"`
+		Username string `json:"username"`
+	} `json:"user"`
+	Actions []struct {
+		ActionID string `json:"action_id"`
+		Value    string `json:"value"`
+	} `json:"actions"`
+}
+
+// verifySlackSignature validates X-Slack-Signature against the request body.
+//
+// Slack signs requests as: HMAC-SHA256("v0:<timestamp>:<body>") → "v0=<hex>"
+// Requests older than 5 minutes are rejected to prevent replay attacks.
+// If no signing secret is configured, all requests are accepted (dev mode).
+func (h *SlackInteractionHandler) verifySlackSignature(timestamp string, body []byte, sig string) bool {
+	if len(h.signingSecret) == 0 {
+		return true // no secret — dev/test mode
+	}
+
+	ts, err := strconv.ParseInt(timestamp, 10, 64)
+	if err != nil {
+		return false
+	}
+	age := time.Since(time.Unix(ts, 0))
+	if age > 5*time.Minute || age < -time.Minute {
+		return false // stale or future-dated: replay attempt
+	}
+
+	if !strings.HasPrefix(sig, "v0=") {
+		return false
+	}
+	sigBytes, err := hex.DecodeString(strings.TrimPrefix(sig, "v0="))
+	if err != nil {
+		return false
+	}
+
+	mac := hmac.New(sha256.New, h.signingSecret)
+	fmt.Fprintf(mac, "v0:%s:", timestamp)
+	mac.Write(body)
+	return hmac.Equal(mac.Sum(nil), sigBytes)
+}
+
+// Handle processes one Slack interactive callback (button click).
+// It reads the request body, verifies the signature, and routes the action.
+// Returns a human-readable confirmation string for the ephemeral Slack response.
+func (h *SlackInteractionHandler) Handle(ctx context.Context, r *http.Request) (string, error) {
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		return "", fmt.Errorf("read body: %w", err)
+	}
+
+	ts := r.Header.Get("X-Slack-Request-Timestamp")
+	sig := r.Header.Get("X-Slack-Signature")
+	if !h.verifySlackSignature(ts, body, sig) {
+		return "", fmt.Errorf("invalid slack signature")
+	}
+
+	// Slack encodes the payload as URL form data: payload=<JSON>
+	form, err := url.ParseQuery(string(body))
+	if err != nil {
+		return "", fmt.Errorf("parse form: %w", err)
+	}
+	raw := form.Get("payload")
+	if raw == "" {
+		return "", fmt.Errorf("missing payload field")
+	}
+
+	var p slackActionPayload
+	if err := json.Unmarshal([]byte(raw), &p); err != nil {
+		return "", fmt.Errorf("unmarshal payload: %w", err)
+	}
+
+	if p.Type != "block_actions" || len(p.Actions) == 0 {
+		return "ok", nil // not a button click — silently ACK
+	}
+
+	username := p.User.Username
+	if username == "" {
+		username = p.User.ID
+	}
+
+	action := p.Actions[0]
+	return h.dispatchAction(ctx, action.ActionID, action.Value, username)
+}
+
+// dispatchAction converts an action_id into a coord signal or dispatch event.
+// Returns a human-readable confirmation for the ephemeral Slack response.
+//
+// Known action_ids:
+//   - pause_squad    → broadcasts "directive: pause-squad" coord signal
+//   - switch_tier    → broadcasts "directive: switch-tier" coord signal
+//   - merge_pr       → dispatches EventSlackAction for the PR merger agent
+//   - ignore_alert   → ACK only, no swarm action
+//   - <anything>     → broadcasts a generic "directive: slack-action:<id>" signal
+func (h *SlackInteractionHandler) dispatchAction(ctx context.Context, actionID, value, username string) (string, error) {
+	coord := h.dispatcher.Coord()
+
+	switch actionID {
+	case "pause_squad":
+		payload := fmt.Sprintf("pause-squad triggered by %s", username)
+		if err := coord.Broadcast(ctx, h.agentID, "directive", payload); err != nil {
+			return "", fmt.Errorf("broadcast pause-squad: %w", err)
+		}
+		return fmt.Sprintf("✅ Pause-squad directive broadcast by @%s", username), nil
+
+	case "switch_tier":
+		payload := fmt.Sprintf("switch-tier triggered by %s", username)
+		if err := coord.Broadcast(ctx, h.agentID, "directive", payload); err != nil {
+			return "", fmt.Errorf("broadcast switch-tier: %w", err)
+		}
+		return fmt.Sprintf("✅ Switch-tier directive broadcast by @%s", username), nil
+
+	case "merge_pr":
+		event := Event{
+			Type:     EventSlackAction,
+			Source:   "slack",
+			Priority: 0,
+			Payload:  map[string]string{"action": "merge_pr", "value": value, "by": username},
+		}
+		if _, err := h.dispatcher.DispatchEvent(ctx, event); err != nil {
+			return "", fmt.Errorf("dispatch merge_pr: %w", err)
+		}
+		return fmt.Sprintf("✅ PR merge dispatched by @%s", username), nil
+
+	case "ignore_alert":
+		return fmt.Sprintf("🙈 Alert acknowledged by @%s", username), nil
+
+	default:
+		payload := fmt.Sprintf("slack-action:%s value:%s by:%s", actionID, value, username)
+		if err := coord.Broadcast(ctx, h.agentID, "directive", payload); err != nil {
+			return "", fmt.Errorf("broadcast action: %w", err)
+		}
+		return fmt.Sprintf("✅ Action *%s* dispatched by @%s", actionID, username), nil
+	}
+}

--- a/internal/dispatch/slack_test.go
+++ b/internal/dispatch/slack_test.go
@@ -2,12 +2,19 @@ package dispatch
 
 import (
 	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
+	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/AgentGuardHQ/octi-pulpo/internal/routing"
 )
@@ -183,7 +190,7 @@ func TestBrain_MaybeNotifyConstraintChange_EdgeTriggered(t *testing.T) {
 	downConstraint := Constraint{Type: "all_drivers_down", Description: "all down", Severity: 0}
 	noneConstraint := Constraint{Type: "none", Description: "healthy", Severity: 2}
 
-	// First down transition: should fire PostDriversDown
+	// First down transition: should fire PostActionableAlert (replaces PostDriversDown)
 	brain.maybeNotifyConstraintChange(ctx, downConstraint)
 	if callCount != 1 {
 		t.Fatalf("expected 1 Slack call on first down transition, got %d", callCount)
@@ -205,5 +212,299 @@ func TestBrain_MaybeNotifyConstraintChange_EdgeTriggered(t *testing.T) {
 	brain.maybeNotifyConstraintChange(ctx, noneConstraint)
 	if callCount != 2 {
 		t.Fatalf("expected no additional Slack call when still healthy, got %d", callCount)
+	}
+}
+
+// ── PostActionableAlert tests ─────────────────────────────────────────────────
+
+func TestNotifier_PostActionableAlert_NoopWhenDisabled(t *testing.T) {
+	n := NewNotifier("")
+	err := n.PostActionableAlert(context.Background(), "🚨", "Title", "body", []ActionButton{
+		{Text: "OK", ActionID: "ok", Value: "ok"},
+	})
+	if err != nil {
+		t.Fatalf("expected no-op, got: %v", err)
+	}
+}
+
+func TestNotifier_PostActionableAlert_BlockKitStructure(t *testing.T) {
+	var received []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		received, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	n := NewNotifier(srv.URL)
+	buttons := []ActionButton{
+		{Text: "Pause Squad", ActionID: "pause_squad", Value: "pause_squad", Style: "danger"},
+		{Text: "Switch Tier", ActionID: "switch_tier", Value: "switch_tier"},
+		{Text: "Ignore", ActionID: "ignore_alert", Value: "ignore"},
+	}
+
+	if err := n.PostActionableAlert(context.Background(), "🚨", "All Drivers Exhausted", "all OPEN", buttons); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var payload map[string]interface{}
+	if err := json.Unmarshal(received, &payload); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+
+	// Must have both "text" fallback and "blocks"
+	if _, ok := payload["text"]; !ok {
+		t.Error("expected 'text' fallback key")
+	}
+	blocks, ok := payload["blocks"].([]interface{})
+	if !ok || len(blocks) < 2 {
+		t.Fatalf("expected at least 2 blocks (section + actions), got: %v", payload["blocks"])
+	}
+
+	// First block must be a section with mrkdwn
+	section := blocks[0].(map[string]interface{})
+	if section["type"] != "section" {
+		t.Errorf("expected section block, got: %v", section["type"])
+	}
+
+	// Second block must be actions with our 3 buttons
+	actions := blocks[1].(map[string]interface{})
+	if actions["type"] != "actions" {
+		t.Errorf("expected actions block, got: %v", actions["type"])
+	}
+	elements, ok := actions["elements"].([]interface{})
+	if !ok || len(elements) != 3 {
+		t.Fatalf("expected 3 button elements, got %d", len(elements))
+	}
+
+	// Verify danger style on first button
+	first := elements[0].(map[string]interface{})
+	if first["style"] != "danger" {
+		t.Errorf("expected danger style on first button, got: %v", first["style"])
+	}
+	if first["action_id"] != "pause_squad" {
+		t.Errorf("expected action_id=pause_squad, got: %v", first["action_id"])
+	}
+}
+
+func TestNotifier_PostActionableAlert_NoButtons(t *testing.T) {
+	var received []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		received, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	n := NewNotifier(srv.URL)
+	if err := n.PostActionableAlert(context.Background(), "🟢", "All Clear", "systems nominal", nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var payload map[string]interface{}
+	if err := json.Unmarshal(received, &payload); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+
+	blocks := payload["blocks"].([]interface{})
+	if len(blocks) != 1 {
+		t.Errorf("expected 1 block (section only, no actions), got %d", len(blocks))
+	}
+}
+
+// ── SlackInteractionHandler signature verification ────────────────────────────
+
+// makeSlackSig builds a valid X-Slack-Signature for testing.
+func makeSlackSig(secret, timestamp string, body []byte) string {
+	mac := hmac.New(sha256.New, []byte(secret))
+	fmt.Fprintf(mac, "v0:%s:", timestamp)
+	mac.Write(body)
+	return "v0=" + hex.EncodeToString(mac.Sum(nil))
+}
+
+func TestSlackInteractionHandler_VerifySignature_Valid(t *testing.T) {
+	secret := "test-secret"
+	h := NewSlackInteractionHandler(secret, nil, "")
+	body := []byte("payload=hello")
+	ts := strconv.FormatInt(time.Now().Unix(), 10)
+	sig := makeSlackSig(secret, ts, body)
+
+	if !h.verifySlackSignature(ts, body, sig) {
+		t.Fatal("expected valid signature to pass")
+	}
+}
+
+func TestSlackInteractionHandler_VerifySignature_WrongSecret(t *testing.T) {
+	h := NewSlackInteractionHandler("correct-secret", nil, "")
+	body := []byte("payload=hello")
+	ts := strconv.FormatInt(time.Now().Unix(), 10)
+	sig := makeSlackSig("wrong-secret", ts, body)
+
+	if h.verifySlackSignature(ts, body, sig) {
+		t.Fatal("expected wrong secret to fail")
+	}
+}
+
+func TestSlackInteractionHandler_VerifySignature_StaleTimestamp(t *testing.T) {
+	secret := "test-secret"
+	h := NewSlackInteractionHandler(secret, nil, "")
+	body := []byte("payload=hello")
+	staleTS := strconv.FormatInt(time.Now().Add(-10*time.Minute).Unix(), 10)
+	sig := makeSlackSig(secret, staleTS, body)
+
+	if h.verifySlackSignature(staleTS, body, sig) {
+		t.Fatal("expected stale timestamp to fail")
+	}
+}
+
+func TestSlackInteractionHandler_VerifySignature_NoSecret_DevMode(t *testing.T) {
+	h := NewSlackInteractionHandler("", nil, "") // no secret = dev mode
+	// Any signature should pass
+	if !h.verifySlackSignature("", []byte("body"), "garbage") {
+		t.Fatal("expected dev mode (no secret) to accept any signature")
+	}
+}
+
+// ── SlackInteractionHandler.Handle tests ─────────────────────────────────────
+
+func makeSlackRequest(t *testing.T, secret string, actionID, value, username string) *http.Request {
+	t.Helper()
+
+	p := map[string]interface{}{
+		"type": "block_actions",
+		"user": map[string]string{"id": "U001", "username": username},
+		"actions": []map[string]string{
+			{"action_id": actionID, "value": value},
+		},
+	}
+	payloadJSON, _ := json.Marshal(p)
+	body := url.Values{"payload": {string(payloadJSON)}}.Encode()
+
+	ts := strconv.FormatInt(time.Now().Unix(), 10)
+	sig := makeSlackSig(secret, ts, []byte(body))
+
+	req := httptest.NewRequest(http.MethodPost, "/slack/actions", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("X-Slack-Request-Timestamp", ts)
+	req.Header.Set("X-Slack-Signature", sig)
+	return req
+}
+
+func TestSlackInteractionHandler_IgnoreAlert(t *testing.T) {
+	d, ctx := testSetup(t)
+	h := NewSlackInteractionHandler("", d, "test-agent") // no secret — dev mode
+
+	req := makeSlackRequest(t, "", "ignore_alert", "ignore", "jared")
+	msg, err := h.Handle(ctx, req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(msg, "acknowledged") {
+		t.Errorf("expected acknowledgement message, got: %s", msg)
+	}
+}
+
+func TestSlackInteractionHandler_PauseSquad(t *testing.T) {
+	d, ctx := testSetup(t)
+	h := NewSlackInteractionHandler("", d, "test-agent")
+
+	req := makeSlackRequest(t, "", "pause_squad", "pause_squad", "jared")
+	msg, err := h.Handle(ctx, req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(msg, "Pause-squad") {
+		t.Errorf("expected pause-squad confirmation, got: %s", msg)
+	}
+}
+
+func TestSlackInteractionHandler_InvalidSignature(t *testing.T) {
+	d, ctx := testSetup(t)
+	h := NewSlackInteractionHandler("real-secret", d, "test-agent")
+
+	req := makeSlackRequest(t, "wrong-secret", "ignore_alert", "ignore", "jared")
+	_, err := h.Handle(ctx, req)
+	if err == nil || !strings.Contains(err.Error(), "invalid slack signature") {
+		t.Fatalf("expected signature error, got: %v", err)
+	}
+}
+
+func TestSlackInteractionHandler_NonActionEvent(t *testing.T) {
+	d, ctx := testSetup(t)
+	h := NewSlackInteractionHandler("", d, "test-agent")
+
+	// A non-block_actions type should ACK silently
+	p := map[string]interface{}{"type": "shortcut"}
+	payloadJSON, _ := json.Marshal(p)
+	body := url.Values{"payload": {string(payloadJSON)}}.Encode()
+
+	ts := strconv.FormatInt(time.Now().Unix(), 10)
+	req := httptest.NewRequest(http.MethodPost, "/slack/actions", strings.NewReader(body))
+	req.Header.Set("X-Slack-Request-Timestamp", ts)
+	req.Header.Set("X-Slack-Signature", makeSlackSig("", ts, []byte(body)))
+
+	msg, err := h.Handle(ctx, req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if msg != "ok" {
+		t.Errorf("expected 'ok' for non-action event, got: %s", msg)
+	}
+}
+
+// ── WebhookServer /slack/actions endpoint ────────────────────────────────────
+
+func TestWebhookServer_SlackActions_MethodNotAllowed(t *testing.T) {
+	d, _ := testSetup(t)
+	ws := NewWebhookServer(d, "")
+	ws.SetSlackInteractions(NewSlackInteractionHandler("", d, "test"))
+
+	req := httptest.NewRequest(http.MethodGet, "/slack/actions", nil)
+	w := httptest.NewRecorder()
+	ws.ServeHTTP(w, req)
+
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Errorf("expected 405, got %d", w.Code)
+	}
+}
+
+func TestWebhookServer_SlackActions_NotConfigured(t *testing.T) {
+	d, _ := testSetup(t)
+	ws := NewWebhookServer(d, "") // no SetSlackInteractions called — but route isn't registered
+
+	// POST to /slack/actions without SetSlackInteractions returns 404 (route not registered)
+	req := httptest.NewRequest(http.MethodPost, "/slack/actions", nil)
+	w := httptest.NewRecorder()
+	ws.ServeHTTP(w, req)
+
+	// Route not registered → 404
+	if w.Code != http.StatusNotFound {
+		t.Errorf("expected 404 when route not registered, got %d", w.Code)
+	}
+}
+
+func TestWebhookServer_SlackActions_IgnoreAlert(t *testing.T) {
+	d, ctx := testSetup(t)
+	_ = ctx
+	ws := NewWebhookServer(d, "")
+	ws.SetSlackInteractions(NewSlackInteractionHandler("", d, "test"))
+
+	req := makeSlackRequest(t, "", "ignore_alert", "ignore", "jared")
+	req.URL.Path = "/slack/actions"
+	w := httptest.NewRecorder()
+	ws.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp map[string]interface{}
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("invalid JSON response: %v", err)
+	}
+	if resp["response_type"] != "ephemeral" {
+		t.Errorf("expected ephemeral response, got: %v", resp["response_type"])
+	}
+	text, _ := resp["text"].(string)
+	if !strings.Contains(text, "acknowledged") {
+		t.Errorf("expected acknowledgement in response text, got: %s", text)
 	}
 }

--- a/internal/dispatch/webhook.go
+++ b/internal/dispatch/webhook.go
@@ -17,14 +17,16 @@ import (
 	"github.com/AgentGuardHQ/octi-pulpo/internal/sprint"
 )
 
-// WebhookServer is a lightweight HTTP server for receiving GitHub webhooks.
+// WebhookServer is a lightweight HTTP server for receiving GitHub webhooks
+// and Slack interactive component callbacks.
 // It replaces webhook-listener.py with coordinated dispatch.
 type WebhookServer struct {
-	dispatcher  *Dispatcher
-	secret      []byte
-	mux         *http.ServeMux
-	sprintStore *sprint.Store
-	benchmark   *BenchmarkTracker
+	dispatcher   *Dispatcher
+	secret       []byte
+	mux          *http.ServeMux
+	sprintStore  *sprint.Store
+	benchmark    *BenchmarkTracker
+	slackActions *SlackInteractionHandler
 }
 
 // NewWebhookServer creates a webhook handler backed by the dispatcher.
@@ -64,6 +66,14 @@ func (ws *WebhookServer) SetSprintStore(s *sprint.Store) {
 // SetBenchmark enables benchmark HTTP endpoints.
 func (ws *WebhookServer) SetBenchmark(bt *BenchmarkTracker) {
 	ws.benchmark = bt
+}
+
+// SetSlackInteractions enables the /slack/actions endpoint for handling
+// Slack button callbacks. Call this after creating the WebhookServer when
+// SLACK_SIGNING_SECRET is available.
+func (ws *WebhookServer) SetSlackInteractions(handler *SlackInteractionHandler) {
+	ws.slackActions = handler
+	ws.mux.HandleFunc("/slack/actions", ws.handleSlackActions)
 }
 
 // ServeHTTP implements the http.Handler interface.
@@ -358,6 +368,36 @@ func (ws *WebhookServer) parseGitHubEvent(eventType, action, repo string, payloa
 	}
 
 	return nil // unrecognized event
+}
+
+// handleSlackActions handles POST /slack/actions — Slack interactive component callbacks.
+// Slack sends a URL-encoded form body with a "payload" field when a user clicks a button.
+// The handler verifies the X-Slack-Signature, dispatches the action, and returns an
+// ephemeral message confirming the action to the user in Slack.
+func (ws *WebhookServer) handleSlackActions(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if ws.slackActions == nil {
+		http.Error(w, "slack interactions not configured", http.StatusServiceUnavailable)
+		return
+	}
+
+	ctx := context.Background()
+	msg, err := ws.slackActions.Handle(ctx, r)
+	if err != nil {
+		// Log the real error but don't leak internals to Slack
+		fmt.Fprintf(os.Stderr, "slack action error: %v\n", err)
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"response_type": "ephemeral",
+		"text":          msg,
+	})
 }
 
 func (ws *WebhookServer) verifySignature(payload []byte, signature string) bool {


### PR DESCRIPTION
## Summary

- **Block Kit alerts with buttons**: `PostActionableAlert` replaces plain-text `PostDriversDown` for the all-drivers-exhausted case. CTO now sees `[Pause Squad] [Switch Tier] [Ignore]` buttons directly in Slack instead of a read-only ping.
- **Slack interaction handler**: new `SlackInteractionHandler` in `slack_interactions.go` — verifies `X-Slack-Signature` (HMAC-SHA256, 5-min replay window), parses `block_actions` payload, and converts button `action_id` to `coord.Broadcast` signals or `EventSlackAction` dispatches.
- **`/slack/actions` HTTP endpoint**: `WebhookServer.SetSlackInteractions(handler)` registers the endpoint. Wire `SLACK_SIGNING_SECRET` env var in the daemon to enable it.
- **Wired in `main.go`**: when `SLACK_SIGNING_SECRET` is set, the daemon registers the interaction endpoint automatically.

## Architecture

```
Brain tick → all_drivers_down → PostActionableAlert (Block Kit + buttons)
                                         │
                              Slack delivers message to channel
                                         │
                              CTO clicks [Pause Squad]
                                         │
                              POST /slack/actions (signed by Slack)
                                         │
                              SlackInteractionHandler.Handle()
                                  ├── verify X-Slack-Signature
                                  ├── parse block_actions payload
                                  └── coord.Broadcast("directive", "pause-squad triggered by @jared")
                                         │
                              All agents listening on Redis pub/sub receive directive
```

## Setup

Configure these env vars on the daemon:

| Var | Purpose |
|-----|---------|
| `SLACK_WEBHOOK_URL` | Outbound: post messages to channel (existing) |
| `SLACK_SIGNING_SECRET` | Inbound: verify Slack button callbacks (new) |

In Slack App settings → **Interactivity & Shortcuts** → set Request URL to `https://<octi-pulpo-host>/slack/actions`.

## Test plan

- [x] `TestNotifier_PostActionableAlert_BlockKitStructure` — verifies sections/actions block layout and danger style
- [x] `TestNotifier_PostActionableAlert_NoButtons` — section-only fallback (no actions block appended)
- [x] `TestSlackInteractionHandler_VerifySignature_*` — valid, wrong secret, stale (>5 min), dev mode (no secret)
- [x] `TestSlackInteractionHandler_IgnoreAlert` — ACK with no coord signal
- [x] `TestSlackInteractionHandler_PauseSquad` — broadcasts pause-squad directive
- [x] `TestSlackInteractionHandler_InvalidSignature` — rejects tampered requests
- [x] `TestWebhookServer_SlackActions_*` — method not allowed, route not registered (404), full happy-path ACK
- [x] `TestBrain_MaybeNotifyConstraintChange_EdgeTriggered` — still passes (edge semantics unchanged)
- [x] `go build ./...` and `go vet ./...` — clean
- [x] 104 dispatch package tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)