### PR TITLE
feat: async standups — standup_report + standup_read MCP tools (#44)

### DIFF
--- a/cmd/octi-pulpo/main.go
+++ b/cmd/octi-pulpo/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/AgentGuardHQ/octi-pulpo/internal/memory"
 	"github.com/AgentGuardHQ/octi-pulpo/internal/routing"
 	"github.com/AgentGuardHQ/octi-pulpo/internal/sprint"
+	"github.com/AgentGuardHQ/octi-pulpo/internal/standup"
 	"github.com/redis/go-redis/v9"
 )
 
@@ -83,11 +84,19 @@ func main() {
 	// Set up benchmark tracker
 	benchmark := dispatch.NewBenchmarkTracker(rdb, namespace)
 
+	standupStore := standup.New(rdb, namespace)
+
+	var standupNotifier *dispatch.Notifier
+	if slackURL := os.Getenv("SLACK_WEBHOOK_URL"); slackURL != "" {
+		standupNotifier = dispatch.NewNotifier(slackURL)
+	}
+
 	server := mcp.New(mem, coord, router)
 	server.SetDispatcher(dispatcher)
 	server.SetSprintStore(sprintStore)
 	server.SetBenchmark(benchmark)
 	server.SetProfileStore(profiles)
+	server.SetStandupStore(standupStore, standupNotifier)
 
 	// Optional HTTP mode: run webhook server alongside MCP
 	httpPort := os.Getenv("OCTI_HTTP_PORT")

--- a/internal/dispatch/slack.go
+++ b/internal/dispatch/slack.go
@@ -6,10 +6,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"sort"
 	"strings"
 	"time"
 
 	"github.com/AgentGuardHQ/octi-pulpo/internal/routing"
+	"github.com/AgentGuardHQ/octi-pulpo/internal/standup"
 )
 
 // Notifier posts structured notifications to a Slack incoming webhook.
@@ -154,6 +156,70 @@ func (n *Notifier) PostSprintGoalAlert(ctx context.Context, squad, goal string) 
 	}
 
 	return n.postBlocks(ctx, blocks)
+}
+
+// PostStandup posts the unified daily standup for all squads that have
+// reported today. Squads are sorted alphabetically for a stable layout.
+// The optional [Reprioritize] button lets the CTO act directly from Slack.
+func (n *Notifier) PostStandup(ctx context.Context, reports map[string]*standup.Report) error {
+	if !n.Enabled() {
+		return nil
+	}
+	if len(reports) == 0 {
+		return nil
+	}
+
+	date := time.Now().UTC().Format("2006-01-02")
+	header := fmt.Sprintf("*📋 Daily Standup — %s*  (%d squads reported)", date, len(reports))
+
+	// Sort squads for a stable order.
+	squads := make([]string, 0, len(reports))
+	for sq := range reports {
+		squads = append(squads, sq)
+	}
+	sort.Strings(squads)
+
+	var body strings.Builder
+	for _, sq := range squads {
+		r := reports[sq]
+		status := standup.StatusOf(r)
+		icon := statusIcon(status)
+
+		body.WriteString(fmt.Sprintf("\n%s *%s* (%s)\n", icon, strings.Title(sq), status))
+
+		if len(r.Done) > 0 {
+			body.WriteString(fmt.Sprintf("  ✅ Done: %s\n", strings.Join(r.Done, " · ")))
+		}
+		if len(r.Doing) > 0 {
+			body.WriteString(fmt.Sprintf("  🔨 Doing: %s\n", strings.Join(r.Doing, " · ")))
+		}
+		if len(r.Blocked) > 0 {
+			body.WriteString(fmt.Sprintf("  🚧 Blocked: %s\n", strings.Join(r.Blocked, " · ")))
+		}
+		if len(r.Requests) > 0 {
+			body.WriteString(fmt.Sprintf("  📥 Requests: %s\n", strings.Join(r.Requests, " · ")))
+		}
+	}
+
+	blocks := []map[string]interface{}{
+		blockSection(header),
+		blockSection(body.String()),
+		blockActions(
+			slackButton("standup_reprioritize", date, "Reprioritize", "primary"),
+		),
+	}
+	return n.postBlocks(ctx, blocks)
+}
+
+func statusIcon(s standup.Status) string {
+	switch s {
+	case standup.StatusGreen:
+		return "🟢"
+	case standup.StatusYellow:
+		return "🟡"
+	default:
+		return "🔴"
+	}
 }
 
 // postBlocks sends a Slack Block Kit payload to the webhook URL.

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -14,6 +14,7 @@ import (
 	"github.com/AgentGuardHQ/octi-pulpo/internal/memory"
 	"github.com/AgentGuardHQ/octi-pulpo/internal/routing"
 	"github.com/AgentGuardHQ/octi-pulpo/internal/sprint"
+	"github.com/AgentGuardHQ/octi-pulpo/internal/standup"
 )
 
 // ToolDef describes an MCP tool for the ListTools response.
