### PR TITLE
feat: cross-squad request routing — request_work, check_requests, fulfill_request MCP tools

### DIFF
--- a/cmd/octi-pulpo/main.go
+++ b/cmd/octi-pulpo/main.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 
 	"github.com/AgentGuardHQ/octi-pulpo/internal/coordination"
+	"github.com/AgentGuardHQ/octi-pulpo/internal/crosssquad"
 	"github.com/AgentGuardHQ/octi-pulpo/internal/dispatch"
 	"github.com/AgentGuardHQ/octi-pulpo/internal/mcp"
 	"github.com/AgentGuardHQ/octi-pulpo/internal/memory"
@@ -83,11 +84,14 @@ func main() {
 	// Set up benchmark tracker
 	benchmark := dispatch.NewBenchmarkTracker(rdb, namespace)
 
+	requestStore := crosssquad.New(rdb, namespace)
+
 	server := mcp.New(mem, coord, router)
 	server.SetDispatcher(dispatcher)
 	server.SetSprintStore(sprintStore)
 	server.SetBenchmark(benchmark)
 	server.SetProfileStore(profiles)
+	server.SetRequestStore(requestStore)
 
 	// Optional HTTP mode: run webhook server alongside MCP
 	httpPort := os.Getenv("OCTI_HTTP_PORT")

--- a/internal/crosssquad/requests.go
+++ b/internal/crosssquad/requests.go
@@ -1,0 +1,143 @@
+package crosssquad
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+const requestTTL = 24 * time.Hour
+
+// Request is a cross-squad work request submitted by one agent to another squad.
+type Request struct {
+	ID              string `json:"id"`
+	FromAgent       string `json:"from_agent"`
+	ToSquad         string `json:"to_squad"`
+	Type            string `json:"type"`                      // report, query, review, fix, deploy
+	Description     string `json:"description"`
+	Priority        int    `json:"priority"`                  // 0=urgent, 1=high, 2=normal
+	DeadlineMinutes int    `json:"deadline_minutes,omitempty"`
+	Status          string `json:"status"`                    // pending, fulfilled
+	CreatedAt       string `json:"created_at"`
+	UpdatedAt       string `json:"updated_at"`
+	FulfilledBy     string `json:"fulfilled_by,omitempty"`
+	Result          string `json:"result,omitempty"`
+	PRNumber        int    `json:"pr_number,omitempty"`
+	AgeMinutes      int    `json:"age_minutes,omitempty"` // computed at read time, not stored
+}
+
+// Store manages cross-squad work requests in Redis.
+type Store struct {
+	rdb *redis.Client
+	ns  string
+}
+
+// New creates a cross-squad request store backed by the given Redis client.
+func New(rdb *redis.Client, namespace string) *Store {
+	return &Store{rdb: rdb, ns: namespace}
+}
+
+// Submit creates a new cross-squad work request and enqueues it for the target squad.
+// Score in the pending sorted set encodes urgency: priority*1e9 + unix_seconds
+// so P0 (urgent) sorts before P1 (high) before P2 (normal), FIFO within the same priority.
+func (s *Store) Submit(ctx context.Context, fromAgent, toSquad, reqType, description string, priority, deadlineMinutes int) (*Request, error) {
+	req := &Request{
+		ID:              fmt.Sprintf("req-%s-%d", fromAgent, time.Now().UnixMilli()),
+		FromAgent:       fromAgent,
+		ToSquad:         toSquad,
+		Type:            reqType,
+		Description:     description,
+		Priority:        priority,
+		DeadlineMinutes: deadlineMinutes,
+		Status:          "pending",
+		CreatedAt:       time.Now().UTC().Format(time.RFC3339),
+		UpdatedAt:       time.Now().UTC().Format(time.RFC3339),
+	}
+
+	data, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("marshal request: %w", err)
+	}
+
+	score := float64(priority)*1e9 + float64(time.Now().Unix())
+
+	pipe := s.rdb.Pipeline()
+	pipe.Set(ctx, s.key("request:"+req.ID), data, requestTTL)
+	pipe.ZAdd(ctx, s.key("requests:pending:"+toSquad), redis.Z{Score: score, Member: req.ID})
+	if _, err = pipe.Exec(ctx); err != nil {
+		return nil, fmt.Errorf("store request: %w", err)
+	}
+
+	return req, nil
+}
+
+// Pending returns all pending requests for a squad, sorted urgent-first.
+// Requests whose TTL has expired are silently pruned from the index.
+func (s *Store) Pending(ctx context.Context, toSquad string) ([]Request, error) {
+	ids, err := s.rdb.ZRange(ctx, s.key("requests:pending:"+toSquad), 0, -1).Result()
+	if err != nil {
+		return nil, fmt.Errorf("list pending requests: %w", err)
+	}
+
+	now := time.Now()
+	var requests []Request
+	for _, id := range ids {
+		data, err := s.rdb.Get(ctx, s.key("request:"+id)).Bytes()
+		if err != nil {
+			// TTL expired — prune stale index entry.
+			s.rdb.ZRem(ctx, s.key("requests:pending:"+toSquad), id) //nolint:errcheck
+			continue
+		}
+		var req Request
+		if err := json.Unmarshal(data, &req); err != nil {
+			continue
+		}
+		if t, err := time.Parse(time.RFC3339, req.CreatedAt); err == nil {
+			req.AgeMinutes = int(now.Sub(t).Minutes())
+		}
+		requests = append(requests, req)
+	}
+	return requests, nil
+}
+
+// Fulfill marks a request as fulfilled, records the result, and removes it from the
+// pending index. The fulfilled record is retained for 1 hour for audit purposes.
+func (s *Store) Fulfill(ctx context.Context, requestID, fulfilledBy, result string, prNumber int) (*Request, error) {
+	data, err := s.rdb.Get(ctx, s.key("request:"+requestID)).Bytes()
+	if err != nil {
+		return nil, fmt.Errorf("request not found: %s", requestID)
+	}
+	var req Request
+	if err := json.Unmarshal(data, &req); err != nil {
+		return nil, fmt.Errorf("unmarshal request: %w", err)
+	}
+
+	req.Status = "fulfilled"
+	req.FulfilledBy = fulfilledBy
+	req.Result = result
+	req.PRNumber = prNumber
+	req.UpdatedAt = time.Now().UTC().Format(time.RFC3339)
+	// Clear computed field before storing.
+	req.AgeMinutes = 0
+
+	updated, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("marshal updated request: %w", err)
+	}
+
+	pipe := s.rdb.Pipeline()
+	pipe.Set(ctx, s.key("request:"+requestID), updated, time.Hour)
+	pipe.ZRem(ctx, s.key("requests:pending:"+req.ToSquad), requestID)
+	if _, err = pipe.Exec(ctx); err != nil {
+		return nil, fmt.Errorf("fulfill request: %w", err)
+	}
+
+	return &req, nil
+}
+
+func (s *Store) key(suffix string) string {
+	return s.ns + ":" + suffix
+}

