### PR TITLE
feat(dispatch): daily CTO briefing — shipped PRs, P0s, blockers, briefing_read MCP (#10)

### DIFF
--- a/internal/dispatch/brain.go
+++ b/internal/dispatch/brain.go
@@ -60,6 +60,7 @@ type Brain struct {
 	lastDashboard     time.Time
 	dashboardPeriod   time.Duration
 	lastStandupDate   string // YYYY-MM-DD, guards once-per-day posting
+	lastBriefingDate  string // YYYY-MM-DD, guards once-per-day briefing
 	driversWereDown   bool   // tracks transition for edge-triggered alerts
 
 	// Self-heal dedup: tracks when each agent/squad was last alerted to avoid
@@ -145,7 +146,10 @@ func (b *Brain) Tick(ctx context.Context) {
 	// 6. Self-heal: stuck agents + inactive squads
 	b.maybeSelfHeal(ctx)
 
-	// 7. Constraint-driven dispatch (if sprint store is available)
+	// 7. Daily CTO briefing — what shipped, P0s, blockers (once per calendar day)
+	b.maybePostDailyBriefing(ctx)
+
+	// 8. Constraint-driven dispatch (if sprint store is available)
 	if b.sprintStore != nil {
 		constraint := b.identifyConstraint(ctx)
 		b.maybeNotifyConstraintChange(ctx, constraint)
@@ -421,6 +425,38 @@ func (b *Brain) checkInactiveSquads(ctx context.Context) {
 			}
 		}
 	}
+}
+
+// maybePostDailyBriefing posts the daily CTO briefing (what shipped, P0s, blockers)
+// once per calendar day. It requires both Slack and sprint store to be configured.
+func (b *Brain) maybePostDailyBriefing(ctx context.Context) {
+	if b.notifier == nil || !b.notifier.Enabled() {
+		return
+	}
+	if b.sprintStore == nil {
+		return
+	}
+	today := time.Now().UTC().Format("2006-01-02")
+	if b.lastBriefingDate == today {
+		return
+	}
+
+	items, err := b.sprintStore.GetAll(ctx)
+	if err != nil {
+		b.log.Printf("daily briefing: get sprint items: %v", err)
+		return
+	}
+
+	drivers := b.dispatcher.router.AllHealth()
+	rdb := b.dispatcher.RedisClient()
+	ns := b.dispatcher.Namespace()
+
+	briefing := BuildDailyBriefing(ctx, rdb, ns, drivers, items)
+	if err := b.notifier.PostDailyBriefing(ctx, briefing); err != nil {
+		b.log.Printf("slack daily briefing: %v", err)
+		return
+	}
+	b.lastBriefingDate = today
 }
 
 // maybeNotifyConstraintChange fires edge-triggered Slack alerts when driver

--- a/internal/dispatch/briefing.go
+++ b/internal/dispatch/briefing.go
@@ -1,0 +1,96 @@
+package dispatch
+
+import (
+	"context"
+	"encoding/json"
+	"strconv"
+	"time"
+
+	"github.com/AgentGuardHQ/octi-pulpo/internal/routing"
+	"github.com/AgentGuardHQ/octi-pulpo/internal/sprint"
+	"github.com/redis/go-redis/v9"
+)
+
+// WorkerResult is a single agent execution record from the worker-results list.
+type WorkerResult struct {
+	Agent       string  `json:"agent"`
+	ExitCode    int     `json:"exit_code"`
+	DurationSec float64 `json:"duration_sec"`
+	HadCommits  bool    `json:"had_commits"`
+	Timestamp   string  `json:"timestamp"`
+}
+
+// DailyBriefing is an aggregated daily swarm intelligence summary.
+// It is the data layer for the CTO daily digest and the eventual NotebookLM export.
+type DailyBriefing struct {
+	Date        string                 `json:"date"`
+	PassRate    float64                `json:"pass_rate"`    // 0–100
+	WorkerOK    int64                  `json:"worker_ok"`
+	WorkerFail  int64                  `json:"worker_fail"`
+	Drivers     []routing.DriverHealth `json:"drivers"`
+	ShippedPRs  []sprint.SprintItem    `json:"shipped_prs"`  // pr_open or done items with PR numbers
+	OpenP0s     []sprint.SprintItem    `json:"open_p0s"`     // P0 items still open
+	Blocked     []sprint.SprintItem    `json:"blocked"`      // open items whose depends_on are not done
+	RecentFails []WorkerResult         `json:"recent_fails"` // latest failed worker runs (exit_code != 0)
+}
+
+// BuildDailyBriefing assembles a DailyBriefing from live Redis state and sprint items.
+// It does not call external APIs; all data comes from the local Redis store.
+func BuildDailyBriefing(ctx context.Context, rdb *redis.Client, ns string, drivers []routing.DriverHealth, items []sprint.SprintItem) DailyBriefing {
+	b := DailyBriefing{
+		Date:    time.Now().UTC().Format("2006-01-02"),
+		Drivers: drivers,
+	}
+
+	// Pass rate from cumulative Redis counters.
+	okStr, _ := rdb.Get(ctx, ns+":worker-ok").Result()
+	failStr, _ := rdb.Get(ctx, ns+":worker-fail").Result()
+	b.WorkerOK, _ = strconv.ParseInt(okStr, 10, 64)
+	b.WorkerFail, _ = strconv.ParseInt(failStr, 10, 64)
+	total := b.WorkerOK + b.WorkerFail
+	if total > 0 {
+		b.PassRate = float64(b.WorkerOK) / float64(total) * 100
+	}
+
+	// Recent failed runs (up to 10).
+	raw, _ := rdb.LRange(ctx, ns+":worker-results", 0, 49).Result()
+	for _, r := range raw {
+		var wr WorkerResult
+		if err := json.Unmarshal([]byte(r), &wr); err != nil {
+			continue
+		}
+		if wr.ExitCode != 0 {
+			b.RecentFails = append(b.RecentFails, wr)
+			if len(b.RecentFails) >= 10 {
+				break
+			}
+		}
+	}
+
+	// Sprint-derived metrics.
+	doneSet := make(map[int]bool)
+	for _, item := range items {
+		if item.Status == "done" {
+			doneSet[item.IssueNum] = true
+		}
+	}
+	for _, item := range items {
+		switch {
+		case item.PRNumber > 0 && (item.Status == "pr_open" || item.Status == "done"):
+			b.ShippedPRs = append(b.ShippedPRs, item)
+		}
+		if item.Priority == 0 && (item.Status == "open" || item.Status == "in_progress") {
+			b.OpenP0s = append(b.OpenP0s, item)
+		}
+		if item.Status == "open" && len(item.DependsOn) > 0 {
+			for _, dep := range item.DependsOn {
+				if !doneSet[dep] {
+					b.Blocked = append(b.Blocked, item)
+					break
+				}
+			}
+		}
+	}
+
+	return b
+}

--- a/internal/dispatch/briefing_test.go
+++ b/internal/dispatch/briefing_test.go
@@ -1,0 +1,178 @@
+package dispatch
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/AgentGuardHQ/octi-pulpo/internal/routing"
+	"github.com/AgentGuardHQ/octi-pulpo/internal/sprint"
+	"github.com/redis/go-redis/v9"
+)
+
+// testRedis returns a Redis client and a unique namespace for the test.
+// The test is skipped when Redis is not reachable.
+func testRedis(t *testing.T) (*redis.Client, string, context.Context) {
+	t.Helper()
+	redisURL := os.Getenv("OCTI_REDIS_URL")
+	if redisURL == "" {
+		redisURL = "redis://localhost:6379"
+	}
+	opts, err := redis.ParseURL(redisURL)
+	if err != nil {
+		t.Skipf("skipping: cannot parse redis URL: %v", err)
+	}
+	rdb := redis.NewClient(opts)
+	ctx := context.Background()
+	if err := rdb.Ping(ctx).Err(); err != nil {
+		t.Skipf("skipping: redis not available: %v", err)
+	}
+	ns := "octi-test-briefing-" + t.Name()
+	cleanup := func() {
+		keys, _ := rdb.Keys(ctx, ns+":*").Result()
+		if len(keys) > 0 {
+			rdb.Del(ctx, keys...)
+		}
+	}
+	cleanup()
+	t.Cleanup(func() { cleanup(); rdb.Close() })
+	return rdb, ns, ctx
+}
+
+func TestBuildDailyBriefing_PassRate(t *testing.T) {
+	rdb, ns, ctx := testRedis(t)
+	rdb.Set(ctx, ns+":worker-ok", "80", 0)
+	rdb.Set(ctx, ns+":worker-fail", "20", 0)
+
+	b := BuildDailyBriefing(ctx, rdb, ns, nil, nil)
+
+	if b.WorkerOK != 80 || b.WorkerFail != 20 {
+		t.Errorf("expected 80/20, got %d/%d", b.WorkerOK, b.WorkerFail)
+	}
+	if b.PassRate < 79 || b.PassRate > 81 {
+		t.Errorf("expected pass rate ~80%%, got %.1f%%", b.PassRate)
+	}
+}
+
+func TestBuildDailyBriefing_SprintFields(t *testing.T) {
+	rdb, ns, ctx := testRedis(t)
+
+	items := []sprint.SprintItem{
+		{IssueNum: 1, Repo: "AgentGuardHQ/octi-pulpo", Title: "shipped", Status: "done", Priority: 2, PRNumber: 10},
+		{IssueNum: 2, Repo: "AgentGuardHQ/octi-pulpo", Title: "P0 open", Status: "open", Priority: 0},
+		{IssueNum: 3, Repo: "AgentGuardHQ/octi-pulpo", Title: "blocked", Status: "open", Priority: 2, DependsOn: []int{99}},
+		{IssueNum: 4, Repo: "AgentGuardHQ/octi-pulpo", Title: "PR in flight", Status: "pr_open", Priority: 1, PRNumber: 42},
+	}
+
+	b := BuildDailyBriefing(ctx, rdb, ns, nil, items)
+
+	if len(b.ShippedPRs) != 2 { // item 1 (done+PR) + item 4 (pr_open+PR)
+		t.Errorf("expected 2 shipped PRs, got %d: %v", len(b.ShippedPRs), b.ShippedPRs)
+	}
+	if len(b.OpenP0s) != 1 || b.OpenP0s[0].IssueNum != 2 {
+		t.Errorf("expected 1 P0 open (issue 2), got %v", b.OpenP0s)
+	}
+	if len(b.Blocked) != 1 || b.Blocked[0].IssueNum != 3 {
+		t.Errorf("expected 1 blocked (issue 3), got %v", b.Blocked)
+	}
+}
+
+func TestBuildDailyBriefing_DepSatisfied(t *testing.T) {
+	rdb, ns, ctx := testRedis(t)
+
+	items := []sprint.SprintItem{
+		{IssueNum: 99, Repo: "AgentGuardHQ/octi-pulpo", Title: "dep done", Status: "done", Priority: 2},
+		{IssueNum: 3, Repo: "AgentGuardHQ/octi-pulpo", Title: "depends on 99", Status: "open", Priority: 2, DependsOn: []int{99}},
+	}
+
+	b := BuildDailyBriefing(ctx, rdb, ns, nil, items)
+
+	if len(b.Blocked) != 0 {
+		t.Errorf("expected no blocked items when dep is done, got %v", b.Blocked)
+	}
+}
+
+func TestBuildDailyBriefing_RecentFails(t *testing.T) {
+	rdb, ns, ctx := testRedis(t)
+
+	// Push a failed worker result.
+	fail := map[string]interface{}{
+		"agent":        "octi-pulpo-sr",
+		"exit_code":    1,
+		"duration_sec": 3.0,
+		"had_commits":  false,
+		"timestamp":    "2026-03-30T00:00:00Z",
+	}
+	data, _ := json.Marshal(fail)
+	rdb.LPush(ctx, ns+":worker-results", string(data))
+
+	b := BuildDailyBriefing(ctx, rdb, ns, nil, nil)
+
+	if len(b.RecentFails) != 1 || b.RecentFails[0].Agent != "octi-pulpo-sr" {
+		t.Errorf("expected 1 recent fail for octi-pulpo-sr, got %v", b.RecentFails)
+	}
+}
+
+func TestPostDailyBriefing_NoopWhenDisabled(t *testing.T) {
+	n := NewNotifier("")
+	err := n.PostDailyBriefing(context.Background(), DailyBriefing{Date: "2026-03-30"})
+	if err != nil {
+		t.Fatalf("expected no error for disabled notifier, got %v", err)
+	}
+}
+
+func TestPostDailyBriefing_Content(t *testing.T) {
+	var received []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		received, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	n := NewNotifier(srv.URL)
+	b := DailyBriefing{
+		Date:       "2026-03-30",
+		PassRate:   75.0,
+		WorkerOK:   75,
+		WorkerFail: 25,
+		Drivers: []routing.DriverHealth{
+			{Name: "claude-code", CircuitState: "CLOSED"},
+			{Name: "codex", CircuitState: "OPEN", Failures: 3},
+		},
+		ShippedPRs: []sprint.SprintItem{
+			{IssueNum: 5, Repo: "AgentGuardHQ/octi-pulpo", Title: "feat shipped", Status: "pr_open", PRNumber: 42},
+		},
+		OpenP0s: []sprint.SprintItem{
+			{IssueNum: 2, Repo: "AgentGuardHQ/octi-pulpo", Title: "urgent bug"},
+		},
+		Blocked: []sprint.SprintItem{
+			{IssueNum: 7, Repo: "AgentGuardHQ/octi-pulpo", Title: "blocked feat", DependsOn: []int{6}},
+		},
+	}
+
+	if err := n.PostDailyBriefing(context.Background(), b); err != nil {
+		t.Fatalf("PostDailyBriefing: %v", err)
+	}
+
+	body := string(received)
+	for _, want := range []string{"Daily CTO Briefing", "75.0%", "claude-code", "PR #42", "urgent bug", "blocked feat"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("expected %q in Slack body, got: %s", want, body)
+		}
+	}
+
+	// Verify blocks array with action buttons is present.
+	var payload map[string]interface{}
+	if err := json.Unmarshal(received, &payload); err != nil {
+		t.Fatalf("unmarshal payload: %v", err)
+	}
+	blocks, ok := payload["blocks"].([]interface{})
+	if !ok || len(blocks) < 2 {
+		t.Errorf("expected blocks with at least 2 elements (section + actions), got: %v", payload)
+	}
+}

