### PR TITLE
feat(dispatch): 4h Slack sprint digest — pass rate + PRs + blockers (#10)

### DIFF
--- a/internal/dispatch/brain.go
+++ b/internal/dispatch/brain.go
@@ -251,8 +251,10 @@ func (b *Brain) probeOneDriver(ctx context.Context, driver string) (bool, string
 	return true, output
 }
 
-// maybePostDashboard posts a Slack budget dashboard at most once per dashboardPeriod.
-// It reads live driver health and cumulative worker counters from Redis.
+// maybePostDashboard posts a Slack status digest at most once per dashboardPeriod.
+// When a sprint store is wired, it sends PostSprintDigest (drivers + pass rate +
+// sprint progress + open PRs + blockers). Otherwise it falls back to the
+// simpler PostBudgetDashboard (drivers + pass rate only).
 func (b *Brain) maybePostDashboard(ctx context.Context) {
 	if b.notifier == nil || !b.notifier.Enabled() {
 		return
@@ -269,6 +271,21 @@ func (b *Brain) maybePostDashboard(ctx context.Context) {
 	failStr, _ := rdb.Get(ctx, ns+":worker-fail").Result()
 	ok, _ := strconv.ParseInt(okStr, 10, 64)
 	fail, _ := strconv.ParseInt(failStr, 10, 64)
+
+	if b.sprintStore != nil {
+		items, err := b.sprintStore.GetAll(ctx)
+		if err != nil {
+			b.log.Printf("sprint digest: get all: %v", err)
+			// fall through to budget-only dashboard
+		} else {
+			if err := b.notifier.PostSprintDigest(ctx, drivers, ok, fail, items); err != nil {
+				b.log.Printf("slack sprint digest: %v", err)
+				return
+			}
+			b.lastDashboard = time.Now()
+			return
+		}
+	}
 
 	if err := b.notifier.PostBudgetDashboard(ctx, drivers, ok, fail); err != nil {
 		b.log.Printf("slack dashboard: %v", err)

--- a/internal/dispatch/slack.go
+++ b/internal/dispatch/slack.go
@@ -6,10 +6,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"sort"
 	"strings"
 	"time"
 
 	"github.com/AgentGuardHQ/octi-pulpo/internal/routing"
+	"github.com/AgentGuardHQ/octi-pulpo/internal/sprint"
 	"github.com/AgentGuardHQ/octi-pulpo/internal/standup"
 )
 
@@ -64,6 +66,111 @@ func (n *Notifier) PostBudgetDashboard(ctx context.Context, drivers []routing.Dr
 	if total > 0 {
 		passRate := float64(workerOK) / float64(total) * 100
 		sb.WriteString(fmt.Sprintf("\nPass rate: *%.1f%%* | OK: %d | Failed: %d", passRate, workerOK, workerFail))
+	}
+
+	return n.post(ctx, map[string]interface{}{"text": sb.String()})
+}
+
+// PostSprintDigest sends a rich 4-hour status digest combining driver health,
+// pass rate, sprint progress, open PRs, and items blocked by unmet dependencies.
+// It supersedes PostBudgetDashboard when sprint data is available.
+func (n *Notifier) PostSprintDigest(ctx context.Context, drivers []routing.DriverHealth, workerOK, workerFail int64, items []sprint.SprintItem) error {
+	if !n.Enabled() {
+		return nil
+	}
+
+	now := time.Now().UTC().Format("15:04 UTC")
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("*📊 Sprint Digest — %s*\n", now))
+
+	// Pass rate
+	total := workerOK + workerFail
+	if total > 0 {
+		passRate := float64(workerOK) / float64(total) * 100
+		sb.WriteString(fmt.Sprintf("Pass rate: *%.1f%%* | OK: %d | Failed: %d\n", passRate, workerOK, workerFail))
+	}
+
+	// Driver health — one line
+	var driverParts []string
+	for _, d := range drivers {
+		icon := "🟢"
+		if d.CircuitState == "OPEN" {
+			icon = "🔴"
+		} else if d.CircuitState == "HALF" {
+			icon = "🟡"
+		}
+		part := fmt.Sprintf("%s `%s`", icon, d.Name)
+		if d.Failures > 0 {
+			part += fmt.Sprintf(" (%d failures)", d.Failures)
+		}
+		driverParts = append(driverParts, part)
+	}
+	if len(driverParts) > 0 {
+		sb.WriteString("Drivers: " + strings.Join(driverParts, " · ") + "\n")
+	}
+
+	if len(items) == 0 {
+		return n.post(ctx, map[string]interface{}{"text": sb.String()})
+	}
+
+	// Sprint progress breakdown
+	counts := map[string]int{}
+	for _, item := range items {
+		counts[item.Status]++
+	}
+	inProgress := counts["in_progress"] + counts["claimed"]
+	sb.WriteString(fmt.Sprintf(
+		"\n*Sprint:* ✅ Done: %d | 🔧 In Progress: %d | 🟡 PR Open: %d | 📋 Open: %d\n",
+		counts["done"], inProgress, counts["pr_open"], counts["open"],
+	))
+
+	// Open PRs — items in pr_open status, sorted by priority
+	var prItems []sprint.SprintItem
+	for _, item := range items {
+		if item.Status == "pr_open" && item.PRNumber > 0 {
+			prItems = append(prItems, item)
+		}
+	}
+	sort.Slice(prItems, func(i, j int) bool {
+		return prItems[i].Priority < prItems[j].Priority
+	})
+	if len(prItems) > 0 {
+		sb.WriteString("\n*Open PRs:*\n")
+		for _, item := range prItems {
+			prURL := fmt.Sprintf("https://github.com/%s/pull/%d", item.Repo, item.PRNumber)
+			sb.WriteString(fmt.Sprintf("  • <%s|#%d> `%s` — %s\n", prURL, item.PRNumber, item.Repo, item.Title))
+		}
+	}
+
+	// Blockers — open items whose dependencies are not yet done
+	doneSet := map[int]bool{}
+	for _, item := range items {
+		if item.Status == "done" {
+			doneSet[item.IssueNum] = true
+		}
+	}
+	var blocked []sprint.SprintItem
+	for _, item := range items {
+		if item.Status != "open" || len(item.DependsOn) == 0 {
+			continue
+		}
+		for _, dep := range item.DependsOn {
+			if !doneSet[dep] {
+				blocked = append(blocked, item)
+				break
+			}
+		}
+	}
+	if len(blocked) > 0 {
+		sb.WriteString("\n*Blockers:*\n")
+		for _, item := range blocked {
+			deps := make([]string, len(item.DependsOn))
+			for i, d := range item.DependsOn {
+				deps[i] = fmt.Sprintf("#%d", d)
+			}
+			sb.WriteString(fmt.Sprintf("  • [P%d] %s — waiting on %s\n",
+				item.Priority, item.Title, strings.Join(deps, ", ")))
+		}
 	}
 
 	return n.post(ctx, map[string]interface{}{"text": sb.String()})

--- a/internal/dispatch/slack_test.go
+++ b/internal/dispatch/slack_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/AgentGuardHQ/octi-pulpo/internal/routing"
+	"github.com/AgentGuardHQ/octi-pulpo/internal/sprint"
 )
 
 func TestNotifier_Enabled(t *testing.T) {
@@ -144,6 +145,168 @@ func TestNotifier_WebhookError(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "500") {
 		t.Errorf("expected 500 in error, got: %v", err)
+	}
+}
+
+func TestNotifier_PostSprintDigest_NoopWhenDisabled(t *testing.T) {
+	ctx := context.Background()
+	n := NewNotifier("")
+	err := n.PostSprintDigest(ctx, nil, 0, 0, nil)
+	if err != nil {
+		t.Fatalf("PostSprintDigest on disabled notifier: %v", err)
+	}
+}
+
+func TestNotifier_PostSprintDigest_Basic(t *testing.T) {
+	var received []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		received, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	ctx := context.Background()
+	n := NewNotifier(srv.URL)
+
+	drivers := []routing.DriverHealth{
+		{Name: "claude-code", CircuitState: "CLOSED", Failures: 0},
+		{Name: "codex", CircuitState: "OPEN", Failures: 73},
+	}
+	items := []sprint.SprintItem{
+		{IssueNum: 1, Repo: "AgentGuardHQ/octi-pulpo", Title: "feat A", Status: "done", Priority: 0},
+		{IssueNum: 2, Repo: "AgentGuardHQ/octi-pulpo", Title: "feat B", Status: "open", Priority: 1},
+		{IssueNum: 3, Repo: "AgentGuardHQ/octi-pulpo", Title: "feat C", Status: "pr_open", PRNumber: 42, Priority: 1},
+	}
+
+	if err := n.PostSprintDigest(ctx, drivers, 90, 10, items); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var payload map[string]interface{}
+	if err := json.Unmarshal(received, &payload); err != nil {
+		t.Fatalf("invalid JSON payload: %v", err)
+	}
+	text, _ := payload["text"].(string)
+
+	checks := []struct {
+		want string
+		desc string
+	}{
+		{"Sprint Digest", "header"},
+		{"90.0%", "pass rate"},
+		{"claude-code", "driver name"},
+		{"codex", "driver name"},
+		{"73 failures", "failure count"},
+		{"Done: 1", "done count"},
+		{"PR Open: 1", "pr_open count"},
+		{"Open: 1", "open count"},
+		{"feat C", "PR item title"},
+		{"#42", "PR number"},
+	}
+	for _, c := range checks {
+		if !strings.Contains(text, c.want) {
+			t.Errorf("expected %q (%s) in digest text, got:\n%s", c.want, c.desc, text)
+		}
+	}
+}
+
+func TestNotifier_PostSprintDigest_ShowsBlockers(t *testing.T) {
+	var received []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		received, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	ctx := context.Background()
+	n := NewNotifier(srv.URL)
+
+	// Item 20 depends on item 10, which is still open → blocker
+	items := []sprint.SprintItem{
+		{IssueNum: 10, Repo: "AgentGuardHQ/octi-pulpo", Title: "dep item", Status: "open", Priority: 1},
+		{IssueNum: 20, Repo: "AgentGuardHQ/octi-pulpo", Title: "blocked item", Status: "open", Priority: 2, DependsOn: []int{10}},
+	}
+
+	if err := n.PostSprintDigest(ctx, nil, 0, 0, items); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var payload map[string]interface{}
+	if err := json.Unmarshal(received, &payload); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	text, _ := payload["text"].(string)
+
+	if !strings.Contains(text, "Blockers") {
+		t.Errorf("expected 'Blockers' section in digest, got:\n%s", text)
+	}
+	if !strings.Contains(text, "blocked item") {
+		t.Errorf("expected blocked item title in digest, got:\n%s", text)
+	}
+	if !strings.Contains(text, "#10") {
+		t.Errorf("expected dependency #10 listed, got:\n%s", text)
+	}
+}
+
+func TestNotifier_PostSprintDigest_NoBlockersWhenDepDone(t *testing.T) {
+	var received []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		received, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	ctx := context.Background()
+	n := NewNotifier(srv.URL)
+
+	// Item 20 depends on item 10, which is done → not a blocker
+	items := []sprint.SprintItem{
+		{IssueNum: 10, Repo: "AgentGuardHQ/octi-pulpo", Title: "dep item", Status: "done", Priority: 0},
+		{IssueNum: 20, Repo: "AgentGuardHQ/octi-pulpo", Title: "unblocked item", Status: "open", Priority: 1, DependsOn: []int{10}},
+	}
+
+	if err := n.PostSprintDigest(ctx, nil, 0, 0, items); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var payload map[string]interface{}
+	if err := json.Unmarshal(received, &payload); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	text, _ := payload["text"].(string)
+	if strings.Contains(text, "Blockers") {
+		t.Errorf("expected no 'Blockers' section when dep is done, got:\n%s", text)
+	}
+}
+
+func TestNotifier_PostSprintDigest_EmptyItems(t *testing.T) {
+	var received []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		received, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	ctx := context.Background()
+	n := NewNotifier(srv.URL)
+
+	drivers := []routing.DriverHealth{
+		{Name: "claude-code", CircuitState: "CLOSED"},
+	}
+	if err := n.PostSprintDigest(ctx, drivers, 50, 50, nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var payload map[string]interface{}
+	if err := json.Unmarshal(received, &payload); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	text, _ := payload["text"].(string)
+	if !strings.Contains(text, "Sprint Digest") {
+		t.Errorf("expected Sprint Digest header with no items, got:\n%s", text)
+	}
+	if strings.Contains(text, "Sprint:") {
+		t.Errorf("expected no Sprint: line when items is nil, got:\n%s", text)
 	}
 }
 


### PR DESCRIPTION
## Summary

Partial closes #10 (the every-4h cadence component; NotebookLM audio/slides pipeline remains separate and depends on #5).

- **`PostSprintDigest`** — new `Notifier` method that combines everything the CTO needs every 4 hours in one Slack message:
  - Pass rate (`%.1f%%`) and worker OK/fail totals
  - Driver health line: `🟢 claude-code · 🔴 codex (73 failures)`
  - Sprint progress breakdown: `✅ Done: N | 🔧 In Progress: N | 🟡 PR Open: N | 📋 Open: N`
  - Open PRs section with clickable GitHub links, sorted by priority
  - Blockers section: open items whose `depends_on` are not yet done

- **`maybePostDashboard`** — now calls `PostSprintDigest` when a sprint store is wired, with a transparent fallback to `PostBudgetDashboard` when sprint data is unavailable (e.g., Redis unreachable)

- **5 new tests**: disabled no-op, full content assertions (pass rate, driver names, PR links), blocker detection, dep-done clears blocker, nil items graceful path

## Architecture

```
Brain.Tick()
  └── maybePostDashboard (every 4h)
        ├── sprintStore != nil → PostSprintDigest(drivers, ok, fail, items)
        │     ├── Pass rate + driver health
        │     ├── Sprint counts (done/in_progress/pr_open/open)
        │     ├── Open PRs list (pr_open items, sorted by priority)
        │     └── Blockers (open items with unmet depends_on)
        └── fallback → PostBudgetDashboard(drivers, ok, fail)
```

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `TestNotifier_PostSprintDigest_*` — 5 tests pass
- [x] `go test ./...` — all pass

🤖 Generated with [Claude Code](https://claude.ai/claude-code)