### PR TITLE
feat: wire-mcp + SyncClosed — workspace MCP server wiring and closed-issue sync

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
-.PHONY: all build clean octi-pulpo octi-worker octi-timer
+.PHONY: all build clean install wire-mcp octi-pulpo octi-worker octi-timer
+
+INSTALL_DIR ?= $(HOME)/.agentguard/bin
 
 all: build
 
@@ -12,6 +14,16 @@ octi-worker:
 
 octi-timer:
 	go build -o bin/octi-timer ./cmd/octi-timer/
+
+install: build
+	mkdir -p $(INSTALL_DIR)
+	cp bin/octi-pulpo $(INSTALL_DIR)/octi-pulpo
+	cp bin/octi-worker $(INSTALL_DIR)/octi-worker
+	cp bin/octi-timer $(INSTALL_DIR)/octi-timer
+	@echo "Installed to $(INSTALL_DIR)"
+
+wire-mcp: install
+	bash scripts/wire-mcp.sh
 
 clean:
 	rm -f bin/octi-pulpo bin/octi-worker bin/octi-timer

--- a/internal/sprint/store.go
+++ b/internal/sprint/store.go
@@ -192,6 +192,10 @@ func (s *Store) Sync(ctx context.Context, repo string) error {
 	if err := s.SyncPRs(ctx, repo); err != nil {
 		s.log.Printf("sync PRs for %s: %v", repo, err)
 	}
+	// Sync closed issues so items that shipped don't stay status="open" in Redis.
+	if err := s.SyncClosed(ctx, repo); err != nil {
+		s.log.Printf("sync closed issues for %s: %v", repo, err)
+	}
 	return nil
 }
 
@@ -436,6 +440,67 @@ func (s *Store) getByRepo(ctx context.Context, repo string) ([]SprintItem, error
 	}
 
 	return items, nil
+}
+
+// SyncClosed fetches recently closed issues from a GitHub repo and marks
+// any matching sprint items as "done". This prevents the brain from
+// re-dispatching work that has already shipped.
+func (s *Store) SyncClosed(ctx context.Context, repo string) error {
+	cmd := exec.CommandContext(ctx, "gh", "issue", "list",
+		"-R", repo,
+		"--state", "closed",
+		"--json", "number",
+		"-L", "50",
+	)
+	out, err := cmd.Output()
+	if err != nil {
+		return fmt.Errorf("gh issue list --state closed -R %s: %w", repo, err)
+	}
+
+	var issues []struct {
+		Number int `json:"number"`
+	}
+	if err := json.Unmarshal(out, &issues); err != nil {
+		return fmt.Errorf("parse closed issues for %s: %w", repo, err)
+	}
+
+	nums := make([]int, len(issues))
+	for i, issue := range issues {
+		nums[i] = issue.Number
+	}
+
+	marked := s.markClosedItems(ctx, repo, nums)
+	if marked > 0 {
+		s.log.Printf("marked %d closed issues as done in %s", marked, repo)
+	}
+	return nil
+}
+
+// markClosedItems marks sprint items for the given issue numbers as "done"
+// if they are currently open or pr_open. Returns the number of items marked.
+func (s *Store) markClosedItems(ctx context.Context, repo string, issueNums []int) int {
+	now := time.Now().UTC().Format(time.RFC3339)
+	var marked int
+	for _, num := range issueNums {
+		key := s.itemKey(repo, num)
+		raw, err := s.rdb.Get(ctx, key).Result()
+		if err != nil {
+			continue // not in sprint store
+		}
+		var item SprintItem
+		if err := json.Unmarshal([]byte(raw), &item); err != nil {
+			continue
+		}
+		if item.Status == "done" {
+			continue
+		}
+		item.Status = "done"
+		item.UpdatedAt = now
+		data, _ := json.Marshal(item)
+		s.rdb.Set(ctx, key, data, 0)
+		marked++
+	}
+	return marked
 }
 
 func (s *Store) itemKey(repo string, issueNum int) string {

--- a/internal/sprint/store_test.go
+++ b/internal/sprint/store_test.go
@@ -312,6 +312,63 @@ func TestStore_SyncPRs_PreservesNonOpen(t *testing.T) {
 	}
 }
 