@@ -47,13 +48,15 @@ type RPCError struct {
 
 // Server is the Octi Pulpo MCP server.
 type Server struct {
-	mem         *memory.Store
-	coord       *coordination.Engine
-	router      *routing.Router
-	dispatcher  *dispatch.Dispatcher
-	sprintStore *sprint.Store
-	benchmark   *dispatch.BenchmarkTracker
-	profiles    *dispatch.ProfileStore
+	mem           *memory.Store
+	coord         *coordination.Engine
+	router        *routing.Router
+	dispatcher    *dispatch.Dispatcher
+	sprintStore   *sprint.Store
+	benchmark     *dispatch.BenchmarkTracker
+	profiles      *dispatch.ProfileStore
+	standupStore  *standup.Store
+	notifier      *dispatch.Notifier
 }
 
 // New creates an MCP server backed by the given memory and coordination engines.
@@ -79,6 +82,13 @@ func (s *Server) SetBenchmark(bt *dispatch.BenchmarkTracker) {
 // SetProfileStore enables the agent leaderboard MCP tool.
 func (s *Server) SetProfileStore(ps *dispatch.ProfileStore) {
 	s.profiles = ps
+}
+
+// SetStandupStore enables the standup_report and standup_read MCP tools.
+// If notifier is non-nil, standup_report will post the aggregated standup to Slack.
+func (s *Server) SetStandupStore(ss *standup.Store, notifier *dispatch.Notifier) {
+	s.standupStore = ss
+	s.notifier = notifier
 }
 
 // Serve runs the MCP server on stdio (stdin/stdout JSON-RPC).
@@ -428,6 +438,68 @@ func (s *Server) handleToolCall(req Request) Response {
 		}
 		return textResult(req.ID, msg)
 
+	case "standup_report":
+		if s.standupStore == nil {
+			return errorResp(req.ID, -32000, "standup store not initialized")
+		}
+		var args struct {
+			Squad    string   `json:"squad"`
+			Done     []string `json:"done"`
+			Doing    []string `json:"doing"`
+			Blocked  []string `json:"blocked"`
+			Requests []string `json:"requests"`
+		}
+		json.Unmarshal(params.Arguments, &args)
+		if args.Squad == "" {
+			return errorResp(req.ID, -32602, "squad is required")
+		}
+		report, err := s.standupStore.Put(ctx, args.Squad, agentID, args.Done, args.Doing, args.Blocked, args.Requests)
+		if err != nil {
+			return errorResp(req.ID, -32000, err.Error())
+		}
+
+		msg := fmt.Sprintf("Standup filed for squad %s (%s). Status: %s",
+			report.Squad, report.Timestamp, standup.StatusOf(report))
+
+		// Post unified standup to Slack if notifier is configured.
+		if s.notifier != nil && s.notifier.Enabled() {
+			all, err := s.standupStore.GetAllToday(ctx)
+			if err == nil {
+				if slackErr := s.notifier.PostStandup(ctx, all); slackErr != nil {
+					fmt.Fprintf(os.Stderr, "standup slack post: %v\n", slackErr)
+				}
+			}
+		}
+		return textResult(req.ID, msg)
+
+	case "standup_read":
+		if s.standupStore == nil {
+			return errorResp(req.ID, -32000, "standup store not initialized")
+		}
+		var args struct {
+			Squad string `json:"squad"`
+			Date  string `json:"date"`
+		}
+		json.Unmarshal(params.Arguments, &args)
+		if args.Squad == "" {
+			return errorResp(req.ID, -32602, "squad is required")
+		}
+		var report *standup.Report
+		var err error
+		if args.Date != "" {
+			report, err = s.standupStore.Get(ctx, args.Squad, args.Date)
+		} else {
+			report, err = s.standupStore.GetToday(ctx, args.Squad)
+		}
+		if err != nil {
+			return errorResp(req.ID, -32000, err.Error())
+		}
+		if report == nil {
+			return textResult(req.ID, fmt.Sprintf("No standup found for squad %s today.", args.Squad))
+		}
+		data, _ := json.Marshal(report)
+		return textResult(req.ID, string(data))
+
 	default:
 		return errorResp(req.ID, -32601, fmt.Sprintf("unknown tool: %s", params.Name))
 	}
@@ -677,6 +749,33 @@ func toolDefs() []ToolDef {
 					"pr_number":  map[string]interface{}{"type": "number", "description": "PR number if the work resulted in a pull request (optional)"},
 				},
 				"required": []string{"request_id", "result"},
+			},
+		},
+		{
+			Name:        "standup_report",
+			Description: "Post your squad's async standup. Stores done/doing/blocked/requests in Redis and triggers a unified Slack standup post with all squads that have reported today.",
+			InputSchema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"squad":    map[string]string{"type": "string", "description": "Your squad name (e.g. 'kernel', 'octi-pulpo', 'shellforge')"},
+					"done":     map[string]interface{}{"type": "array", "items": map[string]string{"type": "string"}, "description": "What your squad completed since the last standup"},
+					"doing":    map[string]interface{}{"type": "array", "items": map[string]string{"type": "string"}, "description": "What your squad is currently working on"},
+					"blocked":  map[string]interface{}{"type": "array", "items": map[string]string{"type": "string"}, "description": "Blockers — issue numbers, dependencies, or external waits"},
+					"requests": map[string]interface{}{"type": "array", "items": map[string]string{"type": "string"}, "description": "Requests to other squads or the CTO"},
+				},
+				"required": []string{"squad"},
+			},
+		},
+		{
+			Name:        "standup_read",
+			Description: "Read another squad's standup report. Returns done/doing/blocked/requests and status (GREEN/YELLOW/RED). Defaults to today's report.",
+			InputSchema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"squad": map[string]string{"type": "string", "description": "Squad name to read (e.g. 'analytics', 'kernel')"},
+					"date":  map[string]string{"type": "string", "description": "Date to read (YYYY-MM-DD). Defaults to today."},
+				},
+				"required": []string{"squad"},
 			},
 		},
 	}

