### PR TITLE
feat(standup): async standups — standup_report + standup_read MCP tools

### DIFF
--- a/cmd/octi-pulpo/main.go
+++ b/cmd/octi-pulpo/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/AgentGuardHQ/octi-pulpo/internal/memory"
 	"github.com/AgentGuardHQ/octi-pulpo/internal/routing"
 	"github.com/AgentGuardHQ/octi-pulpo/internal/sprint"
+	"github.com/AgentGuardHQ/octi-pulpo/internal/standup"
 	"github.com/redis/go-redis/v9"
 )
 
@@ -83,12 +84,21 @@ func main() {
 	// Set up benchmark tracker
 	benchmark := dispatch.NewBenchmarkTracker(rdb, namespace)
 
+	// Set up standup store
+	standupStore := standup.NewStore(rdb, namespace)
+
 	server := mcp.New(mem, coord, router)
 	server.SetDispatcher(dispatcher)
 	server.SetSprintStore(sprintStore)
 	server.SetBenchmark(benchmark)
 	server.SetProfileStore(profiles)
+	server.SetStandupStore(standupStore)
 	server.SetRedis(rdb, namespace)
+
+	// Wire Slack notifier into MCP server for standup digests
+	if slackURL := os.Getenv("SLACK_WEBHOOK_URL"); slackURL != "" {
+		server.SetNotifier(dispatch.NewNotifier(slackURL))
+	}
 
 	// Optional HTTP mode: run webhook server alongside MCP
 	httpPort := os.Getenv("OCTI_HTTP_PORT")

--- a/internal/dispatch/slack.go
+++ b/internal/dispatch/slack.go
@@ -156,6 +156,14 @@ func (n *Notifier) PostSprintGoalAlert(ctx context.Context, squad, goal string) 
 	return n.postBlocks(ctx, blocks)
 }
 
