### PR TITLE
feat(sprint): sprint_reprioritize + sprint_complete MCP tools (#18)

### DIFF
--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -364,6 +364,88 @@ func (s *Server) handleToolCall(req Request) Response {
 		}
 		return textResult(req.ID, strings.Join(synced, "\n"))
 
+	case "sprint_reprioritize":
+		if s.sprintStore == nil {
+			return errorResp(req.ID, -32000, "sprint store not initialized")
+		}
+		var args struct {
+			Repo     string `json:"repo"`
+			IssueNum int    `json:"issue_num"`
+			Priority int    `json:"priority"`
+		}
+		json.Unmarshal(params.Arguments, &args)
+		if args.IssueNum == 0 {
+			return errorResp(req.ID, -32602, "issue_num is required")
+		}
+		if args.Repo == "" {
+			// Search all default repos
+			found := false
+			for _, repo := range sprint.DefaultRepos {
+				if err := s.sprintStore.Reprioritize(ctx, repo, args.IssueNum, args.Priority); err == nil {
+					args.Repo = repo
+					found = true
+					break
+				}
+			}
+			if !found {
+				return errorResp(req.ID, -32000, fmt.Sprintf("issue #%d not found in any sprint repo", args.IssueNum))
+			}
+		} else {
+			if err := s.sprintStore.Reprioritize(ctx, args.Repo, args.IssueNum, args.Priority); err != nil {
+				return errorResp(req.ID, -32000, err.Error())
+			}
+		}
+		priorityLabel := [3]string{"P0 (critical)", "P1 (high)", "P2 (normal)"}
+		label := "custom"
+		if args.Priority >= 0 && args.Priority <= 2 {
+			label = priorityLabel[args.Priority]
+		}
+		return textResult(req.ID, fmt.Sprintf("%s#%d reprioritized to %s", args.Repo, args.IssueNum, label))
+
+	case "sprint_complete":
+		if s.sprintStore == nil {
+			return errorResp(req.ID, -32000, "sprint store not initialized")
+		}
+		var args struct {
+			Repo     string `json:"repo"`
+			IssueNum int    `json:"issue_num"`
+		}
+		json.Unmarshal(params.Arguments, &args)
+		if args.IssueNum == 0 {
+			return errorResp(req.ID, -32602, "issue_num is required")
+		}
+		if args.Repo == "" {
+			for _, repo := range sprint.DefaultRepos {
+				unblocked, err := s.sprintStore.Complete(ctx, repo, args.IssueNum)
+				if err == nil {
+					args.Repo = repo
+					msg := fmt.Sprintf("%s#%d marked done", repo, args.IssueNum)
+					if len(unblocked) > 0 {
+						nums := make([]string, len(unblocked))
+						for i, n := range unblocked {
+							nums[i] = fmt.Sprintf("#%d", n)
+						}
+						msg += fmt.Sprintf("; unblocked: %s", strings.Join(nums, ", "))
+					}
+					return textResult(req.ID, msg)
+				}
+			}
+			return errorResp(req.ID, -32000, fmt.Sprintf("issue #%d not found in any sprint repo", args.IssueNum))
+		}
+		unblocked, err := s.sprintStore.Complete(ctx, args.Repo, args.IssueNum)
+		if err != nil {
+			return errorResp(req.ID, -32000, err.Error())
+		}
+		msg := fmt.Sprintf("%s#%d marked done", args.Repo, args.IssueNum)
+		if len(unblocked) > 0 {
+			nums := make([]string, len(unblocked))
+			for i, n := range unblocked {
+				nums[i] = fmt.Sprintf("#%d", n)
+			}
+			msg += fmt.Sprintf("; unblocked: %s", strings.Join(nums, ", "))
+		}
+		return textResult(req.ID, msg)
+
 	case "benchmark_status":
 		if s.benchmark == nil {
 			return errorResp(req.ID, -32000, "benchmark tracker not initialized")
@@ -660,6 +742,31 @@ func toolDefs() []ToolDef {
 			InputSchema: map[string]interface{}{
 				"type":       "object",
 				"properties": map[string]interface{}{},
+			},
+		},
+		{
+			Name:        "sprint_reprioritize",
+			Description: "Change the priority of a sprint item. Use when the CTO says 'make this P0' or 'deprioritize this'. Affects dispatch order — P0 items are dispatched before P1/P2.",
+			InputSchema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"issue_num": map[string]interface{}{"type": "number", "description": "GitHub issue number to reprioritize"},
+					"priority":  map[string]interface{}{"type": "number", "enum": []int{0, 1, 2}, "description": "New priority: 0=P0 critical, 1=P1 high, 2=P2 normal"},
+					"repo":      map[string]string{"type": "string", "description": "Repo (e.g. AgentGuardHQ/octi-pulpo). If omitted, all tracked repos are searched."},
+				},
+				"required": []string{"issue_num", "priority"},
+			},
+		},
+		{
+			Name:        "sprint_complete",
+			Description: "Mark a sprint item as done. Unblocks any dependent items. Call after merging a PR or closing an issue outside of the normal sync cycle.",
+			InputSchema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"issue_num": map[string]interface{}{"type": "number", "description": "GitHub issue number to mark done"},
+					"repo":      map[string]string{"type": "string", "description": "Repo (e.g. AgentGuardHQ/octi-pulpo). If omitted, all tracked repos are searched."},
+				},
+				"required": []string{"issue_num"},
 			},
 		},
 		{

--- a/internal/sprint/store.go
+++ b/internal/sprint/store.go
@@ -503,6 +503,82 @@ func (s *Store) markClosedItems(ctx context.Context, repo string, issueNums []in
 	return marked
 }
 
+// Reprioritize updates the priority of a sprint item identified by repo + issue number.
+// priority: 0=P0 (critical), 1=P1 (high), 2=P2 (normal).
+// Returns an error if the item is not found.
+func (s *Store) Reprioritize(ctx context.Context, repo string, issueNum int, priority int) error {
+	key := s.itemKey(repo, issueNum)
+	raw, err := s.rdb.Get(ctx, key).Result()
+	if err != nil {
+		return fmt.Errorf("sprint item %s#%d not found: %w", repo, issueNum, err)
+	}
+
+	var item SprintItem
+	if err := json.Unmarshal([]byte(raw), &item); err != nil {
+		return fmt.Errorf("parse sprint item: %w", err)
+	}
+
+	item.Priority = priority
+	item.UpdatedAt = time.Now().UTC().Format(time.RFC3339)
+
+	data, err := json.Marshal(item)
+	if err != nil {
+		return err
+	}
+
+	return s.rdb.Set(ctx, key, data, 0).Err()
+}
+
+// Complete marks a sprint item as "done" and returns the issue numbers of any
+// items that are now unblocked (i.e. were waiting on this item as a dependency).
+func (s *Store) Complete(ctx context.Context, repo string, issueNum int) (unblocked []int, err error) {
+	if err := s.UpdateStatus(ctx, repo, issueNum, "done"); err != nil {
+		return nil, err
+	}
+
+	// Find items whose DependsOn list includes this issue number and are now fully unblocked.
+	all, err := s.GetAll(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	doneSet := make(map[int]bool)
+	for _, item := range all {
+		if item.Status == "done" {
+			doneSet[item.IssueNum] = true
+		}
+	}
+
+	for _, item := range all {
+		if item.Status != "open" {
+			continue
+		}
+		dependsOnCompleted := false
+		for _, dep := range item.DependsOn {
+			if dep == issueNum {
+				dependsOnCompleted = true
+				break
+			}
+		}
+		if !dependsOnCompleted {
+			continue
+		}
+		// Check all deps are now met
+		allMet := true
+		for _, dep := range item.DependsOn {
+			if !doneSet[dep] {
+				allMet = false
+				break
+			}
+		}
+		if allMet {
+			unblocked = append(unblocked, item.IssueNum)
+		}
+	}
+
+	return unblocked, nil
+}
+
 func (s *Store) itemKey(repo string, issueNum int) string {
 	return s.namespace + ":sprint:" + repo + ":" + strconv.Itoa(issueNum)
 }

--- a/internal/sprint/store_test.go
+++ b/internal/sprint/store_test.go
@@ -369,6 +369,100 @@ func TestMarkClosedItems_EmptyList(t *testing.T) {
 	}
 }
 
+func TestStore_Reprioritize(t *testing.T) {
+	s, ctx := testStore(t)
+
+	repo := "AgentGuardHQ/octi-pulpo"
+	s.rdb.SAdd(ctx, s.key("sprint-repos"), repo)
+
+	item := SprintItem{
+		Squad: "octi-pulpo", IssueNum: 44, Repo: repo,
+		Title: "Async standups", Priority: 2, Status: "open",
+	}
+	data, _ := json.Marshal(item)
+	s.rdb.Set(ctx, s.itemKey(repo, 44), data, 0)
+
+	if err := s.Reprioritize(ctx, repo, 44, 0); err != nil {
+		t.Fatalf("reprioritize: %v", err)
+	}
+
+	all, _ := s.GetAll(ctx)
+	if len(all) != 1 {
+		t.Fatalf("expected 1 item, got %d", len(all))
+	}
+	if all[0].Priority != 0 {
+		t.Fatalf("expected priority 0, got %d", all[0].Priority)
+	}
+}
+
+func TestStore_Reprioritize_NotFound(t *testing.T) {
+	s, ctx := testStore(t)
+
+	err := s.Reprioritize(ctx, "AgentGuardHQ/octi-pulpo", 9999, 0)
+	if err == nil {
+		t.Fatal("expected error for missing item, got nil")
+	}
+}
+
+func TestStore_Complete_NoDepedents(t *testing.T) {
+	s, ctx := testStore(t)
+
+	repo := "AgentGuardHQ/octi-pulpo"
+	s.rdb.SAdd(ctx, s.key("sprint-repos"), repo)
+
+	item := SprintItem{
+		Squad: "octi-pulpo", IssueNum: 10, Repo: repo,
+		Title: "Solo item", Priority: 1, Status: "open",
+	}
+	data, _ := json.Marshal(item)
+	s.rdb.Set(ctx, s.itemKey(repo, 10), data, 0)
+
+	unblocked, err := s.Complete(ctx, repo, 10)
+	if err != nil {
+		t.Fatalf("complete: %v", err)
+	}
+	if len(unblocked) != 0 {
+		t.Fatalf("expected 0 unblocked, got %d: %v", len(unblocked), unblocked)
+	}
+
+	all, _ := s.GetAll(ctx)
+	if all[0].Status != "done" {
+		t.Fatalf("expected done, got %s", all[0].Status)
+	}
+}
+
+func TestStore_Complete_UnblocksDependent(t *testing.T) {
+	s, ctx := testStore(t)
+
+	repo := "AgentGuardHQ/octi-pulpo"
+	s.rdb.SAdd(ctx, s.key("sprint-repos"), repo)
+
+	// Item 10: the blocker; item 20: depends on 10; item 30: depends on 10 AND 40 (not done)
+	items := []SprintItem{
+		{Squad: "octi-pulpo", IssueNum: 10, Repo: repo, Title: "Blocker", Priority: 0, Status: "open"},
+		{Squad: "octi-pulpo", IssueNum: 20, Repo: repo, Title: "Waiting on 10", Priority: 1, Status: "open", DependsOn: []int{10}},
+		{Squad: "octi-pulpo", IssueNum: 30, Repo: repo, Title: "Waiting on 10+40", Priority: 1, Status: "open", DependsOn: []int{10, 40}},
+		{Squad: "octi-pulpo", IssueNum: 40, Repo: repo, Title: "Other blocker", Priority: 0, Status: "open"},
+	}
+	for _, item := range items {
+		data, _ := json.Marshal(item)
+		s.rdb.Set(ctx, s.itemKey(repo, item.IssueNum), data, 0)
+	}
+
+	unblocked, err := s.Complete(ctx, repo, 10)
+	if err != nil {
+		t.Fatalf("complete: %v", err)
+	}
+
+	// Only item 20 should be unblocked (item 30 still needs #40)
+	if len(unblocked) != 1 {
+		t.Fatalf("expected 1 unblocked, got %d: %v", len(unblocked), unblocked)
+	}
+	if unblocked[0] != 20 {
+		t.Fatalf("expected issue #20 unblocked, got #%d", unblocked[0])
+	}
+}
+
 func TestInferSquadFromRepo(t *testing.T) {
 	tests := []struct {
 		repo  string


### PR DESCRIPTION
## Summary

Closes part of #18 (adaptive dispatch — CTO control plane).

Adds two MCP tools that were specified in the issue but not yet implemented:

- **`sprint_reprioritize`** — change a sprint item's priority (0=P0/critical, 1=P1/high, 2=P2/normal). Accepts `issue_num` + `priority` (required) and optional `repo`; if `repo` is omitted all tracked repos are searched automatically. Immediately affects dispatch order — P0 items bubble to the top of `NextDispatchable`.
- **`sprint_complete`** — mark an item done and return which issues are now unblocked. Useful for close-outs between `sprint_sync` cycles (e.g. after manually merging a PR from another tool).

### Store changes (`internal/sprint/store.go`)
- `Reprioritize(ctx, repo, issueNum, priority)` — fetches item, updates priority, writes back
- `Complete(ctx, repo, issueNum)` — calls `UpdateStatus` → `"done"`, then scans for items whose `DependsOn` list is now fully satisfied

### MCP changes (`internal/mcp/server.go`)
- Two new `case` branches with nil-guard + arg parsing
- Auto-search across `DefaultRepos` when `repo` is omitted
- Human-readable response: `"AgentGuardHQ/octi-pulpo#44 reprioritized to P0 (critical)"` / `"…#10 marked done; unblocked: #20"`
- Two new `ToolDef` entries in the tools list

## Test plan

- [x] `go build ./...` — passes
- [x] `go vet ./...` — clean
- [x] `TestStore_Reprioritize` — round-trip P2→P0, verify field
- [x] `TestStore_Reprioritize_NotFound` — missing item returns error
- [x] `TestStore_Complete_NoDepedents` — marks done, returns empty unblocked list
- [x] `TestStore_Complete_UnblocksDependent` — item 20 (dep on 10) unblocked; item 30 (dep on 10+40) stays blocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)