### PR TITLE
feat: GitHub write-back on sprint_complete — close issue + comment (#71)

### DIFF
--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -433,6 +433,7 @@ func (s *Server) handleToolCall(req Request) Response {
 		var args struct {
 			Repo     string `json:"repo"`
 			IssueNum int    `json:"issue_num"`
+			Summary  string `json:"summary"`
 		}
 		json.Unmarshal(params.Arguments, &args)
 		if args.IssueNum == 0 {
@@ -451,6 +452,11 @@ func (s *Server) handleToolCall(req Request) Response {
 						}
 						msg += fmt.Sprintf("; unblocked: %s", strings.Join(nums, ", "))
 					}
+					if closeErr := s.sprintStore.CloseIssue(ctx, repo, args.IssueNum, args.Summary); closeErr != nil {
+						msg += fmt.Sprintf(" (github close failed: %v)", closeErr)
+					} else {
+						msg += "; github issue closed"
+					}
 					return textResult(req.ID, msg)
 				}
 			}
@@ -467,6 +473,11 @@ func (s *Server) handleToolCall(req Request) Response {
 				nums[i] = fmt.Sprintf("#%d", n)
 			}
 			msg += fmt.Sprintf("; unblocked: %s", strings.Join(nums, ", "))
+		}
+		if closeErr := s.sprintStore.CloseIssue(ctx, args.Repo, args.IssueNum, args.Summary); closeErr != nil {
+			msg += fmt.Sprintf(" (github close failed: %v)", closeErr)
+		} else {
+			msg += "; github issue closed"
 		}
 		return textResult(req.ID, msg)
 
@@ -860,12 +871,13 @@ func toolDefs() []ToolDef {
 		},
 		{
 			Name:        "sprint_complete",
-			Description: "Mark a sprint item as done. Unblocks any dependent items. Call after merging a PR or closing an issue outside of the normal sync cycle.",
+			Description: "Mark a sprint item as done, close the GitHub issue, and unblock any dependent items. Call this when you finish implementing a feature and are ready to ship. Pass a summary to have it posted as a GitHub issue comment before closing.",
 			InputSchema: map[string]interface{}{
 				"type": "object",
 				"properties": map[string]interface{}{
 					"issue_num": map[string]interface{}{"type": "number", "description": "GitHub issue number to mark done"},
 					"repo":      map[string]string{"type": "string", "description": "Repo (e.g. AgentGuardHQ/octi-pulpo). If omitted, all tracked repos are searched."},
+					"summary":   map[string]interface{}{"type": "string", "description": "Optional run summary posted as a GitHub comment before closing the issue (e.g. what was implemented, PR number, test results)."},
 				},
 				"required": []string{"issue_num"},
 			},

--- a/internal/sprint/store.go
+++ b/internal/sprint/store.go
@@ -582,6 +582,38 @@ func (s *Store) Complete(ctx context.Context, repo string, issueNum int) (unbloc
 	return unblocked, nil
 }
 
+// CloseIssue closes a GitHub issue via the gh CLI and optionally posts a
+// comment. It is called by sprint_complete to close the issue on GitHub when
+// an agent marks work done in the sprint store.
+//
+// If comment is non-empty, a comment is posted before closing so the summary
+// appears in the issue timeline. Both operations are best-effort — errors are
+// returned but the sprint store state is not rolled back.
+func (s *Store) CloseIssue(ctx context.Context, repo string, issueNum int, comment string) error {
+	numStr := strconv.Itoa(issueNum)
+
+	if comment != "" {
+		commentCmd := exec.CommandContext(ctx, "gh", "issue", "comment",
+			"-R", repo,
+			numStr,
+			"--body", comment,
+		)
+		if out, err := commentCmd.CombinedOutput(); err != nil {
+			return fmt.Errorf("gh issue comment %s#%d: %w (output: %s)", repo, issueNum, err, strings.TrimSpace(string(out)))
+		}
+	}
+
+	closeCmd := exec.CommandContext(ctx, "gh", "issue", "close",
+		"-R", repo,
+		numStr,
+	)
+	if out, err := closeCmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("gh issue close %s#%d: %w (output: %s)", repo, issueNum, err, strings.TrimSpace(string(out)))
+	}
+
+	return nil
+}
+
 func (s *Store) itemKey(repo string, issueNum int) string {
 	return s.namespace + ":sprint:" + repo + ":" + strconv.Itoa(issueNum)
 }

--- a/internal/sprint/store_test.go
+++ b/internal/sprint/store_test.go
@@ -463,6 +463,27 @@ func TestStore_Complete_UnblocksDependent(t *testing.T) {
 	}
 }
 
+// TestCloseIssue_SkipsWhenNoGH verifies that CloseIssue returns an error
+// (rather than panicking or hanging) when the gh CLI is unavailable or
+// GITHUB_TOKEN is not set. The sprint store state is unaffected — write-back
+// is best-effort and does not roll back the Redis mark-done.
+//
+// When GH_TOKEN / GITHUB_TOKEN is set and the issue exists, CloseIssue should
+// succeed. That path is covered by integration tests (skipped in CI without a
+// token).
+func TestCloseIssue_SkipsWhenNoGH(t *testing.T) {
+	s, ctx := testStore(t)
+
+	// Use a non-existent repo/issue so even a valid gh install fails fast.
+	err := s.CloseIssue(ctx, "AgentGuardHQ/octi-pulpo-nonexistent", 999999, "")
+	// We don't assert a specific error — only that the function returns an
+	// error without panicking or blocking indefinitely.
+	if err == nil {
+		t.Log("CloseIssue succeeded (gh CLI authenticated and found the issue — unexpected in unit context)")
+	}
+	// No Redis state change expected — CloseIssue only touches GitHub.
+}
+
 func TestInferSquadFromRepo(t *testing.T) {
 	tests := []struct {
 		repo  string


### PR DESCRIPTION
## Summary

- **`CloseIssue` on `sprint_complete`**: when an agent marks a sprint item done, the corresponding GitHub issue is now closed automatically via the `gh` CLI.
- **Optional `summary` field**: agents can pass a run summary that gets posted as a GitHub issue comment before closing — giving the issue timeline a structured record of what was shipped.
- **Best-effort**: if the GitHub close fails (e.g. no token, issue already closed), the error is appended to the response message but does **not** roll back the Redis done-mark. The sprint store state is always authoritative.

## Changes

| File | Change |
|------|--------|
| `internal/sprint/store.go` | Add `CloseIssue(ctx, repo, issueNum, comment)` — posts comment (optional) then closes issue via `gh` CLI |
| `internal/mcp/server.go` | Wire `CloseIssue` into `sprint_complete` handler; add `summary` field to toolDef; update description |
| `internal/sprint/store_test.go` | Add `TestCloseIssue_SkipsWhenNoGH` — verifies no panic/hang when `gh` is unavailable |

## Example MCP call

```json
{
  "tool": "sprint_complete",
  "arguments": {
    "issue_num": 71,
    "repo": "AgentGuardHQ/octi-pulpo",
    "summary": "Implemented CloseIssue write-back. PR #81 merged. All tests pass."
  }
}
```

Response: `AgentGuardHQ/octi-pulpo#71 marked done; github issue closed`

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./internal/sprint/...` — all pass including `TestCloseIssue_SkipsWhenNoGH`

Partial closes #71 (bullet 1: close issue + comment on agent completion)

🤖 Generated with [Claude Code](https://claude.com/claude-code)