### PR TITLE
feat: budget MCP tools — budget_status, budget_set, budget_reset (#79)

### DIFF
--- a/internal/budget/budget.go
+++ b/internal/budget/budget.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"time"
 
 	"github.com/redis/go-redis/v9"
 )
@@ -147,7 +148,7 @@ func (bs *BudgetStore) CheckAndIncrement(ctx context.Context, agent string, cost
 		isCritical = 1
 	}
 
-	timestamp := "2026-03-30T00:00:00Z" // default; in production use time.Now()
+	timestamp := time.Now().UTC().Format(time.RFC3339)
 	result, err := checkAndIncrementScript.Run(ctx, bs.rdb,
 		[]string{bs.key(agent)},
 		costCents, threshold, timestamp, isCritical,
@@ -157,6 +158,34 @@ func (bs *BudgetStore) CheckAndIncrement(ctx context.Context, agent string, cost
 	}
 
 	return result == 1, nil
+}
+
+// ListAll returns all agent budgets stored in this namespace.
+// Returns an empty slice when there are no budgets configured.
+func (bs *BudgetStore) ListAll(ctx context.Context) ([]AgentBudget, error) {
+	pattern := bs.namespace + ":budget:*"
+	var keys []string
+	iter := bs.rdb.Scan(ctx, 0, pattern, 0).Iterator()
+	for iter.Next(ctx) {
+		keys = append(keys, iter.Val())
+	}
+	if err := iter.Err(); err != nil {
+		return nil, fmt.Errorf("scan budgets: %w", err)
+	}
+
+	budgets := make([]AgentBudget, 0, len(keys))
+	for _, k := range keys {
+		raw, err := bs.rdb.Get(ctx, k).Result()
+		if err != nil {
+			continue // key may have expired between SCAN and GET
+		}
+		var b AgentBudget
+		if err := json.Unmarshal([]byte(raw), &b); err != nil {
+			continue
+		}
+		budgets = append(budgets, b)
+	}
+	return budgets, nil
 }
 
 // MonthlyReset zeros out the spent amount, run count, and paused flag for an agent.

--- a/internal/budget/budget_test.go
+++ b/internal/budget/budget_test.go
@@ -212,6 +212,53 @@ func TestCheckAndIncrement_PriorityThresholds(t *testing.T) {
 	}
 }
 
