### PR TITLE
fix: restore sprint_create + fix budget timestamp hardcoding

### DIFF
--- a/internal/budget/budget.go
+++ b/internal/budget/budget.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"time"
 
 	"github.com/redis/go-redis/v9"
 )
@@ -147,7 +148,7 @@ func (bs *BudgetStore) CheckAndIncrement(ctx context.Context, agent string, cost
 		isCritical = 1
 	}
 
-	timestamp := "2026-03-30T00:00:00Z" // default; in production use time.Now()
+	timestamp := time.Now().UTC().Format(time.RFC3339)
 	result, err := checkAndIncrementScript.Run(ctx, bs.rdb,
 		[]string{bs.key(agent)},
 		costCents, threshold, timestamp, isCritical,

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -388,6 +388,34 @@ func (s *Server) handleToolCall(req Request) Response {
 		}
 		return textResult(req.ID, strings.Join(synced, "\n"))
 
+	case "sprint_create":
+		if s.sprintStore == nil {
+			return errorResp(req.ID, -32000, "sprint store not initialized")
+		}
+		var args struct {
+			Repo      string `json:"repo"`
+			IssueNum  int    `json:"issue_num"`
+			Title     string `json:"title"`
+			Priority  int    `json:"priority"`
+			DependsOn []int  `json:"depends_on"`
+			AssignTo  string `json:"assign_to"`
+			Squad     string `json:"squad"`
+		}
+		json.Unmarshal(params.Arguments, &args)
+		item := sprint.SprintItem{
+			Repo:      args.Repo,
+			IssueNum:  args.IssueNum,
+			Title:     args.Title,
+			Priority:  args.Priority,
+			DependsOn: args.DependsOn,
+			AssignTo:  args.AssignTo,
+			Squad:     args.Squad,
+		}
+		if err := s.sprintStore.Create(ctx, item); err != nil {
+			return errorResp(req.ID, -32000, err.Error())
+		}
+		return textResult(req.ID, fmt.Sprintf("Sprint item created: %s#%d — %s (priority: %d)", args.Repo, args.IssueNum, args.Title, args.Priority))
+
 	case "sprint_reprioritize":
 		if s.sprintStore == nil {
 			return errorResp(req.ID, -32000, "sprint store not initialized")
@@ -843,6 +871,23 @@ func toolDefs() []ToolDef {
 			InputSchema: map[string]interface{}{
 				"type":       "object",
 				"properties": map[string]interface{}{},
+			},
+		},
+		{
+			Name:        "sprint_create",
+			Description: "Manually create or upsert a sprint item. Use when an agent identifies work during brainstorm/research that should flow into the sprint backlog, or to pre-load items with explicit priority and dependency chains before sprint_sync runs.",
+			InputSchema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"repo":       map[string]string{"type": "string", "description": "Repo (e.g. AgentGuardHQ/octi-pulpo)"},
+					"issue_num":  map[string]interface{}{"type": "number", "description": "GitHub issue number. Use 0 if not backed by a GitHub issue."},
+					"title":      map[string]string{"type": "string", "description": "Sprint item title"},
+					"priority":   map[string]interface{}{"type": "number", "enum": []int{0, 1, 2}, "description": "Priority: 0=P0 critical, 1=P1 high, 2=P2 normal"},
+					"depends_on": map[string]interface{}{"type": "array", "items": map[string]string{"type": "number"}, "description": "Issue numbers that must complete before this item can be dispatched"},
+					"assign_to":  map[string]string{"type": "string", "description": "Agent name to assign (e.g. sr-kernel-01). Leave empty for auto-dispatch."},
+					"squad":      map[string]string{"type": "string", "description": "Squad name. Inferred from repo if omitted."},
+				},
+				"required": []string{"repo", "issue_num", "title"},
 			},
 		},
 		{

--- a/internal/sprint/store.go
+++ b/internal/sprint/store.go
@@ -582,6 +582,39 @@ func (s *Store) Complete(ctx context.Context, repo string, issueNum int) (unbloc
 	return unblocked, nil
 }
 
+// Create manually inserts or replaces a sprint item in Redis.
+// repo and issue_num are required; title is required; squad is inferred from repo if empty.
+// status defaults to "open" if not provided.
+func (s *Store) Create(ctx context.Context, item SprintItem) error {
+	if item.Repo == "" {
+		return fmt.Errorf("repo is required")
+	}
+	if item.IssueNum == 0 {
+		return fmt.Errorf("issue_num is required")
+	}
+	if item.Title == "" {
+		return fmt.Errorf("title is required")
+	}
+	if item.Squad == "" {
+		item.Squad = inferSquadFromRepo(item.Repo)
+	}
+	if item.Status == "" {
+		item.Status = "open"
+	}
+	item.UpdatedAt = time.Now().UTC().Format(time.RFC3339)
+
+	data, err := json.Marshal(item)
+	if err != nil {
+		return err
+	}
+
+	pipe := s.rdb.Pipeline()
+	pipe.Set(ctx, s.itemKey(item.Repo, item.IssueNum), data, 0)
+	pipe.SAdd(ctx, s.key("sprint-repos"), item.Repo)
+	_, err = pipe.Exec(ctx)
+	return err
+}
+
 func (s *Store) itemKey(repo string, issueNum int) string {
 	return s.namespace + ":sprint:" + repo + ":" + strconv.Itoa(issueNum)
 }

--- a/internal/sprint/store_test.go
+++ b/internal/sprint/store_test.go
@@ -463,6 +463,156 @@ func TestStore_Complete_UnblocksDependent(t *testing.T) {
 	}
 }
 