--- a/internal/crosssquad/requests_test.go
+++ b/internal/crosssquad/requests_test.go
@@ -1,0 +1,151 @@
+package crosssquad
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/redis/go-redis/v9"
+)
+
+func testStore(t *testing.T) (*Store, context.Context) {
+	t.Helper()
+
+	redisURL := os.Getenv("OCTI_REDIS_URL")
+	if redisURL == "" {
+		redisURL = "redis://localhost:6379"
+	}
+
+	opts, err := redis.ParseURL(redisURL)
+	if err != nil {
+		t.Skipf("skipping: cannot parse redis URL: %v", err)
+	}
+	rdb := redis.NewClient(opts)
+
+	ctx := context.Background()
+	if err := rdb.Ping(ctx).Err(); err != nil {
+		t.Skipf("skipping: redis not available: %v", err)
+	}
+
+	ns := "octi-test-" + t.Name()
+	cleanup := func() {
+		keys, _ := rdb.Keys(ctx, ns+":*").Result()
+		if len(keys) > 0 {
+			rdb.Del(ctx, keys...)
+		}
+	}
+	cleanup()
+	t.Cleanup(func() {
+		cleanup()
+		rdb.Close()
+	})
+
+	return New(rdb, ns), ctx
+}
+
+func TestSubmit_StoresPendingRequest(t *testing.T) {
+	store, ctx := testStore(t)
+
+	req, err := store.Submit(ctx, "marketing-em", "analytics", "report", "Need PR velocity report for LinkedIn", 1, 60)
+	if err != nil {
+		t.Fatalf("submit: %v", err)
+	}
+
+	if req.ID == "" {
+		t.Fatal("expected non-empty request ID")
+	}
+	if req.Status != "pending" {
+		t.Fatalf("expected status=pending, got %s", req.Status)
+	}
+	if req.FromAgent != "marketing-em" {
+		t.Fatalf("expected from_agent=marketing-em, got %s", req.FromAgent)
+	}
+	if req.ToSquad != "analytics" {
+		t.Fatalf("expected to_squad=analytics, got %s", req.ToSquad)
+	}
+}
+
+func TestPending_ReturnsPriorityOrdered(t *testing.T) {
+	store, ctx := testStore(t)
+
+	// Submit in reverse priority order: normal first, then urgent.
+	_, err := store.Submit(ctx, "agent-a", "analytics", "report", "normal task", 2, 0)
+	if err != nil {
+		t.Fatalf("submit normal: %v", err)
+	}
+	_, err = store.Submit(ctx, "agent-b", "analytics", "query", "urgent task", 0, 10)
+	if err != nil {
+		t.Fatalf("submit urgent: %v", err)
+	}
+
+	requests, err := store.Pending(ctx, "analytics")
+	if err != nil {
+		t.Fatalf("pending: %v", err)
+	}
+	if len(requests) != 2 {
+		t.Fatalf("expected 2 requests, got %d", len(requests))
+	}
+	// Urgent (priority 0) must sort before normal (priority 2).
+	if requests[0].Priority != 0 {
+		t.Fatalf("expected first request to be urgent (priority 0), got priority %d", requests[0].Priority)
+	}
+	if requests[1].Priority != 2 {
+		t.Fatalf("expected second request to be normal (priority 2), got priority %d", requests[1].Priority)
+	}
+}
+
+func TestPending_EmptySquad(t *testing.T) {
+	store, ctx := testStore(t)
+
+	requests, err := store.Pending(ctx, "no-such-squad")
+	if err != nil {
+		t.Fatalf("pending: %v", err)
+	}
+	if len(requests) != 0 {
+		t.Fatalf("expected 0 requests, got %d", len(requests))
+	}
+}
+
+func TestFulfill_MarksRequestFulfilled(t *testing.T) {
+	store, ctx := testStore(t)
+
+	req, err := store.Submit(ctx, "kernel-sr", "analytics", "query", "What is the P99 latency for /api/health?", 1, 0)
+	if err != nil {
+		t.Fatalf("submit: %v", err)
+	}
+
+	fulfilled, err := store.Fulfill(ctx, req.ID, "analytics-sr", "P99 latency is 42ms. See report at reports/latency-2026-03-29.md", 1415)
+	if err != nil {
+		t.Fatalf("fulfill: %v", err)
+	}
+
+	if fulfilled.Status != "fulfilled" {
+		t.Fatalf("expected status=fulfilled, got %s", fulfilled.Status)
+	}
+	if fulfilled.FulfilledBy != "analytics-sr" {
+		t.Fatalf("expected fulfilled_by=analytics-sr, got %s", fulfilled.FulfilledBy)
+	}
+	if fulfilled.PRNumber != 1415 {
+		t.Fatalf("expected pr_number=1415, got %d", fulfilled.PRNumber)
+	}
+
+	// Request should no longer appear in pending list.
+	pending, err := store.Pending(ctx, "analytics")
+	if err != nil {
+		t.Fatalf("pending after fulfill: %v", err)
+	}
+	for _, r := range pending {
+		if r.ID == req.ID {
+			t.Fatalf("fulfilled request still appears in pending list")
+		}
+	}
+}
+
+func TestFulfill_UnknownRequestReturnsError(t *testing.T) {
+	store, ctx := testStore(t)
+
+	_, err := store.Fulfill(ctx, "req-does-not-exist", "some-agent", "done", 0)
+	if err == nil {
+		t.Fatal("expected error for unknown request ID, got nil")
+	}
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/AgentGuardHQ/octi-pulpo/internal/coordination"
+	"github.com/AgentGuardHQ/octi-pulpo/internal/crosssquad"
 	"github.com/AgentGuardHQ/octi-pulpo/internal/dispatch"
 	"github.com/AgentGuardHQ/octi-pulpo/internal/memory"
 	"github.com/AgentGuardHQ/octi-pulpo/internal/routing"
@@ -47,13 +48,14 @@ type RPCError struct {
 
 // Server is the Octi Pulpo MCP server.
 type Server struct {
-	mem         *memory.Store
-	coord       *coordination.Engine
-	router      *routing.Router
-	dispatcher  *dispatch.Dispatcher
-	sprintStore *sprint.Store
-	benchmark   *dispatch.BenchmarkTracker
-	profiles    *dispatch.ProfileStore
+	mem          *memory.Store
+	coord        *coordination.Engine
+	router       *routing.Router
+	dispatcher   *dispatch.Dispatcher
+	sprintStore  *sprint.Store
+	benchmark    *dispatch.BenchmarkTracker
+	profiles     *dispatch.ProfileStore
+	requestStore *crosssquad.Store
 }
 
 // New creates an MCP server backed by the given memory and coordination engines.
@@ -79,6 +81,11 @@ func (s *Server) SetBenchmark(bt *dispatch.BenchmarkTracker) {
 // SetProfileStore enables the agent leaderboard MCP tool.
 func (s *Server) SetProfileStore(ps *dispatch.ProfileStore) {
 	s.profiles = ps
+}
+
+// SetRequestStore enables cross-squad request routing MCP tools.
+func (s *Server) SetRequestStore(rs *crosssquad.Store) {
+	s.requestStore = rs
 }
 
 // Serve runs the MCP server on stdio (stdin/stdout JSON-RPC).
@@ -368,6 +375,87 @@ func (s *Server) handleToolCall(req Request) Response {
 		}
 		return textResult(req.ID, dispatch.FormatLeaderboard(entries))
 
+	case "request_work":
+		if s.requestStore == nil {
+			return errorResp(req.ID, -32000, "request store not initialized")
+		}
+		var args struct {
+			FromAgent       string `json:"from_agent"`
+			ToSquad         string `json:"to_squad"`
+			Type            string `json:"type"`
+			Description     string `json:"description"`
+			Priority        int    `json:"priority"`
+			DeadlineMinutes int    `json:"deadline_minutes"`
+		}
+		json.Unmarshal(params.Arguments, &args)
+		if args.ToSquad == "" || args.Description == "" {
+			return errorResp(req.ID, -32602, "to_squad and description are required")
+		}
+		if args.FromAgent == "" {
+			args.FromAgent = agentID
+		}
+		if args.Type == "" {
+			args.Type = "task"
+		}
+		req2, err := s.requestStore.Submit(ctx, args.FromAgent, args.ToSquad, args.Type, args.Description, args.Priority, args.DeadlineMinutes)
+		if err != nil {
+			return errorResp(req.ID, -32000, err.Error())
+		}
+		msg := fmt.Sprintf("Request %s submitted to %s squad. Type: %s. Priority: %d.", req2.ID, req2.ToSquad, req2.Type, req2.Priority)
+		if req2.DeadlineMinutes > 0 {
+			msg += fmt.Sprintf(" Deadline: %dm.", req2.DeadlineMinutes)
+		}
+		return textResult(req.ID, msg)
+
+	case "check_requests":
+		if s.requestStore == nil {
+			return errorResp(req.ID, -32000, "request store not initialized")
+		}
+		var args struct {
+			Squad string `json:"squad"`
+		}
+		json.Unmarshal(params.Arguments, &args)
+		if args.Squad == "" {
+			return errorResp(req.ID, -32602, "squad is required")
+		}
+		requests, err := s.requestStore.Pending(ctx, args.Squad)
+		if err != nil {
+			return errorResp(req.ID, -32000, err.Error())
+		}
+		if len(requests) == 0 {
+			return textResult(req.ID, fmt.Sprintf("No pending requests for %s squad.", args.Squad))
+		}
+		data, _ := json.Marshal(requests)
+		return textResult(req.ID, string(data))
+
+	case "fulfill_request":
+		if s.requestStore == nil {
+			return errorResp(req.ID, -32000, "request store not initialized")
+		}
+		var args struct {
+			RequestID string `json:"request_id"`
+			Result    string `json:"result"`
+			PRNumber  int    `json:"pr_number"`
+		}
+		json.Unmarshal(params.Arguments, &args)
+		if args.RequestID == "" || args.Result == "" {
+			return errorResp(req.ID, -32602, "request_id and result are required")
+		}
+		fulfilled, err := s.requestStore.Fulfill(ctx, args.RequestID, agentID, args.Result, args.PRNumber)
+		if err != nil {
+			return errorResp(req.ID, -32000, err.Error())
+		}
+		// Notify the requesting agent via coord_signal.
+		payload := fmt.Sprintf("request %s fulfilled by %s: %s", args.RequestID, agentID, args.Result)
+		if err := s.coord.Broadcast(ctx, agentID, "completed", payload); err != nil {
+			fmt.Fprintf(os.Stderr, "broadcast fulfill signal: %v\n", err)
+		}
+		msg := fmt.Sprintf("Request %s fulfilled. Notified %s.", fulfilled.ID, fulfilled.FromAgent)
+		if fulfilled.PRNumber > 0 {
+			msg += fmt.Sprintf(" PR: #%d.", fulfilled.PRNumber)
+		}
+		return textResult(req.ID, msg)
+
 	default:
 		return errorResp(req.ID, -32601, fmt.Sprintf("unknown tool: %s", params.Name))
 	}
@@ -578,6 +666,46 @@ func toolDefs() []ToolDef {
 			InputSchema: map[string]interface{}{
 				"type":       "object",
 				"properties": map[string]interface{}{},
+			},
+		},
+		{
+			Name:        "request_work",
+			Description: "Request work from another squad. The request is stored in Redis and the target squad's next dispatch tick will pick it up. Use this instead of doing the work yourself when it belongs to another squad's expertise.",
+			InputSchema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"to_squad":         map[string]string{"type": "string", "description": "Target squad name (e.g. 'analytics', 'kernel', 'shellforge')"},
+					"type":             map[string]interface{}{"type": "string", "enum": []string{"report", "query", "review", "fix", "deploy", "task"}, "description": "Work type"},
+					"description":      map[string]string{"type": "string", "description": "What you need done"},
+					"priority":         map[string]interface{}{"type": "number", "description": "0=urgent, 1=high, 2=normal (default 2)"},
+					"deadline_minutes": map[string]interface{}{"type": "number", "description": "Optional: how soon you need it (minutes)"},
+					"from_agent":       map[string]string{"type": "string", "description": "Requesting agent name (defaults to AGENTGUARD_AGENT_NAME env var)"},
+				},
+				"required": []string{"to_squad", "description"},
+			},
+		},
+		{
+			Name:        "check_requests",
+			Description: "Check for incoming cross-squad work requests directed at your squad. Returns pending requests sorted by priority (urgent first).",
+			InputSchema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"squad": map[string]string{"type": "string", "description": "Your squad name — check requests assigned to this squad"},
+				},
+				"required": []string{"squad"},
+			},
+		},
+		{
+			Name:        "fulfill_request",
+			Description: "Mark a cross-squad request as fulfilled. Broadcasts a completion signal back to the requesting agent via coord_signal.",
+			InputSchema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"request_id": map[string]string{"type": "string", "description": "Request ID from check_requests"},
+					"result":     map[string]string{"type": "string", "description": "What you did / where the output is"},
+					"pr_number":  map[string]interface{}{"type": "number", "description": "Optional PR number if work resulted in a PR"},
+				},
+				"required": []string{"request_id", "result"},
 			},
 		},
 	}


