### PR TITLE
feat: async standups — standup_report and standup_read MCP tools

### DIFF
--- a/cmd/octi-pulpo/main.go
+++ b/cmd/octi-pulpo/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/AgentGuardHQ/octi-pulpo/internal/memory"
 	"github.com/AgentGuardHQ/octi-pulpo/internal/routing"
 	"github.com/AgentGuardHQ/octi-pulpo/internal/sprint"
+	"github.com/AgentGuardHQ/octi-pulpo/internal/standup"
 	"github.com/redis/go-redis/v9"
 )
 
@@ -83,11 +84,15 @@ func main() {
 	// Set up benchmark tracker
 	benchmark := dispatch.NewBenchmarkTracker(rdb, namespace)
 
+	// Set up standup store
+	standupStore := standup.New(rdb, namespace)
+
 	server := mcp.New(mem, coord, router)
 	server.SetDispatcher(dispatcher)
 	server.SetSprintStore(sprintStore)
 	server.SetBenchmark(benchmark)
 	server.SetProfileStore(profiles)
+	server.SetStandupStore(standupStore)
 	server.SetRedis(rdb, namespace)
 
 	// Optional HTTP mode: run webhook server alongside MCP
@@ -125,6 +130,7 @@ func main() {
 			brain := dispatch.NewBrain(dispatcher, chains)
 			brain.SetSprintStore(sprintStore)
 			brain.SetProfileStore(profiles)
+			brain.SetStandupStore(standupStore)
 			if slackURL := os.Getenv("SLACK_WEBHOOK_URL"); slackURL != "" {
 				brain.SetNotifier(dispatch.NewNotifier(slackURL))
 			}

--- a/internal/dispatch/brain.go
+++ b/internal/dispatch/brain.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/AgentGuardHQ/octi-pulpo/internal/routing"
 	"github.com/AgentGuardHQ/octi-pulpo/internal/sprint"
+	"github.com/AgentGuardHQ/octi-pulpo/internal/standup"
 )
 
 // Constraint represents the single most important bottleneck in the system.
@@ -42,6 +43,7 @@ type LeverageAction struct {
 //   - Sprint store sync: periodically refresh issue data from GitHub
 //   - Driver health probe: ping each driver every 15 min to detect stale state
 //   - Slack notifications: periodic budget dashboard + driver state change alerts
+//   - Daily standup digest: post aggregated squad standups to Slack once per day
 type Brain struct {
 	dispatcher      *Dispatcher
 	chains          ChainConfig
@@ -51,9 +53,12 @@ type Brain struct {
 	sprintStore     *sprint.Store
 	profiles        *ProfileStore
 	notifier        *Notifier
+	standupStore    *standup.Store
 	lastSync        time.Time
 	lastProbe       time.Time
 	lastDashboard   time.Time
+	lastStandup     time.Time
+	standupDate     string // the date for which we last posted a digest
 	dashboardPeriod time.Duration
 	driversWereDown bool // tracks transition for edge-triggered alerts
 }
@@ -83,6 +88,11 @@ func (b *Brain) SetProfileStore(ps *ProfileStore) {
 // SetNotifier enables Slack notifications for driver state changes and periodic dashboards.
 func (b *Brain) SetNotifier(n *Notifier) {
 	b.notifier = n
+}
+
+// SetStandupStore enables posting of daily standup digests to Slack.
+func (b *Brain) SetStandupStore(ss *standup.Store) {
+	b.standupStore = ss
 }
 
 // Run starts the brain evaluation loop. Blocks until context is cancelled.
@@ -122,7 +132,10 @@ func (b *Brain) Tick(ctx context.Context) {
 	// 4. Periodic Slack dashboard
 	b.maybePostDashboard(ctx)
 
-	// 5. Constraint-driven dispatch (if sprint store is available)
+	// 5. Daily standup digest (once per calendar day, after standups have accumulated)
+	b.maybePostStandupDigest(ctx)
+
+	// 6. Constraint-driven dispatch (if sprint store is available)
 	if b.sprintStore != nil {
 		constraint := b.identifyConstraint(ctx)
 		b.maybeNotifyConstraintChange(ctx, constraint)
@@ -263,6 +276,45 @@ func (b *Brain) maybePostDashboard(ctx context.Context) {
 		return
 	}
 	b.lastDashboard = time.Now()
+}
+
+// maybePostStandupDigest posts the aggregated daily standup to Slack once per
+// calendar day (UTC). It waits until at least one standup has been posted
+// before firing, and only re-fires if the calendar date has changed.
+func (b *Brain) maybePostStandupDigest(ctx context.Context) {
+	if b.notifier == nil || !b.notifier.Enabled() {
+		return
+	}
+	if b.standupStore == nil {
+		return
+	}
+	today := time.Now().UTC().Format("2006-01-02")
+	if b.standupDate == today {
+		return // already posted today's digest
+	}
+	// Post no more than once every hour to avoid hammering Slack during
+	// early-morning warm-up while agents haven't posted yet.
+	if time.Since(b.lastStandup) < time.Hour {
+		return
+	}
+
+	reports, err := b.standupStore.ReadAll(ctx, today)
+	if err != nil {
+		b.log.Printf("standup digest: read all failed: %v", err)
+		return
+	}
+	if len(reports) == 0 {
+		b.lastStandup = time.Now()
+		return // no standups yet — try again next hour
+	}
+
+	if err := b.notifier.PostDailyStandup(ctx, today, reports); err != nil {
+		b.log.Printf("standup digest: slack post failed: %v", err)
+		return
+	}
+	b.standupDate = today
+	b.lastStandup = time.Now()
+	b.log.Printf("standup digest: posted %d squad standups for %s", len(reports), today)
 }
 
 // maybeNotifyConstraintChange fires edge-triggered Slack alerts when driver

--- a/internal/dispatch/slack.go
+++ b/internal/dispatch/slack.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/AgentGuardHQ/octi-pulpo/internal/routing"
+	"github.com/AgentGuardHQ/octi-pulpo/internal/standup"
 )
 
 // Notifier posts structured notifications to a Slack incoming webhook.
@@ -131,6 +132,52 @@ func (n *Notifier) PostPRReadyAlert(ctx context.Context, repo string, prNumber i
 			slackButton("review_pr", prKey, "Review", ""),
 			slackButton("skip_pr", prKey, "Skip", ""),
 		),
+	}
+
+	return n.postBlocks(ctx, blocks)
+}
+
+// PostDailyStandup sends the aggregated daily standup to Slack as a Block Kit message.
+// Each squad gets one section; traffic-light emoji indicates blocker status.
+func (n *Notifier) PostDailyStandup(ctx context.Context, date string, reports []standup.Report) error {
+	if !n.Enabled() {
+		return nil
+	}
+	if len(reports) == 0 {
+		return nil
+	}
+
+	header := fmt.Sprintf("*📋 Daily Standup — %s*", date)
+	blocks := []map[string]interface{}{blockSection(header)}
+
+	for _, r := range reports {
+		status := "🟢"
+		if len(r.Blocked) > 0 {
+			if len(r.Blocked) >= 2 {
+				status = "🔴"
+			} else {
+				status = "🟡"
+			}
+		}
+
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%s *%s*\n", status, strings.ToUpper(r.Squad)))
+		if len(r.Done) > 0 {
+			sb.WriteString(fmt.Sprintf("  Done: %s\n", strings.Join(r.Done, ", ")))
+		} else {
+			sb.WriteString("  Done: nothing\n")
+		}
+		if len(r.Doing) > 0 {
+			sb.WriteString(fmt.Sprintf("  Doing: %s\n", strings.Join(r.Doing, ", ")))
+		}
+		if len(r.Blocked) > 0 {
+			sb.WriteString(fmt.Sprintf("  Blocked: %s\n", strings.Join(r.Blocked, ", ")))
+		}
+		if len(r.Requests) > 0 {
+			sb.WriteString(fmt.Sprintf("  Requests: %s\n", strings.Join(r.Requests, ", ")))
+		}
+
+		blocks = append(blocks, blockSection(strings.TrimRight(sb.String(), "\n")))
 	}
 
 	return n.postBlocks(ctx, blocks)

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -15,6 +15,7 @@ import (
 	"github.com/AgentGuardHQ/octi-pulpo/internal/memory"
 	"github.com/AgentGuardHQ/octi-pulpo/internal/routing"
 	"github.com/AgentGuardHQ/octi-pulpo/internal/sprint"
+	"github.com/AgentGuardHQ/octi-pulpo/internal/standup"
 	"github.com/redis/go-redis/v9"
 )
 
@@ -49,15 +50,16 @@ type RPCError struct {
 
 // Server is the Octi Pulpo MCP server.
 type Server struct {
-	mem         *memory.Store
-	coord       *coordination.Engine
-	router      *routing.Router
-	dispatcher  *dispatch.Dispatcher
-	sprintStore *sprint.Store
-	benchmark   *dispatch.BenchmarkTracker
-	profiles    *dispatch.ProfileStore
-	rdb         *redis.Client
-	redisNS     string
+	mem           *memory.Store
+	coord         *coordination.Engine
+	router        *routing.Router
+	dispatcher    *dispatch.Dispatcher
+	sprintStore   *sprint.Store
+	benchmark     *dispatch.BenchmarkTracker
+	profiles      *dispatch.ProfileStore
+	standupStore  *standup.Store
+	rdb           *redis.Client
+	redisNS       string
 }
 
 // New creates an MCP server backed by the given memory and coordination engines.
@@ -83,6 +85,11 @@ func (s *Server) SetBenchmark(bt *dispatch.BenchmarkTracker) {
 // SetProfileStore enables the agent leaderboard MCP tool.
 func (s *Server) SetProfileStore(ps *dispatch.ProfileStore) {
 	s.profiles = ps
+}
+
+// SetStandupStore enables the standup_report and standup_read MCP tools.
+func (s *Server) SetStandupStore(ss *standup.Store) {
+	s.standupStore = ss
 }
 
 // SetRedis enables Redis-backed budget enrichment for the health_report tool.
@@ -445,6 +452,67 @@ func (s *Server) handleToolCall(req Request) Response {
 		}
 		return textResult(req.ID, msg)
 
+	case "standup_report":
+		if s.standupStore == nil {
+			return errorResp(req.ID, -32000, "standup store not initialized")
+		}
+		var args struct {
+			Squad    string   `json:"squad"`
+			Done     []string `json:"done"`
+			Doing    []string `json:"doing"`
+			Blocked  []string `json:"blocked"`
+			Requests []string `json:"requests"`
+		}
+		json.Unmarshal(params.Arguments, &args)
+		if args.Squad == "" {
+			return errorResp(req.ID, -32602, "squad is required")
+		}
+		r := standup.Report{
+			Squad:    args.Squad,
+			Done:     args.Done,
+			Doing:    args.Doing,
+			Blocked:  args.Blocked,
+			Requests: args.Requests,
+			PostedBy: agentID,
+		}
+		if err := s.standupStore.Post(ctx, r); err != nil {
+			return errorResp(req.ID, -32000, err.Error())
+		}
+		return textResult(req.ID, fmt.Sprintf(
+			"Standup posted for squad %s (done: %d, doing: %d, blocked: %d, requests: %d)",
+			args.Squad, len(args.Done), len(args.Doing), len(args.Blocked), len(args.Requests),
+		))
+
+	case "standup_read":
+		if s.standupStore == nil {
+			return errorResp(req.ID, -32000, "standup store not initialized")
+		}
+		var args struct {
+			Squad string `json:"squad"`
+			Date  string `json:"date"`
+		}
+		json.Unmarshal(params.Arguments, &args)
+		if args.Squad == "all" || args.Squad == "" {
+			reports, err := s.standupStore.ReadAll(ctx, args.Date)
+			if err != nil {
+				return errorResp(req.ID, -32000, err.Error())
+			}
+			if len(reports) == 0 {
+				return textResult(req.ID, "No standups posted yet today.")
+			}
+			data, _ := json.Marshal(reports)
+			return textResult(req.ID, string(data))
+		}
+		r, err := s.standupStore.Read(ctx, args.Squad, args.Date)
+		if err != nil {
+			return errorResp(req.ID, -32000, err.Error())
+		}
+		if r == nil {
+			return textResult(req.ID, fmt.Sprintf("No standup found for squad %s.", args.Squad))
+		}
+		data, _ := json.Marshal(r)
+		return textResult(req.ID, string(data))
+
 	default:
 		return errorResp(req.ID, -32601, fmt.Sprintf("unknown tool: %s", params.Name))
 	}
@@ -715,6 +783,32 @@ func toolDefs() []ToolDef {
 					"pr_number":  map[string]interface{}{"type": "number", "description": "PR number if the work resulted in a pull request (optional)"},
 				},
 				"required": []string{"request_id", "result"},
+			},
+		},
+		{
+			Name:        "standup_report",
+			Description: "Post your squad's async standup. Call once per scheduled run. Stored in Redis and aggregated into the daily Slack standup digest.",
+			InputSchema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"squad":    map[string]string{"type": "string", "description": "Your squad name (e.g. 'kernel', 'octi-pulpo', 'shellforge', 'analytics')"},
+					"done":     map[string]interface{}{"type": "array", "items": map[string]string{"type": "string"}, "description": "What you completed since the last standup (issue numbers, PR links, summaries)"},
+					"doing":    map[string]interface{}{"type": "array", "items": map[string]string{"type": "string"}, "description": "What you are currently working on"},
+					"blocked":  map[string]interface{}{"type": "array", "items": map[string]string{"type": "string"}, "description": "Blockers (issue refs, external deps, waiting-on). Omit or pass empty if unblocked."},
+					"requests": map[string]interface{}{"type": "array", "items": map[string]string{"type": "string"}, "description": "Cross-squad asks — what you need from other squads"},
+				},
+				"required": []string{"squad", "done", "doing"},
+			},
+		},
+		{
+			Name:        "standup_read",
+			Description: "Read a squad's most recent standup (today by default). Pass squad='all' to get all squads. Lets agents understand cross-squad status before making requests.",
+			InputSchema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"squad": map[string]string{"type": "string", "description": "Squad name to read (e.g. 'kernel'), or 'all' for every squad that has posted today"},
+					"date":  map[string]string{"type": "string", "description": "Date in YYYY-MM-DD format. Omit for today."},
+				},
 			},
 		},
 	}