--- a/internal/standup/store.go
+++ b/internal/standup/store.go
@@ -1,0 +1,140 @@
+package standup
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+// Report is a squad's async standup entry for a given date.
+type Report struct {
+	Squad     string   `json:"squad"`
+	Done      []string `json:"done"`
+	Doing     []string `json:"doing"`
+	Blocked   []string `json:"blocked"`
+	Requests  []string `json:"requests"`
+	AuthorID  string   `json:"author_id"`
+	Timestamp string   `json:"timestamp"`
+}
+
+// Status summarises a squad's standup health for display.
+type Status string
+
+const (
+	StatusGreen  Status = "GREEN"
+	StatusYellow Status = "YELLOW"
+	StatusRed    Status = "RED"
+)
+
+// StatusOf derives a traffic-light status from a report:
+//   - RED    — nothing done and has blockers, or completely empty
+//   - YELLOW — has blockers but also has done items
+//   - GREEN  — no blockers
+func StatusOf(r *Report) Status {
+	hasDone := len(r.Done) > 0
+	hasBlocked := len(r.Blocked) > 0
+	if !hasDone && hasBlocked {
+		return StatusRed
+	}
+	if !hasDone && len(r.Doing) == 0 {
+		return StatusRed
+	}
+	if hasBlocked {
+		return StatusYellow
+	}
+	return StatusGreen
+}
+
+// Store manages standup entries in Redis.
+type Store struct {
+	rdb *redis.Client
+	ns  string
+}
+
+// New connects to Redis and returns a Store.
+func New(rdb *redis.Client, namespace string) *Store {
+	return &Store{rdb: rdb, ns: namespace}
+}
+
+// Put stores or overwrites today's standup for squad.
+// Returns the key under which it was stored.
+func (s *Store) Put(ctx context.Context, squad, authorID string, done, doing, blocked, requests []string) (*Report, error) {
+	r := &Report{
+		Squad:     squad,
+		Done:      done,
+		Doing:     doing,
+		Blocked:   blocked,
+		Requests:  requests,
+		AuthorID:  authorID,
+		Timestamp: time.Now().UTC().Format(time.RFC3339),
+	}
+	data, err := json.Marshal(r)
+	if err != nil {
+		return nil, err
+	}
+
+	date := time.Now().UTC().Format("2006-01-02")
+	key := s.key(squad, date)
+
+	// Keep standup data for 7 days.
+	if err := s.rdb.Set(ctx, key, data, 7*24*time.Hour).Err(); err != nil {
+		return nil, fmt.Errorf("store standup for %s: %w", squad, err)
+	}
+
+	// Track which squads reported today so GetAllToday can discover them.
+	setKey := s.ns + ":standups:squads:" + date
+	s.rdb.SAdd(ctx, setKey, squad)
+	s.rdb.Expire(ctx, setKey, 7*24*time.Hour)
+
+	return r, nil
+}
+
+// Get retrieves the standup report for squad on date (YYYY-MM-DD).
+// Returns nil, nil when no report exists.
+func (s *Store) Get(ctx context.Context, squad, date string) (*Report, error) {
+	raw, err := s.rdb.Get(ctx, s.key(squad, date)).Bytes()
+	if err == redis.Nil {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get standup %s/%s: %w", squad, date, err)
+	}
+	var r Report
+	if err := json.Unmarshal(raw, &r); err != nil {
+		return nil, err
+	}
+	return &r, nil
+}
+
+// GetToday returns squad's standup for today's UTC date.
+func (s *Store) GetToday(ctx context.Context, squad string) (*Report, error) {
+	return s.Get(ctx, squad, time.Now().UTC().Format("2006-01-02"))
+}
+
+// GetAllToday returns all standup reports filed today, keyed by squad name.
+func (s *Store) GetAllToday(ctx context.Context) (map[string]*Report, error) {
+	date := time.Now().UTC().Format("2006-01-02")
+	setKey := s.ns + ":standups:squads:" + date
+
+	squads, err := s.rdb.SMembers(ctx, setKey).Result()
+	if err != nil {
+		return nil, fmt.Errorf("list squads: %w", err)
+	}
+
+	results := make(map[string]*Report, len(squads))
+	for _, sq := range squads {
+		r, err := s.Get(ctx, sq, date)
+		if err != nil || r == nil {
+			continue
+		}
+		results[sq] = r
+	}
+	return results, nil
+}
+
+func (s *Store) key(squad, date string) string {
+	return fmt.Sprintf("%s:standup:%s:%s", s.ns, squad, date)
+}