### PR DESCRIPTION
## Summary

- Adds `request_work` MCP tool — agents submit cross-squad work requests (type, priority, deadline) instead of doing wrong-squad work themselves
- Adds `check_requests` — lists pending requests for a squad, sorted urgent-first (P0 before P1 before P2, FIFO within priority)
- Adds `fulfill_request` — marks a request done and broadcasts a `coord_signal` back to the requesting agent

## Architecture

```
marketing-em: request_work(to: analytics, type: report, priority: 1)
  → Redis: octi:request:{id} (24h TTL) + octi:requests:pending:analytics (sorted set)
    → analytics-sr: check_requests(squad: analytics) → sees the request
      → analytics-sr: does the work
        → fulfill_request(request_id, result, pr_number)
          → coord_signal("completed") broadcast to swarm
            → marketing-em: sees fulfillment in signal stream
```

**Score encoding**: `priority * 1e9 + unix_seconds` — P0 scores 0–1.7B, P1 scores 1–2.7B, P2 scores 2–3.7B. `ZRange` (ascending) gives urgent-first, FIFO within same priority.

## Changes

- `internal/crosssquad/requests.go` — new `Store` with `Submit`, `Pending`, `Fulfill`
- `internal/crosssquad/requests_test.go` — 5 integration tests (Redis required)
- `internal/mcp/server.go` — 3 new tool handlers + `SetRequestStore` + tool defs
- `cmd/octi-pulpo/main.go` — wire `crosssquad.New` and `SetRequestStore`

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — no issues
- [x] `go test ./internal/crosssquad/...` — 5/5 pass against local Redis

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)