+func TestStore_Create_Basic(t *testing.T) {
+	s, ctx := testStore(t)
+
+	item := SprintItem{
+		Repo:     "AgentGuardHQ/octi-pulpo",
+		IssueNum: 99,
+		Title:    "Manual sprint item",
+		Priority: 1,
+	}
+	if err := s.Create(ctx, item); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	all, err := s.GetAll(ctx)
+	if err != nil {
+		t.Fatalf("get all: %v", err)
+	}
+	if len(all) != 1 {
+		t.Fatalf("expected 1 item, got %d", len(all))
+	}
+	got := all[0]
+	if got.IssueNum != 99 {
+		t.Errorf("issue_num: got %d, want 99", got.IssueNum)
+	}
+	if got.Title != "Manual sprint item" {
+		t.Errorf("title: got %q, want %q", got.Title, "Manual sprint item")
+	}
+	if got.Priority != 1 {
+		t.Errorf("priority: got %d, want 1", got.Priority)
+	}
+	if got.Squad != "octi-pulpo" {
+		t.Errorf("squad: got %q, want octi-pulpo (inferred)", got.Squad)
+	}
+	if got.Status != "open" {
+		t.Errorf("status: got %q, want open (default)", got.Status)
+	}
+	if got.UpdatedAt == "" {
+		t.Error("updated_at should be set")
+	}
+}
+
+func TestStore_Create_WithDependencies(t *testing.T) {
+	s, ctx := testStore(t)
+
+	item := SprintItem{
+		Repo:      "AgentGuardHQ/agentguard",
+		IssueNum:  50,
+		Title:     "Feature with deps",
+		Priority:  0,
+		DependsOn: []int{10, 20},
+		AssignTo:  "kernel-sr",
+		Squad:     "kernel",
+	}
+	if err := s.Create(ctx, item); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	all, _ := s.GetAll(ctx)
+	if len(all) != 1 {
+		t.Fatalf("expected 1 item, got %d", len(all))
+	}
+	got := all[0]
+	if len(got.DependsOn) != 2 || got.DependsOn[0] != 10 || got.DependsOn[1] != 20 {
+		t.Errorf("depends_on: got %v, want [10 20]", got.DependsOn)
+	}
+	if got.AssignTo != "kernel-sr" {
+		t.Errorf("assign_to: got %q, want kernel-sr", got.AssignTo)
+	}
+	if got.Squad != "kernel" {
+		t.Errorf("squad: got %q, want kernel (explicit)", got.Squad)
+	}
+}
+
+func TestStore_Create_ReplacesExisting(t *testing.T) {
+	s, ctx := testStore(t)
+
+	repo := "AgentGuardHQ/octi-pulpo"
+	original := SprintItem{
+		Repo: repo, IssueNum: 10, Title: "Old title", Priority: 2, Status: "open",
+	}
+	if err := s.Create(ctx, original); err != nil {
+		t.Fatalf("create original: %v", err)
+	}
+
+	updated := SprintItem{
+		Repo: repo, IssueNum: 10, Title: "New title", Priority: 0, Squad: "octi-pulpo",
+	}
+	if err := s.Create(ctx, updated); err != nil {
+		t.Fatalf("create updated: %v", err)
+	}
+
+	all, _ := s.GetAll(ctx)
+	if len(all) != 1 {
+		t.Fatalf("expected 1 item after upsert, got %d", len(all))
+	}
+	if all[0].Title != "New title" {
+		t.Errorf("expected 'New title', got %q", all[0].Title)
+	}
+	if all[0].Priority != 0 {
+		t.Errorf("expected priority 0, got %d", all[0].Priority)
+	}
+}
+
+func TestStore_Create_ValidationErrors(t *testing.T) {
+	s, ctx := testStore(t)
+
+	cases := []struct {
+		name string
+		item SprintItem
+	}{
+		{"missing repo", SprintItem{IssueNum: 1, Title: "t"}},
+		{"missing issue_num", SprintItem{Repo: "AgentGuardHQ/octi-pulpo", Title: "t"}},
+		{"missing title", SprintItem{Repo: "AgentGuardHQ/octi-pulpo", IssueNum: 1}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := s.Create(ctx, tc.item); err == nil {
+				t.Fatalf("expected error for %s, got nil", tc.name)
+			}
+		})
+	}
+}
+
+func TestStore_Create_DispatchableAfterCreate(t *testing.T) {
+	s, ctx := testStore(t)
+
+	// Create a P0 item with no deps — should appear in NextDispatchable
+	item := SprintItem{
+		Repo:     "AgentGuardHQ/shellforge",
+		IssueNum: 77,
+		Title:    "Critical fix",
+		Priority: 0,
+	}
+	if err := s.Create(ctx, item); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	dispatchable, err := s.NextDispatchable(ctx)
+	if err != nil {
+		t.Fatalf("next dispatchable: %v", err)
+	}
+	if len(dispatchable) != 1 {
+		t.Fatalf("expected 1 dispatchable, got %d", len(dispatchable))
+	}
+	if dispatchable[0].IssueNum != 77 {
+		t.Fatalf("expected issue #77, got #%d", dispatchable[0].IssueNum)
+	}
+}
+
 func TestInferSquadFromRepo(t *testing.T) {
 	tests := []struct {
 		repo  string


### PR DESCRIPTION
## Summary

- **Restored `Store.Create`** in `sprint/store.go` — dropped in the Paperclip harvest squash merge (#70). Manually upserts sprint items with explicit priority, dependencies, and squad (inferred from repo when absent).
- **Restored `sprint_create` MCP tool** in `mcp/server.go` — agents can now call `sprint_create` to inject work items directly into the sprint backlog without waiting for `sprint_sync`.
- **Fixed hardcoded `last_run_at` timestamp** in `budget/budget.go` — was always stored as `"2026-03-30T00:00:00Z"` regardless of when the agent ran. Now uses `time.Now().UTC()`.

## Root cause

`34654c1` added `sprint_create` and `Store.Create`, but they were silently dropped when `96b49c3` (Paperclip harvest) squash-merged a branch that predated those changes.

## Test plan

- [ ] `go build ./...` passes ✅
- [ ] `go vet ./...` passes ✅
- [ ] 5 restored tests cover: basic creation, dependency chains, upsert semantics, validation errors, dispatchability after create
- [ ] Budget timestamp: `last_run_at` now reflects actual run time (verify via `GetBudget` after `CheckAndIncrement`)

Partial closes #18 (Phase 1 sprint management tooling)
Partial closes #73 (agent-driven ticket ingestion — `sprint_create` is the foundation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)