+func TestMarkClosedItems_MarksOpenAndPROpen(t *testing.T) {
+	s, ctx := testStore(t)
+	repo := "AgentGuardHQ/octi-pulpo"
+	s.rdb.SAdd(ctx, s.key("sprint-repos"), repo)
+
+	items := []SprintItem{
+		{Squad: "octi-pulpo", IssueNum: 8, Repo: repo, Title: "Cost routing", Priority: 0, Status: "open"},
+		{Squad: "octi-pulpo", IssueNum: 9, Repo: repo, Title: "Slack ctrl", Priority: 0, Status: "pr_open", PRNumber: 41},
+		{Squad: "octi-pulpo", IssueNum: 10, Repo: repo, Title: "Briefings", Priority: 0, Status: "done"},
+		{Squad: "octi-pulpo", IssueNum: 11, Repo: repo, Title: "WIP", Priority: 0, Status: "in_progress"},
+	}
+	for _, item := range items {
+		data, _ := json.Marshal(item)
+		s.rdb.Set(ctx, s.itemKey(repo, item.IssueNum), data, 0)
+	}
+
+	// Closed issues on GitHub: #8 and #9. #10 already done. #11 in_progress should still become done.
+	marked := s.markClosedItems(ctx, repo, []int{8, 9, 10, 11})
+	if marked != 3 {
+		t.Fatalf("expected 3 marked, got %d", marked)
+	}
+
+	all, _ := s.GetAll(ctx)
+	byNum := make(map[int]SprintItem, len(all))
+	for _, item := range all {
+		byNum[item.IssueNum] = item
+	}
+
+	for _, num := range []int{8, 9, 11} {
+		if byNum[num].Status != "done" {
+			t.Errorf("issue #%d: expected done, got %s", num, byNum[num].Status)
+		}
+	}
+	if byNum[10].Status != "done" {
+		t.Errorf("issue #10 should stay done, got %s", byNum[10].Status)
+	}
+}
+
+func TestMarkClosedItems_SkipsUntracked(t *testing.T) {
+	s, ctx := testStore(t)
+	repo := "AgentGuardHQ/octi-pulpo"
+
+	// Sprint store has no items for this repo
+	marked := s.markClosedItems(ctx, repo, []int{1, 2, 3})
+	if marked != 0 {
+		t.Fatalf("expected 0 marked for untracked items, got %d", marked)
+	}
+}
+
+func TestMarkClosedItems_EmptyList(t *testing.T) {
+	s, ctx := testStore(t)
+	marked := s.markClosedItems(ctx, "AgentGuardHQ/octi-pulpo", []int{})
+	if marked != 0 {
+		t.Fatalf("expected 0 for empty list, got %d", marked)
+	}
+}
+
 func TestInferSquadFromRepo(t *testing.T) {
 	tests := []struct {
 		repo  string

--- a/scripts/wire-mcp.sh
+++ b/scripts/wire-mcp.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# wire-mcp.sh — register octi-pulpo as an MCP server in the workspace Claude settings.
+#
+# Usage:
+#   bash scripts/wire-mcp.sh
+#   make wire-mcp          # builds, installs, then wires
+#
+# Environment:
+#   AGENTGUARD_WORKSPACE   path to the workspace (default: ~/agentguard-workspace)
+#   INSTALL_DIR            where the binary lives (default: ~/.agentguard/bin)
+
+set -euo pipefail
+
+INSTALL_DIR="${INSTALL_DIR:-${HOME}/.agentguard/bin}"
+BINARY="${INSTALL_DIR}/octi-pulpo"
+WORKSPACE="${AGENTGUARD_WORKSPACE:-${HOME}/agentguard-workspace}"
+SETTINGS="${WORKSPACE}/.claude/settings.json"
+
+if [ ! -f "${BINARY}" ]; then
+  echo "ERROR: octi-pulpo binary not found at ${BINARY}" >&2
+  echo "Run 'make install' or 'make wire-mcp' first." >&2
+  exit 1
+fi
+
+if [ ! -f "${SETTINGS}" ]; then
+  echo "ERROR: Claude settings not found at ${SETTINGS}" >&2
+  exit 1
+fi
+
+if ! command -v jq &>/dev/null; then
+  echo "ERROR: jq is required to update settings. Install with: sudo apt install jq" >&2
+  exit 1
+fi
+
+# Build the mcpServers entry.
+MCP_ENTRY=$(cat <<EOF
+{
+  "command": "${BINARY}",
+  "env": {
+    "OCTI_REDIS_URL": "redis://localhost:6379",
+    "OCTI_NAMESPACE": "octi"
+  }
+}
+EOF
+)
+
+TMP=$(mktemp)
+jq --argjson entry "${MCP_ENTRY}" '.mcpServers["octi-pulpo"] = $entry' "${SETTINGS}" > "${TMP}"
+mv "${TMP}" "${SETTINGS}"
+
+echo "octi-pulpo registered as MCP server in ${SETTINGS}"
+echo "Binary: ${BINARY}"
+echo ""
+echo "Restart Claude Code to pick up the new MCP server."


### PR DESCRIPTION
## Summary

- **`make install` / `make wire-mcp`** — builds all three binaries, installs to `~/.agentguard/bin/`, then runs `scripts/wire-mcp.sh` to add octi-pulpo to `mcpServers` in the workspace `.claude/settings.json`. This is the **"wire as workspace MCP server"** sprint deliverable — zero manual config required for agents to discover octi-pulpo tools.
- **`SyncClosed`** — closes the dispatch retry-loop bug: `Sync()` now fetches closed GitHub issues and marks matching sprint items as `done` so the brain stops re-dispatching agents to closed issues (root cause of the #8 re-dispatch storm today). `markClosedItems` is a pure Redis helper for testability.

## What was broken

```
Sync() only called: gh issue list --state open
Result:  issue #8 closed on GitHub but stays status="open" in Redis
Brain:   sees P0 open item → dispatches octi-pulpo-sr
         SR creates PR → gets "skipped: agent already has active claim"
         Brain loops every minute indefinitely
```

## Fix

```
After Sync(): SyncClosed() calls gh issue list --state closed
              any matching sprint item → status="done"
Brain:        NextDispatchable() skips "done" items → loop stops
```

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./...` — 186 tests pass across all 10 packages
- [x] `TestMarkClosedItems_MarksOpenAndPROpen` — open + pr_open + in_progress items become done; already-done items counted correctly
- [x] `TestMarkClosedItems_SkipsUntracked` — untracked issue numbers don't panic, return 0
- [x] `TestMarkClosedItems_EmptyList` — empty input returns 0

## Related

- Closes the dispatch retry loop that was hammering issue #8 (already closed via PR #35)
- Complements PR #58 (SyncPRs) which handles the open-PR-but-no-issue-update case

🤖 Generated with [Claude Code](https://claude.com/claude-code)