### PR TITLE
feat: cross-squad request routing — request_work, check_requests, fulfill_request

### DIFF
--- a/cmd/octi-pulpo/main.go
+++ b/cmd/octi-pulpo/main.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 
 	"github.com/AgentGuardHQ/octi-pulpo/internal/coordination"
+	"github.com/AgentGuardHQ/octi-pulpo/internal/crosssquad"
 	"github.com/AgentGuardHQ/octi-pulpo/internal/dispatch"
 	"github.com/AgentGuardHQ/octi-pulpo/internal/mcp"
 	"github.com/AgentGuardHQ/octi-pulpo/internal/memory"
@@ -83,11 +84,15 @@ func main() {
 	// Set up benchmark tracker
 	benchmark := dispatch.NewBenchmarkTracker(rdb, namespace)
 
+	// Set up cross-squad request store
+	requestStore := crosssquad.New(rdb, namespace)
+
 	server := mcp.New(mem, coord, router)
 	server.SetDispatcher(dispatcher)
 	server.SetSprintStore(sprintStore)
 	server.SetBenchmark(benchmark)
 	server.SetProfileStore(profiles)
+	server.SetRequestStore(requestStore)
 
 	// Optional HTTP mode: run webhook server alongside MCP
 	httpPort := os.Getenv("OCTI_HTTP_PORT")
@@ -124,6 +129,7 @@ func main() {
 			brain := dispatch.NewBrain(dispatcher, chains)
 			brain.SetSprintStore(sprintStore)
 			brain.SetProfileStore(profiles)
+			brain.SetRequestStore(requestStore)
 			if slackURL := os.Getenv("SLACK_WEBHOOK_URL"); slackURL != "" {
 				brain.SetNotifier(dispatch.NewNotifier(slackURL))
 			}

--- a/internal/crosssquad/store.go
+++ b/internal/crosssquad/store.go
@@ -1,0 +1,199 @@
+// Package crosssquad provides cross-squad work request routing.
+// Agents from any squad can request work from another squad's SR via
+// request_work, and target SRs can check_requests and fulfill_request.
+package crosssquad
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+// Status values for cross-squad requests.
+const (
+	StatusPending   = "pending"
+	StatusClaimed   = "claimed"
+	StatusFulfilled = "fulfilled"
+	StatusEscalated = "escalated"
+)
+
+// ValidTypes is the set of accepted request types.
+var ValidTypes = map[string]bool{
+	"report": true,
+	"query":  true,
+	"review": true,
+	"fix":    true,
+	"deploy": true,
+}
+
+// Request is a cross-squad work request.
+type Request struct {
+	ID              string `json:"id"`
+	FromAgent       string `json:"from_agent"`
+	ToSquad         string `json:"to_squad"`
+	Type            string `json:"type"`
+	Description     string `json:"description"`
+	Priority        int    `json:"priority"`        // 0=urgent, 1=high, 2=normal
+	DeadlineMinutes int    `json:"deadline_minutes,omitempty"`
+	Status          string `json:"status"`
+	CreatedAt       string `json:"created_at"`
+	FulfilledAt     string `json:"fulfilled_at,omitempty"`
+	Result          string `json:"result,omitempty"`
+	PRNumber        int    `json:"pr_number,omitempty"`
+	AgeMinutes      int    `json:"age_minutes,omitempty"` // computed on read, not persisted
+}
+
+// Store manages cross-squad requests in Redis.
+type Store struct {
+	rdb *redis.Client
+	ns  string
+}
+
+// New creates a cross-squad request store backed by the given Redis client.
+func New(rdb *redis.Client, namespace string) *Store {
+	return &Store{rdb: rdb, ns: namespace}
+}
+
+func (s *Store) key(suffix string) string {
+	return s.ns + ":xsquad:" + suffix
+}
+
+// Create stores a new cross-squad request. Returns the generated request.
+func (s *Store) Create(ctx context.Context, fromAgent, toSquad, reqType, description string, priority, deadlineMinutes int) (*Request, error) {
+	if !ValidTypes[reqType] {
+		return nil, fmt.Errorf("invalid request type %q: must be one of report, query, review, fix, deploy", reqType)
+	}
+	if priority < 0 || priority > 2 {
+		priority = 2
+	}
+
+	id := fmt.Sprintf("req-%d", time.Now().UnixMilli())
+	req := &Request{
+		ID:              id,
+		FromAgent:       fromAgent,
+		ToSquad:         toSquad,
+		Type:            reqType,
+		Description:     description,
+		Priority:        priority,
+		DeadlineMinutes: deadlineMinutes,
+		Status:          StatusPending,
+		CreatedAt:       time.Now().UTC().Format(time.RFC3339),
+	}
+
+	data, err := json.Marshal(req)
+	if err != nil {
+		return nil, err
+	}
+
+	pipe := s.rdb.Pipeline()
+	// Store request body, retained for 7 days
+	pipe.Set(ctx, s.key("request:"+id), data, 7*24*time.Hour)
+	// Add to the target squad's pending sorted set — lower score = higher priority
+	pipe.ZAdd(ctx, s.key("pending:"+toSquad), redis.Z{
+		Score:  float64(priority),
+		Member: id,
+	})
+	_, err = pipe.Exec(ctx)
+	return req, err
+}
+
+// List returns all pending/claimed requests for a squad, sorted by priority.
+// Fulfilled and escalated entries are cleaned up on read.
+func (s *Store) List(ctx context.Context, toSquad string) ([]Request, error) {
+	ids, err := s.rdb.ZRange(ctx, s.key("pending:"+toSquad), 0, -1).Result()
+	if err != nil {
+		return nil, err
+	}
+
+	now := time.Now().UTC()
+	var requests []Request
+
+	for _, id := range ids {
+		raw, err := s.rdb.Get(ctx, s.key("request:"+id)).Result()
+		if err != nil {
+			// Key expired — remove from sorted set
+			s.rdb.ZRem(ctx, s.key("pending:"+toSquad), id)
+			continue
+		}
+		var req Request
+		if err := json.Unmarshal([]byte(raw), &req); err != nil {
+			continue
+		}
+		// Clean up terminal states from the pending set
+		if req.Status == StatusFulfilled || req.Status == StatusEscalated {
+			s.rdb.ZRem(ctx, s.key("pending:"+toSquad), id)
+			continue
+		}
+		// Compute age for display
+		if t, err := time.Parse(time.RFC3339, req.CreatedAt); err == nil {
+			req.AgeMinutes = int(now.Sub(t).Minutes())
+		}
+		// Escalate overdue requests
+		if req.DeadlineMinutes > 0 && req.AgeMinutes > req.DeadlineMinutes && req.Status == StatusPending {
+			req.Status = StatusEscalated
+			s.save(ctx, &req)
+			s.rdb.ZRem(ctx, s.key("pending:"+toSquad), id)
+			continue
+		}
+		requests = append(requests, req)
+	}
+	return requests, nil
+}
+
+// Fulfill marks a request as completed.
+func (s *Store) Fulfill(ctx context.Context, requestID, result string, prNumber int) (*Request, error) {
+	raw, err := s.rdb.Get(ctx, s.key("request:"+requestID)).Result()
+	if err != nil {
+		return nil, fmt.Errorf("request %s not found", requestID)
+	}
+	var req Request
+	if err := json.Unmarshal([]byte(raw), &req); err != nil {
+		return nil, err
+	}
+
+	req.Status = StatusFulfilled
+	req.Result = result
+	req.FulfilledAt = time.Now().UTC().Format(time.RFC3339)
+	req.PRNumber = prNumber
+
+	if err := s.save(ctx, &req); err != nil {
+		return nil, err
+	}
+	// Remove from pending set
+	s.rdb.ZRem(ctx, s.key("pending:"+req.ToSquad), requestID)
+	return &req, nil
+}
+
+// PendingSquads returns the names of squads that have at least one pending request.
+func (s *Store) PendingSquads(ctx context.Context) ([]string, error) {
+	prefix := s.key("pending:")
+	keys, err := s.rdb.Keys(ctx, prefix+"*").Result()
+	if err != nil {
+		return nil, err
+	}
+
+	var squads []string
+	for _, k := range keys {
+		count, _ := s.rdb.ZCard(ctx, k).Result()
+		if count > 0 {
+			squads = append(squads, k[len(prefix):])
+		}
+	}
+	return squads, nil
+}
+
+// save persists a request body back to Redis, preserving the existing TTL.
+func (s *Store) save(ctx context.Context, req *Request) error {
+	data, err := json.Marshal(req)
+	if err != nil {
+		return err
+	}
+	ttl, _ := s.rdb.TTL(ctx, s.key("request:"+req.ID)).Result()
+	if ttl <= 0 {
+		ttl = 7 * 24 * time.Hour
+	}
+	return s.rdb.Set(ctx, s.key("request:"+req.ID), data, ttl).Err()
+}

--- a/internal/crosssquad/store_test.go
+++ b/internal/crosssquad/store_test.go
@@ -1,0 +1,158 @@
+package crosssquad_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/AgentGuardHQ/octi-pulpo/internal/crosssquad"
+	"github.com/redis/go-redis/v9"
+)
+
+// newTestStore creates a Store backed by real Redis on localhost:6379.
+// Each test uses a unique namespace to avoid cross-test pollution.
+func newTestStore(t *testing.T) *crosssquad.Store {
+	t.Helper()
+	ns := fmt.Sprintf("test-xsquad-%d", time.Now().UnixNano())
+	rdb := redis.NewClient(&redis.Options{Addr: "localhost:6379"})
+	t.Cleanup(func() {
+		// Clean up all keys created by this test
+		ctx := context.Background()
+		keys, _ := rdb.Keys(ctx, ns+":xsquad:*").Result()
+		if len(keys) > 0 {
+			rdb.Del(ctx, keys...)
+		}
+		rdb.Close()
+	})
+	return crosssquad.New(rdb, ns)
+}
+
+func TestCreate_ValidRequest(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	req, err := store.Create(ctx, "marketing-em", "analytics", "report", "PR velocity for LinkedIn post", 1, 60)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if req.ID == "" {
+		t.Error("expected non-empty ID")
+	}
+	if req.Status != crosssquad.StatusPending {
+		t.Errorf("expected status=%s, got %s", crosssquad.StatusPending, req.Status)
+	}
+	if req.FromAgent != "marketing-em" || req.ToSquad != "analytics" {
+		t.Errorf("unexpected from/to: %s -> %s", req.FromAgent, req.ToSquad)
+	}
+}
+
+func TestCreate_InvalidType(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	_, err := store.Create(ctx, "agent", "squad", "badtype", "desc", 1, 0)
+	if err == nil {
+		t.Error("expected error for invalid type")
+	}
+}
+
+func TestList_ReturnsPending(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	// Create priority-0 first, then priority-1 — list must return 0 first
+	store.Create(ctx, "kernel-sr", "cloud", "review", "PR #123", 0, 0)
+	store.Create(ctx, "kernel-sr", "cloud", "query", "DB schema for auth", 1, 0)
+
+	requests, err := store.List(ctx, "cloud")
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(requests) != 2 {
+		t.Errorf("expected 2 requests, got %d", len(requests))
+	}
+	// ZRange returns by ascending score — priority 0 before priority 1
+	if requests[0].Priority != 0 {
+		t.Errorf("expected highest-priority request first, got priority=%d", requests[0].Priority)
+	}
+}
+
+func TestList_ExcludesFulfilled(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	req, _ := store.Create(ctx, "marketing-em", "analytics", "report", "weekly summary", 1, 0)
+	store.Fulfill(ctx, req.ID, "report generated at reports/week13.md", 0)
+
+	requests, err := store.List(ctx, "analytics")
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(requests) != 0 {
+		t.Errorf("expected 0 requests after fulfillment, got %d", len(requests))
+	}
+}
+
+func TestFulfill_UpdatesStatus(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	req, _ := store.Create(ctx, "kernel-sr", "cloud", "fix", "Neon connection pool leak", 0, 0)
+	fulfilled, err := store.Fulfill(ctx, req.ID, "fixed in PR #456", 456)
+	if err != nil {
+		t.Fatalf("Fulfill: %v", err)
+	}
+	if fulfilled.Status != crosssquad.StatusFulfilled {
+		t.Errorf("expected status=%s, got %s", crosssquad.StatusFulfilled, fulfilled.Status)
+	}
+	if fulfilled.PRNumber != 456 {
+		t.Errorf("expected pr_number=456, got %d", fulfilled.PRNumber)
+	}
+	if fulfilled.FulfilledAt == "" {
+		t.Error("expected fulfilled_at to be set")
+	}
+}
+
+func TestFulfill_NotFound(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	_, err := store.Fulfill(ctx, "req-does-not-exist", "result", 0)
+	if err == nil {
+		t.Error("expected error for missing request")
+	}
+}
+
+func TestPendingSquads(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	store.Create(ctx, "kernel-sr", "cloud", "query", "DB help", 1, 0)
+	store.Create(ctx, "kernel-sr", "analytics", "report", "metrics", 1, 0)
+
+	squads, err := store.PendingSquads(ctx)
+	if err != nil {
+		t.Fatalf("PendingSquads: %v", err)
+	}
+	found := make(map[string]bool)
+	for _, s := range squads {
+		found[s] = true
+	}
+	if !found["cloud"] || !found["analytics"] {
+		t.Errorf("expected cloud and analytics in pending squads, got %v", squads)
+	}
+}
+
+func TestList_EmptySquad(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	requests, err := store.List(ctx, "no-such-squad")
+	if err != nil {
+		t.Fatalf("List on empty squad: %v", err)
+	}
+	if len(requests) != 0 {
+		t.Errorf("expected 0 requests for empty squad, got %d", len(requests))
+	}
+}

--- a/internal/dispatch/brain.go
+++ b/internal/dispatch/brain.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/AgentGuardHQ/octi-pulpo/internal/crosssquad"
 	"github.com/AgentGuardHQ/octi-pulpo/internal/routing"
 	"github.com/AgentGuardHQ/octi-pulpo/internal/sprint"
 )