--- a/internal/dispatch/slack.go
+++ b/internal/dispatch/slack.go
@@ -218,6 +218,77 @@ func (n *Notifier) PostDriverAlert(ctx context.Context, driverName string, failu
 	return n.postBlocks(ctx, blocks)
 }
 
+// PostDailyBriefing sends a structured daily briefing to Slack:
+// what shipped (open PRs), decisions needed (P0 open items + blocked items),
+// pass rate, and a snapshot of driver health.
+// This is the data-layer prep for the eventual NotebookLM export (issue #10).
+func (n *Notifier) PostDailyBriefing(ctx context.Context, b DailyBriefing) error {
+	if !n.Enabled() {
+		return nil
+	}
+
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("*📋 Daily CTO Briefing — %s*\n", b.Date))
+
+	// Pass rate
+	if b.WorkerOK+b.WorkerFail > 0 {
+		sb.WriteString(fmt.Sprintf("Pass rate: *%.1f%%* (%d ok / %d fail)\n", b.PassRate, b.WorkerOK, b.WorkerFail))
+	}
+
+	// Driver health
+	var driverParts []string
+	for _, d := range b.Drivers {
+		icon := "🟢"
+		if d.CircuitState == "OPEN" {
+			icon = "🔴"
+		} else if d.CircuitState == "HALF" {
+			icon = "🟡"
+		}
+		driverParts = append(driverParts, fmt.Sprintf("%s `%s`", icon, d.Name))
+	}
+	if len(driverParts) > 0 {
+		sb.WriteString("Drivers: " + strings.Join(driverParts, " · ") + "\n")
+	}
+
+	// What shipped (PRs in flight or done)
+	if len(b.ShippedPRs) > 0 {
+		sb.WriteString("\n*✅ What Shipped (PRs)*\n")
+		for _, item := range b.ShippedPRs {
+			prURL := fmt.Sprintf("https://github.com/%s/pull/%d", item.Repo, item.PRNumber)
+			sb.WriteString(fmt.Sprintf("  • <%s|PR #%d>: %s\n", prURL, item.PRNumber, item.Title))
+		}
+	}
+
+	// Decisions needed — P0 open items
+	if len(b.OpenP0s) > 0 {
+		sb.WriteString("\n*🔴 Decisions Needed (P0 Open)*\n")
+		for _, item := range b.OpenP0s {
+			issueURL := fmt.Sprintf("https://github.com/%s/issues/%d", item.Repo, item.IssueNum)
+			sb.WriteString(fmt.Sprintf("  • <%s|%s#%d>: %s\n", issueURL, item.Repo, item.IssueNum, item.Title))
+		}
+	}
+
+	// Blocked items
+	if len(b.Blocked) > 0 {
+		sb.WriteString("\n*🚧 Blocked*\n")
+		for _, item := range b.Blocked {
+			issueURL := fmt.Sprintf("https://github.com/%s/issues/%d", item.Repo, item.IssueNum)
+			sb.WriteString(fmt.Sprintf("  • <%s|%s#%d>: %s (needs: %v)\n", issueURL, item.Repo, item.IssueNum, item.Title, item.DependsOn))
+		}
+	}
+
+	blocks := []map[string]interface{}{
+		blockSection(sb.String()),
+		blockActions(
+			slackButton("view_sprint", b.Date, "View Sprint", "primary"),
+			slackButton("view_blockers", b.Date, "View Blockers", ""),
+			slackButton("reprioritize", b.Date, "Reprioritize", ""),
+		),
+	}
+
+	return n.postBlocks(ctx, blocks)
+}
+
 // PostDailyStandup posts a unified standup summary for all squads to Slack.
 func (n *Notifier) PostDailyStandup(ctx context.Context, entries []standup.Entry) error {
 	if !n.Enabled() {

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -282,6 +282,19 @@ func (s *Server) handleToolCall(req Request) Response {
 		data, _ := json.Marshal(report)
 		return textResult(req.ID, string(data))
 
+	case "briefing_read":
+		if s.sprintStore == nil || s.rdb == nil {
+			return errorResp(req.ID, -32000, "sprint store or redis not initialized")
+		}
+		items, err := s.sprintStore.GetAll(ctx)
+		if err != nil {
+			return errorResp(req.ID, -32000, err.Error())
+		}
+		drivers := s.router.AllHealth()
+		briefing := dispatch.BuildDailyBriefing(ctx, s.rdb, s.redisNS, drivers, items)
+		data, _ := json.Marshal(briefing)
+		return textResult(req.ID, string(data))
+
 	case "dispatch_event":
 		if s.dispatcher == nil {
 			return errorResp(req.ID, -32000, "dispatcher not initialized")
@@ -846,6 +859,14 @@ func toolDefs() []ToolDef {
 		{
 			Name:        "health_report",
 			Description: "Get current health status of all drivers in the swarm — circuit breaker state, failure counts, last success/failure timestamps, time since last success, and recommended actions per driver.",
+			InputSchema: map[string]interface{}{
+				"type":       "object",
+				"properties": map[string]interface{}{},
+			},
+		},
+		{
+			Name:        "briefing_read",
+			Description: "Build and return today's CTO daily briefing: pass rate, driver health, shipped PRs, open P0 issues, and blocked items. This is the structured data layer for the daily Slack digest and eventual NotebookLM export.",
 			InputSchema: map[string]interface{}{
 				"type":       "object",
 				"properties": map[string]interface{}{},


### PR DESCRIPTION
## Summary

Partial closes #10 (daily briefing cadence; NotebookLM audio/slides pipeline depends on #5; 4h sprint digest already in PR #74).

- **`DailyBriefing` / `BuildDailyBriefing`** (`dispatch/briefing.go`) — aggregates pass rate, driver health, shipped PRs, open P0s, blocked items (unmet `depends_on`), and recent failed runs from Redis. This is the structured export layer that will feed into NotebookLM once issue #5 (browser driver) lands.
- **`PostDailyBriefing`** (`dispatch/slack.go`) — Block Kit message with "What Shipped", "Decisions Needed (P0)", "Blocked" sections and `[View Sprint] [View Blockers] [Reprioritize]` action buttons.
- **`maybePostDailyBriefing`** (`dispatch/brain.go`) — fires once per calendar day from the brain loop (separate cadence from the 4h sprint digest in PR #74).
- **`briefing_read`** MCP tool (`mcp/server.go`) — on-demand structured briefing for agents and operators; same `DailyBriefing` payload as JSON.
- **6 new tests** — all pass.

## Architecture

```
Brain.Tick()
  ├── maybePostDashboard (every 4h)  ← PR #74
  ├── maybePostDailyStandup (daily)  ← existing
  └── maybePostDailyBriefing (daily) ← this PR
        ├── BuildDailyBriefing(ctx, rdb, ns, drivers, items)
        │     ├── pass rate + recent fails from Redis
        │     ├── shipped PRs  (status=pr_open|done, PRNumber>0)
        │     ├── open P0s     (priority=0, status=open|in_progress)
        │     └── blocked      (open items with unmet depends_on)
        └── PostDailyBriefing → Block Kit with action buttons

MCP briefing_read → BuildDailyBriefing → JSON (on-demand)
```

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./...` — 291 tests pass (6 new)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)