+func TestListAll(t *testing.T) {
+	bs, ctx := budgetTestSetup(t)
+
+	// Empty namespace returns empty slice, not error.
+	all, err := bs.ListAll(ctx)
+	if err != nil {
+		t.Fatalf("list all empty: %v", err)
+	}
+	if len(all) != 0 {
+		t.Fatalf("expected 0 budgets, got %d", len(all))
+	}
+
+	agents := []AgentBudget{
+		{Agent: "sr-list-01", Driver: "claude-code", BudgetMonthlyCents: 500},
+		{Agent: "sr-list-02", Driver: "codex", BudgetMonthlyCents: 300},
+		{Agent: "sr-list-03", Driver: "ollama", BudgetMonthlyCents: 0, Paused: true},
+	}
+	for _, b := range agents {
+		if b.BudgetMonthlyCents == 0 {
+			// Store zero-budget agents directly (SetBudget doesn't validate)
+			b.BudgetMonthlyCents = 1 // minimal valid value for storage
+		}
+		if err := bs.SetBudget(ctx, b); err != nil {
+			t.Fatalf("set budget %s: %v", b.Agent, err)
+		}
+	}
+
+	all, err = bs.ListAll(ctx)
+	if err != nil {
+		t.Fatalf("list all: %v", err)
+	}
+	if len(all) != 3 {
+		t.Fatalf("expected 3 budgets, got %d", len(all))
+	}
+
+	// Verify each agent appears exactly once.
+	found := make(map[string]bool)
+	for _, b := range all {
+		found[b.Agent] = true
+	}
+	for _, b := range agents {
+		if !found[b.Agent] {
+			t.Errorf("agent %s missing from ListAll result", b.Agent)
+		}
+	}
+}
+
 func TestMonthlyReset(t *testing.T) {
 	bs, ctx := budgetTestSetup(t)
 

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -599,6 +599,82 @@ func (s *Server) handleToolCall(req Request) Response {
 		return textResult(req.ID, string(data))
 
 
+	case "budget_status":
+		if s.budgetStore == nil {
+			return errorResp(req.ID, -32000, "budget store not initialized")
+		}
+		var args struct {
+			Agent string `json:"agent"` // optional; omit for all agents
+		}
+		json.Unmarshal(params.Arguments, &args)
+		if args.Agent != "" {
+			b, err := s.budgetStore.GetBudget(ctx, args.Agent)
+			if err != nil {
+				return errorResp(req.ID, -32000, err.Error())
+			}
+			data, _ := json.Marshal(b)
+			return textResult(req.ID, string(data))
+		}
+		all, err := s.budgetStore.ListAll(ctx)
+		if err != nil {
+			return errorResp(req.ID, -32000, err.Error())
+		}
+		if len(all) == 0 {
+			return textResult(req.ID, "No agent budgets configured.")
+		}
+		data, _ := json.Marshal(all)
+		return textResult(req.ID, string(data))
+
+	case "budget_set":
+		if s.budgetStore == nil {
+			return errorResp(req.ID, -32000, "budget store not initialized")
+		}
+		var args struct {
+			Agent              string `json:"agent"`
+			Driver             string `json:"driver"`
+			Box                string `json:"box"`
+			BudgetMonthlyCents int    `json:"budget_monthly_cents"`
+		}
+		json.Unmarshal(params.Arguments, &args)
+		if args.Agent == "" {
+			return errorResp(req.ID, -32602, "agent is required")
+		}
+		if args.BudgetMonthlyCents <= 0 {
+			return errorResp(req.ID, -32602, "budget_monthly_cents must be > 0")
+		}
+		// Merge into existing record to preserve accumulated spent/runs.
+		existing, err := s.budgetStore.GetBudget(ctx, args.Agent)
+		if err != nil {
+			existing = budget.AgentBudget{Agent: args.Agent}
+		}
+		existing.BudgetMonthlyCents = args.BudgetMonthlyCents
+		if args.Driver != "" {
+			existing.Driver = args.Driver
+		}
+		if args.Box != "" {
+			existing.Box = args.Box
+		}
+		if err := s.budgetStore.SetBudget(ctx, existing); err != nil {
+			return errorResp(req.ID, -32000, err.Error())
+		}
+		return textResult(req.ID, fmt.Sprintf("Budget set for %s: $%.2f/month (driver: %s)", args.Agent, float64(args.BudgetMonthlyCents)/100, existing.Driver))
+
+	case "budget_reset":
+		if s.budgetStore == nil {
+			return errorResp(req.ID, -32000, "budget store not initialized")
+		}
+		var args struct {
+			Agent string `json:"agent"`
+		}
+		json.Unmarshal(params.Arguments, &args)
+		if args.Agent == "" {
+			return errorResp(req.ID, -32602, "agent is required")
+		}
+		if err := s.budgetStore.MonthlyReset(ctx, args.Agent); err != nil {
+			return errorResp(req.ID, -32000, err.Error())
+		}
+		return textResult(req.ID, fmt.Sprintf("Budget reset for %s: spent zeroed, unpaused", args.Agent))
+
 	case "org_chart":
 		if s.orgStore == nil {
 			return errorResp(req.ID, -32000, "org store not initialized")
@@ -819,12 +895,13 @@ func toolDefs() []ToolDef {
 		},
 		{
 			Name:        "dispatch_trigger",
-			Description: "Manually trigger an agent run. Bypasses event matching but still respects cooldown and coordination claims.",
+			Description: "Manually trigger an agent run. Bypasses event matching but still respects cooldown and coordination claims. Pass budget to override the automatic dynamic budget level.",
 			InputSchema: map[string]interface{}{
 				"type": "object",
 				"properties": map[string]interface{}{
 					"agent":    map[string]string{"type": "string", "description": "Agent name to trigger"},
 					"priority": map[string]interface{}{"type": "number", "description": "Priority (0=critical, 1=high, 2=normal, 3=background). Default: 1"},
+					"budget":   map[string]interface{}{"type": "string", "enum": []string{"low", "medium", "high"}, "description": "Budget tier override — low (local only), medium (local+subscription+cli), high (all tiers including API). Omit to use the automatic dynamic budget derived from current driver health."},
 				},
 				"required": []string{"agent"},
 			},
@@ -897,6 +974,41 @@ func toolDefs() []ToolDef {
 			InputSchema: map[string]interface{}{
 				"type":       "object",
 				"properties": map[string]interface{}{},
+			},
+		},
+		{
+			Name:        "budget_status",
+			Description: "Show per-agent monthly budget: limit, spent, runs, last run, and whether the agent is paused. Omit agent to list all configured budgets.",
+			InputSchema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"agent": map[string]string{"type": "string", "description": "Agent name. Omit to return all agent budgets."},
+				},
+			},
+		},
+		{
+			Name:        "budget_set",
+			Description: "Provision or update an agent's monthly budget. Preserves accumulated spent/runs — only updates the limit and optional driver/box metadata. Call this to unblock a new agent that has no budget record yet (required before first dispatch).",
+			InputSchema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"agent":                map[string]string{"type": "string", "description": "Agent name"},
+					"budget_monthly_cents": map[string]interface{}{"type": "number", "description": "Monthly budget cap in cents (e.g. 770 = $7.70/month)"},
+					"driver":               map[string]string{"type": "string", "description": "Driver the agent uses (e.g. claude-code, codex). Optional."},
+					"box":                  map[string]string{"type": "string", "description": "Host box the agent runs on. Optional."},
+				},
+				"required": []string{"agent", "budget_monthly_cents"},
+			},
+		},
+		{
+			Name:        "budget_reset",
+			Description: "Monthly budget reset for an agent: zeroes spent amount and run count, clears the paused flag. Use at the start of each billing cycle or to manually unblock a paused agent.",
+			InputSchema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"agent": map[string]string{"type": "string", "description": "Agent name to reset"},
+				},
+				"required": []string{"agent"},
 			},
 		},
 		{


### PR DESCRIPTION
## Summary

- **Fixes silent dispatch blocking**: `CheckAndIncrement` returns `denied` when no budget record exists for an agent. `budget_set` is the missing provisioning step — without it, every agent with `BudgetStore` enabled is silently skipped on every non-CRITICAL dispatch.
- **Adds 3 MCP budget tools**: `budget_status` (inspect), `budget_set` (provision/update), `budget_reset` (monthly cycle reset)
- **Fixes `last_run_at` accuracy**: hardcoded `"2026-03-30T00:00:00Z"` timestamp replaced with `time.Now().UTC()`
- **Exposes `budget` field on `dispatch_trigger`**: agents can now pass `"high"` to unlock API-tier burst capacity via MCP

## Changes

| File | Change |
|------|--------|
| `internal/budget/budget.go` | Fix timestamp; add `ListAll` method |
| `internal/mcp/server.go` | Add 3 budget tool handlers + toolDefs; fix `dispatch_trigger` schema |
| `internal/budget/budget_test.go` | Add `TestListAll` |

## Test plan

- [ ] `go build ./...` passes (verified)
- [ ] `go vet ./...` passes (verified)
- [ ] `TestListAll` covers empty namespace and multi-agent listing
- [ ] Existing budget tests still pass (timestamp fix doesn't break assertions — tests check `last_run_at != ""`, not the exact value)

Closes #79
Sprint goal: "Ship budget-aware dispatch + wire as workspace MCP server"

🤖 Generated with [Claude Code](https://claude.com/claude-code)