--- a/internal/standup/store.go
+++ b/internal/standup/store.go
@@ -1,0 +1,114 @@
+package standup
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+// Report is a squad's async standup for one day.
+type Report struct {
+	Squad     string    `json:"squad"`
+	Date      string    `json:"date"`       // YYYY-MM-DD
+	Done      []string  `json:"done"`       // completed since last standup
+	Doing     []string  `json:"doing"`      // in-progress
+	Blocked   []string  `json:"blocked"`    // blockers (empty = none)
+	Requests  []string  `json:"requests"`   // cross-squad asks
+	PostedAt  time.Time `json:"posted_at"`
+	PostedBy  string    `json:"posted_by"`  // agent ID
+}
+
+// Store is a Redis-backed standup store.
+type Store struct {
+	rdb *redis.Client
+	ns  string
+}
+
+// New creates a standup store. redisURL must be parseable by go-redis.
+func New(rdb *redis.Client, namespace string) *Store {
+	return &Store{rdb: rdb, ns: namespace}
+}
+
+// Post saves a standup report. If a report already exists for the same squad
+// and date, it is overwritten — EMs can re-post to amend.
+func (s *Store) Post(ctx context.Context, r Report) error {
+	if r.Date == "" {
+		r.Date = today()
+	}
+	if r.PostedAt.IsZero() {
+		r.PostedAt = time.Now().UTC()
+	}
+
+	data, err := json.Marshal(r)
+	if err != nil {
+		return fmt.Errorf("marshal standup: %w", err)
+	}
+
+	pipe := s.rdb.Pipeline()
+	// Store the report keyed by squad+date (overwrites previous posts for today)
+	pipe.Set(ctx, s.key(r.Squad, r.Date), data, 14*24*time.Hour)
+	// Track which squads have posted for this date
+	pipe.SAdd(ctx, s.dateKey(r.Date), r.Squad)
+	pipe.Expire(ctx, s.dateKey(r.Date), 14*24*time.Hour)
+	_, err = pipe.Exec(ctx)
+	return err
+}
+
+// Read returns the most recent standup for a squad on the given date.
+// Pass an empty date to read today's standup.
+func (s *Store) Read(ctx context.Context, squad, date string) (*Report, error) {
+	if date == "" {
+		date = today()
+	}
+	data, err := s.rdb.Get(ctx, s.key(squad, date)).Result()
+	if err == redis.Nil {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("read standup %s/%s: %w", squad, date, err)
+	}
+	var r Report
+	if err := json.Unmarshal([]byte(data), &r); err != nil {
+		return nil, fmt.Errorf("unmarshal standup: %w", err)
+	}
+	return &r, nil
+}
+
+// ReadAll returns all squad standups for the given date, sorted by squad name.
+// Pass an empty date to read today's standups.
+func (s *Store) ReadAll(ctx context.Context, date string) ([]Report, error) {
+	if date == "" {
+		date = today()
+	}
+	squads, err := s.rdb.SMembers(ctx, s.dateKey(date)).Result()
+	if err != nil {
+		return nil, fmt.Errorf("list squads for %s: %w", date, err)
+	}
+	sort.Strings(squads)
+
+	reports := make([]Report, 0, len(squads))
+	for _, squad := range squads {
+		r, err := s.Read(ctx, squad, date)
+		if err != nil || r == nil {
+			continue
+		}
+		reports = append(reports, *r)
+	}
+	return reports, nil
+}
+
+func (s *Store) key(squad, date string) string {
+	return fmt.Sprintf("%s:standup:%s:%s", s.ns, squad, date)
+}
+
+func (s *Store) dateKey(date string) string {
+	return fmt.Sprintf("%s:standup-squads:%s", s.ns, date)
+}
+
+func today() string {
+	return time.Now().UTC().Format("2006-01-02")
+}