+// PostText sends a plain-text mrkdwn message to the Slack webhook.
+func (n *Notifier) PostText(ctx context.Context, text string) error {
+	if !n.Enabled() {
+		return nil
+	}
+	return n.post(ctx, map[string]interface{}{"text": text})
+}
+
 // postBlocks sends a Slack Block Kit payload to the webhook URL.
 func (n *Notifier) postBlocks(ctx context.Context, blocks []map[string]interface{}) error {
 	return n.post(ctx, map[string]interface{}{"blocks": blocks})

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -15,6 +15,7 @@ import (
 	"github.com/AgentGuardHQ/octi-pulpo/internal/memory"
 	"github.com/AgentGuardHQ/octi-pulpo/internal/routing"
 	"github.com/AgentGuardHQ/octi-pulpo/internal/sprint"
+	"github.com/AgentGuardHQ/octi-pulpo/internal/standup"
 	"github.com/redis/go-redis/v9"
 )
 
@@ -49,15 +50,17 @@ type RPCError struct {
 
 // Server is the Octi Pulpo MCP server.
 type Server struct {
-	mem         *memory.Store
-	coord       *coordination.Engine
-	router      *routing.Router
-	dispatcher  *dispatch.Dispatcher
-	sprintStore *sprint.Store
-	benchmark   *dispatch.BenchmarkTracker
-	profiles    *dispatch.ProfileStore
-	rdb         *redis.Client
-	redisNS     string
+	mem          *memory.Store
+	coord        *coordination.Engine
+	router       *routing.Router
+	dispatcher   *dispatch.Dispatcher
+	sprintStore  *sprint.Store
+	benchmark    *dispatch.BenchmarkTracker
+	profiles     *dispatch.ProfileStore
+	standupStore *standup.Store
+	notifier     *dispatch.Notifier
+	rdb          *redis.Client
+	redisNS      string
 }
 
 // New creates an MCP server backed by the given memory and coordination engines.
@@ -83,6 +86,16 @@ func (s *Server) SetBenchmark(bt *dispatch.BenchmarkTracker) {
 // SetProfileStore enables the agent leaderboard MCP tool.
 func (s *Server) SetProfileStore(ps *dispatch.ProfileStore) {
 	s.profiles = ps
+}
+
+// SetStandupStore enables standup_report and standup_read MCP tools.
+func (s *Server) SetStandupStore(ss *standup.Store) {
+	s.standupStore = ss
+}
+
+// SetNotifier enables Slack posting from MCP tools (e.g. daily standup digest).
+func (s *Server) SetNotifier(n *dispatch.Notifier) {
+	s.notifier = n
 }
 
 // SetRedis enables Redis-backed budget enrichment for the health_report tool.
@@ -445,6 +458,69 @@ func (s *Server) handleToolCall(req Request) Response {
 		}
 		return textResult(req.ID, msg)
 
+	case "standup_report":
+		if s.standupStore == nil {
+			return errorResp(req.ID, -32000, "standup store not initialized")
+		}
+		var args struct {
+			Squad    string   `json:"squad"`
+			Done     []string `json:"done"`
+			Doing    []string `json:"doing"`
+			Blocked  []string `json:"blocked"`
+			Requests []string `json:"requests"`
+		}
+		json.Unmarshal(params.Arguments, &args)
+		if args.Squad == "" {
+			return errorResp(req.ID, -32602, "squad is required")
+		}
+		if err := s.standupStore.Report(ctx, args.Squad, agentID, args.Done, args.Doing, args.Blocked, args.Requests); err != nil {
+			return errorResp(req.ID, -32000, err.Error())
+		}
+		msg := fmt.Sprintf("Standup filed for squad %q by %s", args.Squad, agentID)
+		if len(args.Blocked) > 0 {
+			msg += fmt.Sprintf(" — %d blocker(s) noted", len(args.Blocked))
+		}
+		// Post unified digest to Slack whenever any standup is filed
+		if s.notifier != nil {
+			today := time.Now().UTC().Format("2006-01-02")
+			if entries, err := s.standupStore.ReadToday(ctx); err == nil {
+				_ = s.notifier.PostText(ctx, standup.FormatSlack(today, entries))
+			}
+		}
+		return textResult(req.ID, msg)
+
+	case "standup_read":
+		if s.standupStore == nil {
+			return errorResp(req.ID, -32000, "standup store not initialized")
+		}
+		var args struct {
+			Squad string `json:"squad"`
+			Date  string `json:"date"`
+		}
+		json.Unmarshal(params.Arguments, &args)
+		today := time.Now().UTC().Format("2006-01-02")
+		date := args.Date
+		if date == "" {
+			date = today
+		}
+		if args.Squad != "" {
+			entry, err := s.standupStore.Read(ctx, args.Squad, date)
+			if err != nil {
+				return errorResp(req.ID, -32000, err.Error())
+			}
+			if entry == nil {
+				return textResult(req.ID, fmt.Sprintf("No standup filed for squad %q on %s.", args.Squad, date))
+			}
+			data, _ := json.Marshal(entry)
+			return textResult(req.ID, string(data))
+		}
+		// No squad specified — return all squads for the date
+		entries, err := s.standupStore.ReadDate(ctx, date)
+		if err != nil {
+			return errorResp(req.ID, -32000, err.Error())
+		}
+		return textResult(req.ID, standup.FormatSlack(date, entries))
+
 	default:
 		return errorResp(req.ID, -32601, fmt.Sprintf("unknown tool: %s", params.Name))
 	}
@@ -715,6 +791,32 @@ func toolDefs() []ToolDef {
 					"pr_number":  map[string]interface{}{"type": "number", "description": "PR number if the work resulted in a pull request (optional)"},
 				},
 				"required": []string{"request_id", "result"},
+			},
+		},
+		{
+			Name:        "standup_report",
+			Description: "Post your squad's async standup — done, doing, blocked, requests. Stored in Redis and triggers a unified Slack digest. Call at the start of each scheduled run.",
+			InputSchema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"squad":    map[string]string{"type": "string", "description": "Your squad name (e.g. 'kernel', 'octi-pulpo', 'shellforge')"},
+					"done":     map[string]interface{}{"type": "array", "items": map[string]string{"type": "string"}, "description": "What your squad completed since the last standup"},
+					"doing":    map[string]interface{}{"type": "array", "items": map[string]string{"type": "string"}, "description": "What your squad is actively working on now"},
+					"blocked":  map[string]interface{}{"type": "array", "items": map[string]string{"type": "string"}, "description": "Blockers — issues, dependencies, or requests that are stuck"},
+					"requests": map[string]interface{}{"type": "array", "items": map[string]string{"type": "string"}, "description": "Things you need from other squads or the CTO"},
+				},
+				"required": []string{"squad"},
+			},
+		},
+		{
+			Name:        "standup_read",
+			Description: "Read async standup reports. Omit squad to get all squads for the day as a formatted digest. Pass squad name to get a specific squad's raw entry. Optionally pass date (YYYY-MM-DD) for historical lookups.",
+			InputSchema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"squad": map[string]string{"type": "string", "description": "Squad name to read. Omit to get all squads' standups for the date."},
+					"date":  map[string]string{"type": "string", "description": "Date in YYYY-MM-DD format. Defaults to today (UTC)."},
+				},
 			},
 		},
 	}