--- a/internal/standup/store_test.go
+++ b/internal/standup/store_test.go
@@ -1,0 +1,53 @@
+package standup
+
+import (
+	"testing"
+)
+
+func TestStatusOf(t *testing.T) {
+	tests := []struct {
+		name    string
+		report  Report
+		want    Status
+	}{
+		{
+			name:   "green — has done, no blockers",
+			report: Report{Done: []string{"Merged #1"}, Doing: []string{"Working on #2"}},
+			want:   StatusGreen,
+		},
+		{
+			name:   "green — doing only, no blockers",
+			report: Report{Doing: []string{"Working on #2"}},
+			want:   StatusGreen,
+		},
+		{
+			name:   "yellow — done and blocked",
+			report: Report{Done: []string{"Merged #1"}, Blocked: []string{"#2 needs review"}},
+			want:   StatusYellow,
+		},
+		{
+			name:   "red — blocked, nothing done",
+			report: Report{Blocked: []string{"#2 needs review"}},
+			want:   StatusRed,
+		},
+		{
+			name:   "red — completely empty",
+			report: Report{},
+			want:   StatusRed,
+		},
+		{
+			name:   "green — has requests but no blockers",
+			report: Report{Done: []string{"Merged #1"}, Requests: []string{"analytics report"}},
+			want:   StatusGreen,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := StatusOf(&tc.report)
+			if got != tc.want {
+				t.Errorf("StatusOf(%+v) = %q, want %q", tc.report, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `standup_report` MCP tool: EM agents post squad standups (done/doing/blocked/requests) that are stored in Redis and immediately trigger a unified Slack Block Kit message for all squads that have reported today.
- Adds `standup_read` MCP tool: any agent can read another squad's standup by name, defaulting to today's date.
- Adds `internal/standup.Store` — Redis-backed with 7-day TTL and a per-date squad-discovery set so `GetAllToday` finds all reporters without a fixed list.
- Adds `dispatch.Notifier.PostStandup` — sorts squads alphabetically, renders GREEN 🟢 / YELLOW 🟡 / RED 🔴 status, and includes a `[Reprioritize]` action button.
- Wires everything into `cmd/octi-pulpo/main.go` via `SLACK_WEBHOOK_URL`.

## Test plan

- [ ] `go test ./internal/standup/...` — 6 `StatusOf` unit tests pass
- [ ] `go build ./...` — clean build
- [ ] `go vet ./...` — no issues
- [ ] Manual: call `standup_report` via MCP client → check Redis key + Slack webhook fires
- [ ] Manual: call `standup_read` with a squad that has no report → returns "No standup found"
- [ ] Manual: call `standup_read` with a valid squad → returns JSON with done/doing/blocked/requests

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)