--- a/internal/standup/store_test.go
+++ b/internal/standup/store_test.go
@@ -1,0 +1,164 @@
+package standup
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/redis/go-redis/v9"
+)
+
+// testStore creates a standup Store for integration tests.
+// Skips if Redis is not available. Each call uses a unique namespace to
+// prevent cross-test contamination, and registers a cleanup to delete
+// all keys created during the test.
+func testStore(t *testing.T) *Store {
+	t.Helper()
+
+	redisURL := os.Getenv("OCTI_REDIS_URL")
+	if redisURL == "" {
+		redisURL = "redis://localhost:6379"
+	}
+
+	opts, err := redis.ParseURL(redisURL)
+	if err != nil {
+		t.Skipf("skipping: cannot parse redis URL: %v", err)
+	}
+	rdb := redis.NewClient(opts)
+	if err := rdb.Ping(context.Background()).Err(); err != nil {
+		rdb.Close()
+		t.Skipf("skipping: redis not available: %v", err)
+	}
+
+	ns := "octi-test-standup-" + strings.ReplaceAll(t.Name(), "/", "-")
+	t.Cleanup(func() {
+		ctx := context.Background()
+		keys, _ := rdb.Keys(ctx, ns+":*").Result()
+		if len(keys) > 0 {
+			rdb.Del(ctx, keys...)
+		}
+		rdb.Close()
+	})
+
+	return New(rdb, ns)
+}
+
+func TestPost_and_Read(t *testing.T) {
+	s := testStore(t)
+	ctx := context.Background()
+
+	r := Report{
+		Squad:    "kernel",
+		Done:     []string{"Merged #1391"},
+		Doing:    []string{"Working on #1410"},
+		Blocked:  []string{},
+		Requests: []string{"Need analytics report"},
+		PostedBy: "test-agent",
+	}
+
+	if err := s.Post(ctx, r); err != nil {
+		t.Fatalf("Post: %v", err)
+	}
+
+	got, err := s.Read(ctx, "kernel", "")
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if got == nil {
+		t.Fatal("expected a report, got nil")
+	}
+	if got.Squad != "kernel" {
+		t.Errorf("Squad = %q, want %q", got.Squad, "kernel")
+	}
+	if len(got.Done) != 1 || got.Done[0] != "Merged #1391" {
+		t.Errorf("Done = %v, want [Merged #1391]", got.Done)
+	}
+	if got.PostedBy != "test-agent" {
+		t.Errorf("PostedBy = %q, want %q", got.PostedBy, "test-agent")
+	}
+}
+
+func TestRead_missing_returns_nil(t *testing.T) {
+	s := testStore(t)
+	ctx := context.Background()
+
+	got, err := s.Read(ctx, "nonexistent-squad", "")
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if got != nil {
+		t.Errorf("expected nil for missing squad, got %+v", got)
+	}
+}
+
+func TestPost_overwrites_same_day(t *testing.T) {
+	s := testStore(t)
+	ctx := context.Background()
+
+	first := Report{Squad: "octi-pulpo", Done: []string{"v1"}, Doing: []string{"a"}, PostedBy: "agent-1"}
+	if err := s.Post(ctx, first); err != nil {
+		t.Fatalf("Post first: %v", err)
+	}
+
+	second := Report{Squad: "octi-pulpo", Done: []string{"v2"}, Doing: []string{"b"}, PostedBy: "agent-2"}
+	if err := s.Post(ctx, second); err != nil {
+		t.Fatalf("Post second: %v", err)
+	}
+
+	got, err := s.Read(ctx, "octi-pulpo", "")
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if got == nil {
+		t.Fatal("expected a report, got nil")
+	}
+	if got.Done[0] != "v2" {
+		t.Errorf("expected amended report (v2), got %q", got.Done[0])
+	}
+}
+
+func TestReadAll(t *testing.T) {
+	s := testStore(t)
+	ctx := context.Background()
+
+	squads := []string{"kernel", "octi-pulpo", "shellforge"}
+	for _, sq := range squads {
+		r := Report{Squad: sq, Done: []string{"did something"}, Doing: []string{"doing something"}, PostedBy: "test"}
+		if err := s.Post(ctx, r); err != nil {
+			t.Fatalf("Post %s: %v", sq, err)
+		}
+	}
+
+	all, err := s.ReadAll(ctx, "")
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	if len(all) != 3 {
+		t.Errorf("ReadAll returned %d reports, want 3", len(all))
+	}
+
+	// Results should be sorted by squad name
+	names := make([]string, len(all))
+	for i, r := range all {
+		names[i] = r.Squad
+	}
+	for i := 1; i < len(names); i++ {
+		if names[i] < names[i-1] {
+			t.Errorf("ReadAll not sorted: %v", names)
+		}
+	}
+}
+
+func TestReadAll_empty(t *testing.T) {
+	s := testStore(t)
+	ctx := context.Background()
+
+	all, err := s.ReadAll(ctx, "")
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	if len(all) != 0 {
+		t.Errorf("expected empty slice for fresh namespace, got %d items", len(all))
+	}
+}