--- a/internal/standup/store.go
+++ b/internal/standup/store.go
@@ -1,0 +1,146 @@
+// Package standup provides async standup storage and formatting for the swarm.
+// Each squad's EM posts a daily standup via the standup_report MCP tool.
+// Standups are stored in Redis at {ns}:standup:{squad}:{YYYY-MM-DD} and
+// expire after 30 days. The brain aggregates them into a unified Slack digest.
+package standup
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+// Entry represents a single squad's async standup for a given day.
+type Entry struct {
+	Squad    string   `json:"squad"`
+	Done     []string `json:"done"`
+	Doing    []string `json:"doing"`
+	Blocked  []string `json:"blocked"`
+	Requests []string `json:"requests"`
+	PostedBy string   `json:"posted_by"`
+	PostedAt string   `json:"posted_at"`
+}
+
+// Store manages async standup reports in Redis.
+type Store struct {
+	rdb       *redis.Client
+	namespace string
+}
+
+// NewStore creates a standup store backed by Redis.
+func NewStore(rdb *redis.Client, namespace string) *Store {
+	return &Store{rdb: rdb, namespace: namespace}
+}
+
+// Report stores a squad's standup for today, overwriting any prior report.
+func (s *Store) Report(ctx context.Context, squad, postedBy string, done, doing, blocked, requests []string) error {
+	date := time.Now().UTC().Format("2006-01-02")
+	key := s.key(squad, date)
+	e := Entry{
+		Squad:    squad,
+		Done:     done,
+		Doing:    doing,
+		Blocked:  blocked,
+		Requests: requests,
+		PostedBy: postedBy,
+		PostedAt: time.Now().UTC().Format(time.RFC3339),
+	}
+	data, err := json.Marshal(e)
+	if err != nil {
+		return fmt.Errorf("standup: marshal: %w", err)
+	}
+	return s.rdb.Set(ctx, key, data, 30*24*time.Hour).Err()
+}
+
+// Read returns the standup for the given squad and date (YYYY-MM-DD).
+// Returns nil entry (no error) if no standup has been filed.
+func (s *Store) Read(ctx context.Context, squad, date string) (*Entry, error) {
+	data, err := s.rdb.Get(ctx, s.key(squad, date)).Bytes()
+	if err == redis.Nil {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("standup: read %s/%s: %w", squad, date, err)
+	}
+	var e Entry
+	if err := json.Unmarshal(data, &e); err != nil {
+		return nil, fmt.Errorf("standup: unmarshal: %w", err)
+	}
+	return &e, nil
+}
+
+// ReadToday returns all filed standups for the current UTC day.
+func (s *Store) ReadToday(ctx context.Context) ([]Entry, error) {
+	return s.ReadDate(ctx, time.Now().UTC().Format("2006-01-02"))
+}
+
+// ReadDate returns all filed standups for the given date (YYYY-MM-DD).
+func (s *Store) ReadDate(ctx context.Context, date string) ([]Entry, error) {
+	pattern := fmt.Sprintf("%s:standup:*:%s", s.namespace, date)
+	keys, err := s.rdb.Keys(ctx, pattern).Result()
+	if err != nil {
+		return nil, fmt.Errorf("standup: scan %s: %w", date, err)
+	}
+	entries := make([]Entry, 0, len(keys))
+	for _, key := range keys {
+		data, err := s.rdb.Get(ctx, key).Bytes()
+		if err != nil {
+			continue
+		}
+		var e Entry
+		if err := json.Unmarshal(data, &e); err != nil {
+			continue
+		}
+		entries = append(entries, e)
+	}
+	return entries, nil
+}
+
+func (s *Store) key(squad, date string) string {
+	return fmt.Sprintf("%s:standup:%s:%s", s.namespace, squad, date)
+}
+
+// FormatSlack formats standup entries as a Slack mrkdwn digest.
+func FormatSlack(date string, entries []Entry) string {
+	if len(entries) == 0 {
+		return fmt.Sprintf("*📋 Daily Standup — %s*\nNo standups filed yet.", date)
+	}
+
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("*📋 Daily Standup — %s*\n\n", date))
+
+	for _, e := range entries {
+		icon := "🟢"
+		if len(e.Blocked) > 0 {
+			icon = "🟡"
+		}
+		title := titleCase(e.Squad)
+		sb.WriteString(fmt.Sprintf("%s *%s*\n", icon, title))
+		if len(e.Done) > 0 {
+			sb.WriteString(fmt.Sprintf("  *Done:* %s\n", strings.Join(e.Done, ", ")))
+		}
+		if len(e.Doing) > 0 {
+			sb.WriteString(fmt.Sprintf("  *Doing:* %s\n", strings.Join(e.Doing, ", ")))
+		}
+		if len(e.Blocked) > 0 {
+			sb.WriteString(fmt.Sprintf("  *Blocked:* %s\n", strings.Join(e.Blocked, ", ")))
+		}
+		if len(e.Requests) > 0 {
+			sb.WriteString(fmt.Sprintf("  *Requests:* %s\n", strings.Join(e.Requests, ", ")))
+		}
+		sb.WriteString("\n")
+	}
+
+	return strings.TrimRight(sb.String(), "\n")
+}
+
+func titleCase(s string) string {
+	if s == "" {
+		return s
+	}
+	return strings.ToUpper(s[:1]) + s[1:]
+}