@@ -42,6 +43,7 @@ type LeverageAction struct {
 //   - Sprint store sync: periodically refresh issue data from GitHub
 //   - Driver health probe: ping each driver every 15 min to detect stale state
 //   - Slack notifications: periodic budget dashboard + driver state change alerts
+//   - Cross-squad routing: dispatch target SRs for pending cross-squad requests
 type Brain struct {
 	dispatcher      *Dispatcher
 	chains          ChainConfig
@@ -50,6 +52,7 @@ type Brain struct {
 	log             *log.Logger
 	sprintStore     *sprint.Store
 	profiles        *ProfileStore
+	requestStore    *crosssquad.Store
 	notifier        *Notifier
 	lastSync        time.Time
 	lastProbe       time.Time
@@ -83,6 +86,11 @@ func (b *Brain) SetProfileStore(ps *ProfileStore) {
 // SetNotifier enables Slack notifications for driver state changes and periodic dashboards.
 func (b *Brain) SetNotifier(n *Notifier) {
 	b.notifier = n
+}
+
+// SetRequestStore enables cross-squad request dispatching in the brain.
+func (b *Brain) SetRequestStore(rs *crosssquad.Store) {
+	b.requestStore = rs
 }
 
 // Run starts the brain evaluation loop. Blocks until context is cancelled.
@@ -122,7 +130,10 @@ func (b *Brain) Tick(ctx context.Context) {
 	// 4. Periodic Slack dashboard
 	b.maybePostDashboard(ctx)
 
-	// 5. Constraint-driven dispatch (if sprint store is available)
+	// 5. Cross-squad request routing — dispatch SRs for pending requests
+	b.dispatchCrossSquadRequests(ctx)
+
+	// 6. Constraint-driven dispatch (if sprint store is available)
 	if b.sprintStore != nil {
 		constraint := b.identifyConstraint(ctx)
 		b.maybeNotifyConstraintChange(ctx, constraint)
@@ -539,6 +550,40 @@ func (b *Brain) srForSquad(squad string) string {
 		"analytics":  "analytics-sr",
 	}
 	return mapping[squad]
+}
+
+// dispatchCrossSquadRequests checks the cross-squad request store and dispatches
+// the target squad's SR for each squad that has pending requests.
+func (b *Brain) dispatchCrossSquadRequests(ctx context.Context) {
+	if b.requestStore == nil {
+		return
+	}
+	squads, err := b.requestStore.PendingSquads(ctx)
+	if err != nil || len(squads) == 0 {
+		return
+	}
+	for _, squad := range squads {
+		agent := b.srForSquad(squad)
+		if agent == "" {
+			b.log.Printf("cross-squad: no SR mapping for squad %q — skipping", squad)
+			continue
+		}
+		event := Event{
+			Type:   EventType("cross-squad.request"),
+			Source: "brain",
+			Payload: map[string]string{
+				"squad":  squad,
+				"reason": fmt.Sprintf("pending cross-squad requests for squad %s — check_requests to see them", squad),
+			},
+			Priority: 1,
+		}
+		result, err := b.dispatcher.Dispatch(ctx, event, agent, 1)
+		if err != nil {
+			b.log.Printf("cross-squad dispatch %s: %v", agent, err)
+			continue
+		}
+		b.log.Printf("cross-squad: dispatched %s for squad %s requests (%s)", agent, squad, result.Action)
+	}
 }
 
 // checkBackpressureRecovery looks for agents that were queued due to

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/AgentGuardHQ/octi-pulpo/internal/coordination"
+	"github.com/AgentGuardHQ/octi-pulpo/internal/crosssquad"
 	"github.com/AgentGuardHQ/octi-pulpo/internal/dispatch"
 	"github.com/AgentGuardHQ/octi-pulpo/internal/memory"
 	"github.com/AgentGuardHQ/octi-pulpo/internal/routing"
@@ -47,13 +48,14 @@ type RPCError struct {
 
 // Server is the Octi Pulpo MCP server.
 type Server struct {
-	mem         *memory.Store
-	coord       *coordination.Engine
-	router      *routing.Router
-	dispatcher  *dispatch.Dispatcher
-	sprintStore *sprint.Store
-	benchmark   *dispatch.BenchmarkTracker
-	profiles    *dispatch.ProfileStore
+	mem          *memory.Store
+	coord        *coordination.Engine
+	router       *routing.Router
+	dispatcher   *dispatch.Dispatcher
+	sprintStore  *sprint.Store
+	benchmark    *dispatch.BenchmarkTracker
+	profiles     *dispatch.ProfileStore
+	requestStore *crosssquad.Store
 }
 
 // New creates an MCP server backed by the given memory and coordination engines.
@@ -79,6 +81,11 @@ func (s *Server) SetBenchmark(bt *dispatch.BenchmarkTracker) {
 // SetProfileStore enables the agent leaderboard MCP tool.
 func (s *Server) SetProfileStore(ps *dispatch.ProfileStore) {
 	s.profiles = ps
+}
+
+// SetRequestStore enables cross-squad request routing MCP tools.
+func (s *Server) SetRequestStore(rs *crosssquad.Store) {
+	s.requestStore = rs
 }
 
 // Serve runs the MCP server on stdio (stdin/stdout JSON-RPC).
@@ -368,6 +375,79 @@ func (s *Server) handleToolCall(req Request) Response {
 		}
 		return textResult(req.ID, dispatch.FormatLeaderboard(entries))
 
+	case "request_work":
+		if s.requestStore == nil {
+			return errorResp(req.ID, -32000, "request store not initialized")
+		}
+		var args struct {
+			FromAgent       string `json:"from_agent"`
+			ToSquad         string `json:"to_squad"`
+			Type            string `json:"type"`
+			Description     string `json:"description"`
+			Priority        int    `json:"priority"`
+			DeadlineMinutes int    `json:"deadline_minutes"`
+		}
+		json.Unmarshal(params.Arguments, &args)
+		if args.ToSquad == "" || args.Description == "" || args.Type == "" {
+			return errorResp(req.ID, -32602, "to_squad, type, and description are required")
+		}
+		// Fall back to the calling agent's identity if from_agent not specified
+		if args.FromAgent == "" {
+			args.FromAgent = agentID
+		}
+		r, err := s.requestStore.Create(ctx, args.FromAgent, args.ToSquad, args.Type, args.Description, args.Priority, args.DeadlineMinutes)
+		if err != nil {
+			return errorResp(req.ID, -32000, err.Error())
+		}
+		return textResult(req.ID, fmt.Sprintf("Request %s created — %s will be notified on next brain tick", r.ID, args.ToSquad))
+
+	case "check_requests":
+		if s.requestStore == nil {
+			return errorResp(req.ID, -32000, "request store not initialized")
+		}
+		var args struct {
+			Squad string `json:"squad"`
+		}
+		json.Unmarshal(params.Arguments, &args)
+		if args.Squad == "" {
+			return errorResp(req.ID, -32602, "squad is required")
+		}
+		requests, err := s.requestStore.List(ctx, args.Squad)
+		if err != nil {
+			return errorResp(req.ID, -32000, err.Error())
+		}
+		if len(requests) == 0 {
+			return textResult(req.ID, fmt.Sprintf("No pending requests for squad %q.", args.Squad))
+		}
+		data, _ := json.Marshal(requests)
+		return textResult(req.ID, string(data))
+
+	case "fulfill_request":
+		if s.requestStore == nil {
+			return errorResp(req.ID, -32000, "request store not initialized")
+		}
+		var args struct {
+			RequestID string `json:"request_id"`
+			Result    string `json:"result"`
+			PRNumber  int    `json:"pr_number"`
+		}
+		json.Unmarshal(params.Arguments, &args)
+		if args.RequestID == "" || args.Result == "" {
+			return errorResp(req.ID, -32602, "request_id and result are required")
+		}
+		fulfilled, err := s.requestStore.Fulfill(ctx, args.RequestID, args.Result, args.PRNumber)
+		if err != nil {
+			return errorResp(req.ID, -32000, err.Error())
+		}
+		// Notify the requesting agent via coord_signal
+		signalPayload := fmt.Sprintf("Request %s fulfilled by %s: %s", fulfilled.ID, agentID, fulfilled.Result)
+		s.coord.Broadcast(ctx, agentID, "completed", signalPayload)
+		msg := fmt.Sprintf("Request %s marked fulfilled. Signal sent to swarm.", fulfilled.ID)
+		if fulfilled.PRNumber > 0 {
+			msg += fmt.Sprintf(" (PR #%d)", fulfilled.PRNumber)
+		}
+		return textResult(req.ID, msg)
+
 	default:
 		return errorResp(req.ID, -32601, fmt.Sprintf("unknown tool: %s", params.Name))
 	}
@@ -578,6 +658,46 @@ func toolDefs() []ToolDef {
 			InputSchema: map[string]interface{}{
 				"type":       "object",
 				"properties": map[string]interface{}{},
+			},
+		},
+		{
+			Name:        "request_work",
+			Description: "Request work from another squad. The brain will dispatch the target squad's SR with your request context on the next tick.",
+			InputSchema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"from_agent":       map[string]string{"type": "string", "description": "Your agent name (defaults to AGENTGUARD_AGENT_NAME)"},
+					"to_squad":         map[string]string{"type": "string", "description": "Target squad (e.g. analytics, cloud, kernel)"},
+					"type":             map[string]interface{}{"type": "string", "enum": []string{"report", "query", "review", "fix", "deploy"}, "description": "Type of work requested"},
+					"description":      map[string]string{"type": "string", "description": "What you need — be specific"},
+					"priority":         map[string]interface{}{"type": "number", "description": "0=urgent, 1=high, 2=normal (default: 2)"},
+					"deadline_minutes": map[string]interface{}{"type": "number", "description": "Optional deadline in minutes. Overdue requests are auto-escalated."},
+				},
+				"required": []string{"to_squad", "type", "description"},
+			},
+		},
+		{
+			Name:        "check_requests",
+			Description: "Check for incoming cross-squad work requests for your squad. Returns pending requests sorted by priority.",
+			InputSchema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"squad": map[string]string{"type": "string", "description": "Your squad name (e.g. analytics, cloud)"},
+				},
+				"required": []string{"squad"},
+			},
+		},
+		{
+			Name:        "fulfill_request",
+			Description: "Mark a cross-squad request as completed. Sends a coord_signal to notify the requesting agent.",
+			InputSchema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"request_id": map[string]string{"type": "string", "description": "The request ID from check_requests (e.g. req-1234567890)"},
+					"result":     map[string]string{"type": "string", "description": "Where the output can be found (file path, report URL, PR description)"},
+					"pr_number":  map[string]interface{}{"type": "number", "description": "Optional PR number if the work resulted in a PR"},
+				},
+				"required": []string{"request_id", "result"},
 			},
 		},
 	}


### PR DESCRIPTION
## Summary

- New `internal/crosssquad` package with a Redis-backed request store (sorted sets by priority, 7-day TTL, auto-escalation for overdue requests)
- Three new MCP tools: `request_work`, `check_requests`, `fulfill_request`
- Brain integration: `dispatchCrossSquadRequests()` added to the tick loop — on every tick, squads with pending requests get their SR dispatched with context to run `check_requests`

## How it works

```
marketing-em: request_work(to: analytics, type: report, description: "PR velocity for LinkedIn")
  → Redis: octi:xsquad:pending:analytics sorted set
    → Brain tick: dispatchCrossSquadRequests() sees analytics has pending requests
      → dispatch analytics-sr via "cross-squad.request" event (respects cooldowns/claims)
        → analytics-sr: check_requests(squad: analytics) → sees the request
          → analytics-sr: does the work
            → analytics-sr: fulfill_request(request_id: req-xxx, result: "report at reports/...")
              → coord_signal "completed" broadcast to swarm
                → marketing-em: picks up the signal, writes LinkedIn post
```

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./internal/crosssquad/...` — 8/8 passing
- [x] `go test ./internal/dispatch/...` — 90/90 passing (no regressions)

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)