### PR DESCRIPTION
## Summary

Closes #44

Implements async standup support as MCP tools backed by Redis, with a daily Slack digest aggregated by the brain.

- **`standup_report`** — EM posts squad standup (done/doing/blocked/requests). Idempotent: re-posting today amends, not duplicates.
- **`standup_read`** — Any agent reads a squad's standup. Pass `squad=all` to get every squad that has posted today.
- **Daily Slack digest** — Brain posts aggregated standup once per calendar day (UTC). Traffic-light per squad (🟢/🟡/🔴 based on blocker count). Hourly retry until at least one squad has posted.
- **`internal/standup`** — New package: Redis key `{ns}:standup:{squad}:{date}`, 14-day TTL, squad index for cross-squad aggregation.
- 5 integration tests (all pass against local Redis).

## Test plan

- [ ] `go build ./...` — passes
- [ ] `go vet ./...` — passes
- [ ] `go test ./internal/standup/...` — 5/5 passing
- [ ] `go test ./...` — all packages pass
- [ ] Manual: call `standup_report` from MCP client, verify key in Redis
- [ ] Manual: call `standup_read` with `squad=all`, verify aggregated output
- [ ] Manual: set `SLACK_WEBHOOK_URL` + `OCTI_DAEMON=1`, verify Slack digest posts once per day

🤖 Generated with [Claude Code](https://claude.com/claude-code)