### PR TITLE
feat(dispatch): self-heal brain — stuck agents + inactive squads (#18 Phase 2)

### DIFF
--- a/internal/dispatch/brain.go
+++ b/internal/dispatch/brain.go
@@ -44,6 +44,7 @@ type LeverageAction struct {
 //   - Driver health probe: ping each driver every 15 min to detect stale state
 //   - Slack notifications: periodic budget dashboard + driver state change alerts
 //   - Daily standup: post unified squad standup to Slack once per day
+//   - Self-heal: detect stuck agents (triage flag) + inactive squads, alert CTO
 type Brain struct {
 	dispatcher        *Dispatcher
 	chains            ChainConfig
@@ -60,17 +61,24 @@ type Brain struct {
 	dashboardPeriod   time.Duration
 	lastStandupDate   string // YYYY-MM-DD, guards once-per-day posting
 	driversWereDown   bool   // tracks transition for edge-triggered alerts
+
+	// Self-heal dedup: tracks when each agent/squad was last alerted to avoid
+	// flooding Slack on every tick. Keys are agent names or squad names.
+	stuckAgentAlerted    map[string]time.Time
+	inactiveSquadAlerted map[string]time.Time
 }
 
 // NewBrain creates a dispatch brain.
 func NewBrain(dispatcher *Dispatcher, chains ChainConfig) *Brain {
 	return &Brain{
-		dispatcher:      dispatcher,
-		chains:          chains,
-		tickInterval:    60 * time.Second,
-		probeInterval:   15 * time.Minute,
-		dashboardPeriod: 4 * time.Hour,
-		log:             log.New(os.Stderr, "brain: ", log.LstdFlags),
+		dispatcher:           dispatcher,
+		chains:               chains,
+		tickInterval:         60 * time.Second,
+		probeInterval:        15 * time.Minute,
+		dashboardPeriod:      4 * time.Hour,
+		log:                  log.New(os.Stderr, "brain: ", log.LstdFlags),
+		stuckAgentAlerted:    make(map[string]time.Time),
+		inactiveSquadAlerted: make(map[string]time.Time),
 	}
 }
 
@@ -134,7 +142,10 @@ func (b *Brain) Tick(ctx context.Context) {
 	// 5. Daily standup (once per calendar day)
 	b.maybePostDailyStandup(ctx)
 
-	// 6. Constraint-driven dispatch (if sprint store is available)
+	// 6. Self-heal: stuck agents + inactive squads
+	b.maybeSelfHeal(ctx)
+
+	// 7. Constraint-driven dispatch (if sprint store is available)
 	if b.sprintStore != nil {
 		constraint := b.identifyConstraint(ctx)
 		b.maybeNotifyConstraintChange(ctx, constraint)
@@ -305,6 +316,94 @@ func (b *Brain) maybePostDailyStandup(ctx context.Context) {
 		return
 	}
 	b.lastStandupDate = today
+}
+
+// maybeSelfHeal runs Phase 2 adaptive recovery checks on every tick:
+//
+//  1. Stuck agents: agents with TriageFlag=true get a Slack alert (at most once per 12h).
+//  2. Inactive squads: squads with no dispatch activity in the last 24h get a Slack alert
+//     (at most once per 24h). Activity is determined from the dispatch log.
+func (b *Brain) maybeSelfHeal(ctx context.Context) {
+	if b.profiles == nil {
+		return
+	}
+
+	b.checkStuckAgents(ctx)
+	b.checkInactiveSquads(ctx)
+}
+
+// checkStuckAgents scans all agent profiles for triage-flagged agents and fires
+// a one-time Slack alert (per 12h window) for each.
+func (b *Brain) checkStuckAgents(ctx context.Context) {
+	profiles, err := b.profiles.AllProfiles(ctx)
+	if err != nil {
+		b.log.Printf("self-heal: list profiles: %v", err)
+		return
+	}
+
+	for _, p := range profiles {
+		if !p.TriageFlag {
+			continue
+		}
+		// Deduplicate: alert at most once per 12h per agent.
+		if last, ok := b.stuckAgentAlerted[p.Name]; ok && time.Since(last) < 12*time.Hour {
+			continue
+		}
+		b.log.Printf("self-heal: stuck agent %s (%d consecutive failures) — alerting", p.Name, p.ConsecutiveFails)
+		b.stuckAgentAlerted[p.Name] = time.Now()
+
+		if b.notifier != nil && b.notifier.Enabled() {
+			if err := b.notifier.PostStuckAgentAlert(ctx, p.Name, p.ConsecutiveFails); err != nil {
+				b.log.Printf("self-heal: slack alert for %s: %v", p.Name, err)
+			}
+		}
+	}
+}
+
+// checkInactiveSquads inspects the recent dispatch log and alerts when a squad
+// has had no dispatch activity for more than 24 hours.
+func (b *Brain) checkInactiveSquads(ctx context.Context) {
+	records, err := b.dispatcher.RecentDispatches(ctx, 200)
+	if err != nil || len(records) == 0 {
+		return
+	}
+
+	// Build the most recent dispatch timestamp per squad.
+	lastActivity := make(map[string]time.Time)
+	for _, rec := range records {
+		squad := inferSquad(rec.Agent)
+		if squad == "" {
+			continue
+		}
+		ts, err := time.Parse(time.RFC3339, rec.Timestamp)
+		if err != nil {
+			continue
+		}
+		if ts.After(lastActivity[squad]) {
+			lastActivity[squad] = ts
+		}
+	}
+
+	threshold := 24 * time.Hour
+	for squad, last := range lastActivity {
+		idle := time.Since(last)
+		if idle < threshold {
+			continue
+		}
+		// Deduplicate: alert at most once per 24h per squad.
+		if alertedAt, ok := b.inactiveSquadAlerted[squad]; ok && time.Since(alertedAt) < 24*time.Hour {
+			continue
+		}
+		idleHours := int(idle.Hours())
+		b.log.Printf("self-heal: inactive squad %s (idle %dh) — alerting", squad, idleHours)
+		b.inactiveSquadAlerted[squad] = time.Now()
+
+		if b.notifier != nil && b.notifier.Enabled() {
+			if err := b.notifier.PostInactiveSquadAlert(ctx, squad, idleHours); err != nil {
+				b.log.Printf("self-heal: slack alert for squad %s: %v", squad, err)
+			}
+		}
+	}
 }
 
 // maybeNotifyConstraintChange fires edge-triggered Slack alerts when driver

--- a/internal/dispatch/brain_test.go
+++ b/internal/dispatch/brain_test.go
@@ -1,6 +1,7 @@
 package dispatch
 
 import (
+	"encoding/json"
 	"testing"
 	"time"
 )
@@ -78,4 +79,139 @@ func containsSubstring(s, substr string) bool {
 		}
 	}
 	return false
+}
+
+// TestBrain_CheckStuckAgents verifies that a triaged agent appears in the
+// stuckAgentAlerted map after checkStuckAgents runs, and is not re-alerted
+// within the 12h dedup window.
+func TestBrain_CheckStuckAgents(t *testing.T) {
+	d, ctx := testSetup(t)
+	brain := NewBrain(d, DefaultChains())
+
+	// Wire a disabled notifier (no webhook) so Post* calls are no-ops.
+	brain.SetNotifier(NewNotifier(""))
+
+	ps := NewProfileStore(d.rdb, d.namespace, func(string) time.Duration { return 3 * time.Minute })
+	brain.SetProfileStore(ps)
+
+	// Record 3 consecutive failures to set TriageFlag.
+	for i := 0; i < 3; i++ {
+		if err := ps.RecordRun(ctx, "kernel-sr", RunResult{ExitCode: 1, Duration: 5}); err != nil {
+			t.Fatalf("record run: %v", err)
+		}
+	}
+
+	profile, _ := ps.GetProfile(ctx, "kernel-sr")
+	if !profile.TriageFlag {
+		t.Fatal("expected TriageFlag=true after 3 failures")
+	}
+
+	// First self-heal: should populate stuckAgentAlerted.
+	brain.checkStuckAgents(ctx)
+	if _, ok := brain.stuckAgentAlerted["kernel-sr"]; !ok {
+		t.Fatal("expected kernel-sr in stuckAgentAlerted after first check")
+	}
+
+	// Record the alerted time, then run again immediately.
+	firstAlert := brain.stuckAgentAlerted["kernel-sr"]
+	brain.checkStuckAgents(ctx)
+	if brain.stuckAgentAlerted["kernel-sr"] != firstAlert {
+		t.Fatal("expected dedup: no re-alert within 12h window")
+	}
+}
+
+// TestBrain_CheckStuckAgents_ClearsOnRecovery verifies that once a TriageFlag
+// is cleared (agent succeeded), the stuck-agent alert is no longer fired.
+func TestBrain_CheckStuckAgents_ClearsOnRecovery(t *testing.T) {
+	d, ctx := testSetup(t)
+	brain := NewBrain(d, DefaultChains())
+	brain.SetNotifier(NewNotifier(""))
+
+	ps := NewProfileStore(d.rdb, d.namespace, func(string) time.Duration { return 3 * time.Minute })
+	brain.SetProfileStore(ps)
+
+	// 3 failures → triage flag
+	for i := 0; i < 3; i++ {
+		ps.RecordRun(ctx, "cloud-sr", RunResult{ExitCode: 1, Duration: 5})
+	}
+
+	// Successful run clears triage flag
+	ps.RecordRun(ctx, "cloud-sr", RunResult{ExitCode: 0, Duration: 60, HadCommits: true})
+
+	profile, _ := ps.GetProfile(ctx, "cloud-sr")
+	if profile.TriageFlag {
+		t.Fatal("expected TriageFlag=false after successful run")
+	}
+
+	// Self-heal should not mark cloud-sr
+	brain.checkStuckAgents(ctx)
+	if _, ok := brain.stuckAgentAlerted["cloud-sr"]; ok {
+		t.Fatal("unexpected alert: cloud-sr TriageFlag cleared but still appeared in stuckAgentAlerted")
+	}
+}
+
+// TestBrain_CheckInactiveSquads verifies that squads with recent activity are
+// not flagged, and that squads with no dispatch log entries are ignored.
+func TestBrain_CheckInactiveSquads(t *testing.T) {
+	d, ctx := testSetup(t)
+	brain := NewBrain(d, DefaultChains())
+	brain.SetNotifier(NewNotifier(""))
+
+	ps := NewProfileStore(d.rdb, d.namespace, func(string) time.Duration { return 3 * time.Minute })
+	brain.SetProfileStore(ps)
+
+	// Empty dispatch log — no squads to alert.
+	brain.checkInactiveSquads(ctx)
+	if len(brain.inactiveSquadAlerted) != 0 {
+		t.Fatalf("expected no alerts on empty log, got %d", len(brain.inactiveSquadAlerted))
+	}
+}
+
+// TestBrain_CheckInactiveSquads_ActiveSquad verifies that a squad with recent
+// activity (< 24h) is NOT flagged as inactive.
+func TestBrain_CheckInactiveSquads_ActiveSquad(t *testing.T) {
+	d, ctx := testSetup(t)
+	brain := NewBrain(d, DefaultChains())
+	brain.SetNotifier(NewNotifier(""))
+
+	ps := NewProfileStore(d.rdb, d.namespace, func(string) time.Duration { return 3 * time.Minute })
+	brain.SetProfileStore(ps)
+
+	// Write a recent dispatch record for kernel-sr (< 24h ago).
+	recentRecord := DispatchRecord{
+		Agent:     "kernel-sr",
+		Result:    "dispatched",
+		Timestamp: time.Now().UTC().Add(-1 * time.Hour).Format(time.RFC3339),
+	}
+	data := mustMarshal(t, recentRecord)
+	d.rdb.LPush(ctx, d.namespace+":dispatch-log", data)
+
+	brain.checkInactiveSquads(ctx)
+	if _, ok := brain.inactiveSquadAlerted["kernel"]; ok {
+		t.Fatal("kernel squad should NOT be flagged: activity within 24h")
+	}
+}
+
+// TestBrain_SelfHeal_NoProfileStore verifies that maybeSelfHeal is a no-op
+// when no ProfileStore is set.
+func TestBrain_SelfHeal_NoProfileStore(t *testing.T) {
+	d, ctx := testSetup(t)
+	brain := NewBrain(d, DefaultChains())
+
+	// No profiles set — maybeSelfHeal should return without panicking.
+	brain.maybeSelfHeal(ctx)
+
+	if len(brain.stuckAgentAlerted) != 0 || len(brain.inactiveSquadAlerted) != 0 {
+		t.Fatal("expected empty alert maps when no ProfileStore configured")
+	}
+}
+
+// mustMarshal is a test helper that marshals v to JSON or fails the test.
+func mustMarshal(t *testing.T, v interface{}) string {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return string(b)
 }

--- a/internal/dispatch/slack.go
+++ b/internal/dispatch/slack.go
@@ -166,6 +166,33 @@ func (n *Notifier) PostPRReadyAlert(ctx context.Context, repo string, prNumber i
 	return n.postBlocks(ctx, blocks)
 }
 
+// PostStuckAgentAlert sends a Slack alert when an agent has accumulated 3+ consecutive
+// failures (TriageFlag=true), indicating it needs operator attention before being
+// dispatched aggressively again.
+func (n *Notifier) PostStuckAgentAlert(ctx context.Context, agent string, consecutiveFails int) error {
+	if !n.Enabled() {
+		return nil
+	}
+	text := fmt.Sprintf(
+		"⚠️ *Stuck Agent: `%s`*\n%d consecutive failures — triage flag set.\nAgent is in 12h backoff. Review recent runs before re-enabling.",
+		agent, consecutiveFails,
+	)
+	return n.post(ctx, map[string]interface{}{"text": text})
+}
+
+// PostInactiveSquadAlert sends a Slack alert when a squad has had no dispatch activity
+// for more than 24 hours.
+func (n *Notifier) PostInactiveSquadAlert(ctx context.Context, squad string, idleHours int) error {
+	if !n.Enabled() {
+		return nil
+	}
+	text := fmt.Sprintf(
+		"🕐 *Inactive Squad: `%s`*\nNo dispatch activity in the last %dh.\nCheck schedule, driver health, or open sprint items.",
+		squad, idleHours,
+	)
+	return n.post(ctx, map[string]interface{}{"text": text})
+}
+
 // PostSprintGoalAlert sends an interactive Block Kit message when a sprint goal is delivered.
 // It includes [Accept] and [Request Changes] action buttons.
 func (n *Notifier) PostSprintGoalAlert(ctx context.Context, squad, goal string) error {


### PR DESCRIPTION
## Summary

Phase 2 adaptive dispatch from issue #18: the Brain's tick loop now detects and alerts on operational problems automatically, rather than requiring manual monitoring.

- **Stuck agent detection**: scans all `AgentProfile` records each tick; when `TriageFlag=true` (set by `ProfileStore` at 3+ consecutive failures) a Slack alert fires — at most once per 12h per agent to avoid noise
- **Inactive squad detection**: reads the last 200 dispatch log entries to compute per-squad last-activity time; squads idle >24h get a Slack alert — at most once per 24h per squad
- **Two new `Notifier` methods**: `PostStuckAgentAlert` and `PostInactiveSquadAlert` — both no-ops when webhook is unconfigured (consistent with all other `Post*` methods)
- **In-memory dedup maps** on `Brain` (`stuckAgentAlerted`, `inactiveSquadAlerted`) initialized in `NewBrain`; resets on process restart which is acceptable (causes one extra alert max)

## Architecture

`maybeSelfHeal` slots between the daily standup and constraint-driven dispatch in `Tick()`:

```
Tick()
  ├── maybeSyncSprint
  ├── maybeProbeDrivers
  ├── checkBackpressureRecovery / checkQueueHealth / checkStalledDispatches
  ├── maybePostDashboard
  ├── maybePostDailyStandup
  ├── maybeSelfHeal          ← NEW (Phase 2)
  └── identifyConstraint / highestLeverageAction
```

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `TestBrain_CheckStuckAgents` — alert fires, dedup prevents re-alert within 12h
- [x] `TestBrain_CheckStuckAgents_ClearsOnRecovery` — triage flag cleared on success, no alert
- [x] `TestBrain_CheckInactiveSquads` — empty log is a no-op
- [x] `TestBrain_CheckInactiveSquads_ActiveSquad` — recent activity (<24h) not flagged
- [x] `TestBrain_SelfHeal_NoProfileStore` — graceful no-op when ProfileStore is nil
- [x] `go test ./...` — 278 pass, 11 packages (↑ from 273)

Partial closes #18 (Phase 2 self-healing)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)