--- a/internal/standup/store_test.go
+++ b/internal/standup/store_test.go
@@ -1,0 +1,155 @@
+package standup
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+func testSetup(t *testing.T) (*Store, context.Context) {
+	t.Helper()
+	opts, err := redis.ParseURL("redis://localhost:6379")
+	if err != nil {
+		t.Skipf("skipping: cannot parse redis URL: %v", err)
+	}
+	rdb := redis.NewClient(opts)
+	ctx := context.Background()
+	if err := rdb.Ping(ctx).Err(); err != nil {
+		t.Skipf("skipping: redis not available: %v", err)
+	}
+	ns := "standup-test-" + strings.ReplaceAll(t.Name(), "/", "-")
+	t.Cleanup(func() {
+		keys, _ := rdb.Keys(ctx, ns+":*").Result()
+		if len(keys) > 0 {
+			rdb.Del(ctx, keys...)
+		}
+		rdb.Close()
+	})
+	return NewStore(rdb, ns), ctx
+}
+
+func TestReport_and_Read(t *testing.T) {
+	store, ctx := testSetup(t)
+
+	err := store.Report(ctx, "kernel", "kernel-jr",
+		[]string{"Merged PR #1391"},
+		[]string{"Working on #1410"},
+		[]string{"#1376 needs NODE_PATH fix"},
+		[]string{"analytics report"},
+	)
+	if err != nil {
+		t.Fatalf("Report: %v", err)
+	}
+
+	date := time.Now().UTC().Format("2006-01-02")
+	entry, err := store.Read(ctx, "kernel", date)
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if entry == nil {
+		t.Fatal("expected entry, got nil")
+	}
+	if entry.Squad != "kernel" {
+		t.Errorf("squad = %q, want %q", entry.Squad, "kernel")
+	}
+	if entry.PostedBy != "kernel-jr" {
+		t.Errorf("posted_by = %q, want %q", entry.PostedBy, "kernel-jr")
+	}
+	if len(entry.Done) != 1 || entry.Done[0] != "Merged PR #1391" {
+		t.Errorf("done = %v, want [Merged PR #1391]", entry.Done)
+	}
+	if len(entry.Blocked) != 1 {
+		t.Errorf("blocked = %v, want 1 item", entry.Blocked)
+	}
+}
+
+func TestRead_missing(t *testing.T) {
+	store, ctx := testSetup(t)
+	entry, err := store.Read(ctx, "nonexistent", "2000-01-01")
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if entry != nil {
+		t.Errorf("expected nil for missing entry, got %+v", entry)
+	}
+}
+
+func TestReadToday_multipleSquads(t *testing.T) {
+	store, ctx := testSetup(t)
+
+	squads := []string{"kernel", "octi-pulpo", "shellforge"}
+	for _, sq := range squads {
+		err := store.Report(ctx, sq, sq+"-em",
+			[]string{"done item"},
+			[]string{"doing item"},
+			nil,
+			nil,
+		)
+		if err != nil {
+			t.Fatalf("Report %s: %v", sq, err)
+		}
+	}
+
+	entries, err := store.ReadToday(ctx)
+	if err != nil {
+		t.Fatalf("ReadToday: %v", err)
+	}
+	if len(entries) != len(squads) {
+		t.Errorf("ReadToday returned %d entries, want %d", len(entries), len(squads))
+	}
+}
+
+func TestReport_overwrite(t *testing.T) {
+	store, ctx := testSetup(t)
+
+	// File initial standup
+	if err := store.Report(ctx, "kernel", "agent-v1", []string{"old work"}, nil, nil, nil); err != nil {
+		t.Fatalf("first Report: %v", err)
+	}
+	// Overwrite with updated standup
+	if err := store.Report(ctx, "kernel", "agent-v2", []string{"updated work"}, nil, nil, nil); err != nil {
+		t.Fatalf("second Report: %v", err)
+	}
+
+	date := time.Now().UTC().Format("2006-01-02")
+	entry, err := store.Read(ctx, "kernel", date)
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if entry.PostedBy != "agent-v2" {
+		t.Errorf("expected overwrite: posted_by = %q, want agent-v2", entry.PostedBy)
+	}
+	if len(entry.Done) != 1 || entry.Done[0] != "updated work" {
+		t.Errorf("expected overwrite: done = %v", entry.Done)
+	}
+}
+
+func TestFormatSlack_empty(t *testing.T) {
+	got := FormatSlack("2026-03-30", nil)
+	if !strings.Contains(got, "No standups filed") {
+		t.Errorf("expected 'No standups filed', got: %s", got)
+	}
+}
+
+func TestFormatSlack_withEntries(t *testing.T) {
+	entries := []Entry{
+		{Squad: "kernel", Done: []string{"Merged PR #1"}, Doing: []string{"#1410"}, Blocked: []string{"#1376"}, Requests: []string{"analytics"}},
+		{Squad: "shellforge", Done: []string{"Fixed bug"}, Doing: []string{"Tests"}},
+	}
+	got := FormatSlack("2026-03-30", entries)
+	if !strings.Contains(got, "Daily Standup — 2026-03-30") {
+		t.Errorf("missing date header in: %s", got)
+	}
+	if !strings.Contains(got, "🟡") {
+		t.Errorf("expected blocked icon for kernel in: %s", got)
+	}
+	if !strings.Contains(got, "🟢") {
+		t.Errorf("expected green icon for shellforge in: %s", got)
+	}
+	if !strings.Contains(got, "#1376") {
+		t.Errorf("blocker not in output: %s", got)
+	}
+}


### PR DESCRIPTION
## Summary

Implements #44 — async daily standups for the swarm.

- **`standup_report`** MCP tool: squad EMs file their standup (`done`, `doing`, `blocked`, `requests`). Stored in Redis at `{ns}:standup:{squad}:{YYYY-MM-DD}` with 30-day TTL. Overwrites any prior report for the same squad+day.
- **`standup_read`** MCP tool: read a single squad's raw entry, or all squads as a formatted Slack digest (omit `squad` param). Accepts optional `date` for historical lookups.
- **Slack digest**: when `SLACK_WEBHOOK_URL` is set, each `standup_report` call re-posts the unified all-squad digest so the CTO always sees the current day's picture.
- **`PostText`** added to `dispatch.Notifier` for plain mrkdwn Slack messages.
- **6 tests** in `internal/standup/store_test.go` — cover report, read, overwrite, multi-squad, format (green/yellow icons, blockers).

## Files changed

| File | Change |
|------|--------|
| `internal/standup/store.go` | New package — `Entry`, `Store`, `FormatSlack` |
| `internal/standup/store_test.go` | 6 integration tests |
| `internal/dispatch/slack.go` | +`PostText` method |
| `internal/mcp/server.go` | +`standup_report`/`standup_read` handlers + tool defs |
| `cmd/octi-pulpo/main.go` | Wires `standup.Store` + `Notifier` into MCP server |

## Test plan

- [ ] `go test ./internal/standup/...` — all 6 pass (requires local Redis)
- [ ] `go build ./...` and `go vet ./...` — clean
- [ ] Call `standup_report` via MCP client, verify Redis key set
- [ ] Call `standup_read` without squad arg, verify formatted digest returned
- [ ] With `SLACK_WEBHOOK_URL` set, verify Slack message posted on `standup_report`

🤖 Generated with [Claude Code](https://claude.com/claude-code)