### PR TITLE
feat: budget MCP tools — budget_status, budget_set, budget_reset + timestamp fix

### DIFF
--- a/internal/budget/budget.go
+++ b/internal/budget/budget.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"time"
 
 	"github.com/redis/go-redis/v9"
 )
@@ -147,7 +148,7 @@ func (bs *BudgetStore) CheckAndIncrement(ctx context.Context, agent string, cost
 		isCritical = 1
 	}
 
-	timestamp := "2026-03-30T00:00:00Z" // default; in production use time.Now()
+	timestamp := time.Now().UTC().Format(time.RFC3339)
 	result, err := checkAndIncrementScript.Run(ctx, bs.rdb,
 		[]string{bs.key(agent)},
 		costCents, threshold, timestamp, isCritical,
@@ -171,6 +172,28 @@ func (bs *BudgetStore) MonthlyReset(ctx context.Context, agent string) error {
 	budget.Paused = false
 
 	return bs.SetBudget(ctx, budget)
+}
+
+// ListAll returns all agent budgets stored in this namespace.
+func (bs *BudgetStore) ListAll(ctx context.Context) ([]AgentBudget, error) {
+	keys, err := bs.rdb.Keys(ctx, bs.namespace+":budget:*").Result()
+	if err != nil {
+		return nil, fmt.Errorf("list budget keys: %w", err)
+	}
+
+	budgets := make([]AgentBudget, 0, len(keys))
+	for _, k := range keys {
+		raw, err := bs.rdb.Get(ctx, k).Result()
+		if err != nil {
+			continue // key may have expired between Keys and Get
+		}
+		var b AgentBudget
+		if err := json.Unmarshal([]byte(raw), &b); err != nil {
+			continue
+		}
+		budgets = append(budgets, b)
+	}
+	return budgets, nil
 }
 
 // key returns a namespaced Redis key for agent budgets.

--- a/internal/budget/budget_test.go
+++ b/internal/budget/budget_test.go
@@ -255,3 +255,44 @@ func TestMonthlyReset(t *testing.T) {
 		t.Errorf("expected agent name preserved, got %s", got.Agent)
 	}
 }
+
+func TestListAll(t *testing.T) {
+	bs, ctx := budgetTestSetup(t)
+
+	agents := []AgentBudget{
+		{Agent: "list-agent-01", Driver: "claude-code", Box: "jared", BudgetMonthlyCents: 500, SpentMonthlyCents: 100, RunsThisMonth: 3},
+		{Agent: "list-agent-02", Driver: "codex", Box: "jared", BudgetMonthlyCents: 1000, SpentMonthlyCents: 200, RunsThisMonth: 7},
+		{Agent: "list-agent-03", Driver: "copilot", Box: "box2", BudgetMonthlyCents: 250, SpentMonthlyCents: 0, RunsThisMonth: 0},
+	}
+	for _, a := range agents {
+		if err := bs.SetBudget(ctx, a); err != nil {
+			t.Fatalf("set budget for %s: %v", a.Agent, err)
+		}
+	}
+
+	all, err := bs.ListAll(ctx)
+	if err != nil {
+		t.Fatalf("list all: %v", err)
+	}
+	if len(all) != 3 {
+		t.Fatalf("expected 3 budgets, got %d", len(all))
+	}
+
+	byAgent := make(map[string]AgentBudget, len(all))
+	for _, b := range all {
+		byAgent[b.Agent] = b
+	}
+	for _, want := range agents {
+		got, ok := byAgent[want.Agent]
+		if !ok {
+			t.Errorf("agent %s not found in ListAll result", want.Agent)
+			continue
+		}
+		if got.BudgetMonthlyCents != want.BudgetMonthlyCents {
+			t.Errorf("%s: expected budget=%d, got %d", want.Agent, want.BudgetMonthlyCents, got.BudgetMonthlyCents)
+		}
+		if got.SpentMonthlyCents != want.SpentMonthlyCents {
+			t.Errorf("%s: expected spent=%d, got %d", want.Agent, want.SpentMonthlyCents, got.SpentMonthlyCents)
+		}
+	}
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -599,6 +599,88 @@ func (s *Server) handleToolCall(req Request) Response {
 		return textResult(req.ID, string(data))
 
 
+	case "budget_status":
+		if s.budgetStore == nil {
+			return errorResp(req.ID, -32000, "budget store not initialized")
+		}
+		var args struct {
+			Agent string `json:"agent"`
+		}
+		json.Unmarshal(params.Arguments, &args)
+		if args.Agent != "" {
+			b, err := s.budgetStore.GetBudget(ctx, args.Agent)
+			if err != nil {
+				return errorResp(req.ID, -32000, err.Error())
+			}
+			data, _ := json.Marshal(b)
+			return textResult(req.ID, string(data))
+		}
+		all, err := s.budgetStore.ListAll(ctx)
+		if err != nil {
+			return errorResp(req.ID, -32000, err.Error())
+		}
+		data, _ := json.Marshal(all)
+		return textResult(req.ID, string(data))
+
+	case "budget_set":
+		if s.budgetStore == nil {
+			return errorResp(req.ID, -32000, "budget store not initialized")
+		}
+		var args struct {
+			Agent              string `json:"agent"`
+			Driver             string `json:"driver"`
+			Box                string `json:"box"`
+			BudgetMonthlyCents int    `json:"budget_monthly_cents"`
+		}
+		if err := json.Unmarshal(params.Arguments, &args); err != nil {
+			return errorResp(req.ID, -32602, "invalid arguments: "+err.Error())
+		}
+		if args.Agent == "" {
+			return errorResp(req.ID, -32602, "agent is required")
+		}
+		if args.BudgetMonthlyCents <= 0 {
+			return errorResp(req.ID, -32602, "budget_monthly_cents must be positive")
+		}
+		// Merge into existing record to preserve spent/runs, or create fresh.
+		existing, err := s.budgetStore.GetBudget(ctx, args.Agent)
+		if err != nil {
+			// Key missing — start fresh.
+			existing = budget.AgentBudget{Agent: args.Agent}
+		}
+		existing.BudgetMonthlyCents = args.BudgetMonthlyCents
+		if args.Driver != "" {
+			existing.Driver = args.Driver
+		}
+		if args.Box != "" {
+			existing.Box = args.Box
+		}
+		if err := s.budgetStore.SetBudget(ctx, existing); err != nil {
+			return errorResp(req.ID, -32000, err.Error())
+		}
+		data, _ := json.Marshal(existing)
+		return textResult(req.ID, string(data))
+
+	case "budget_reset":
+		if s.budgetStore == nil {
+			return errorResp(req.ID, -32000, "budget store not initialized")
+		}
+		var args struct {
+			Agent string `json:"agent"`
+		}
+		json.Unmarshal(params.Arguments, &args)
+		if args.Agent == "" {
+			return errorResp(req.ID, -32602, "agent is required")
+		}
+		if err := s.budgetStore.MonthlyReset(ctx, args.Agent); err != nil {
+			return errorResp(req.ID, -32000, err.Error())
+		}
+		b, err := s.budgetStore.GetBudget(ctx, args.Agent)
+		if err != nil {
+			return errorResp(req.ID, -32000, err.Error())
+		}
+		data, _ := json.Marshal(b)
+		return textResult(req.ID, string(data))
+
 	case "org_chart":
 		if s.orgStore == nil {
 			return errorResp(req.ID, -32000, "org store not initialized")
@@ -825,6 +907,7 @@ func toolDefs() []ToolDef {
 				"properties": map[string]interface{}{
 					"agent":    map[string]string{"type": "string", "description": "Agent name to trigger"},
 					"priority": map[string]interface{}{"type": "number", "description": "Priority (0=critical, 1=high, 2=normal, 3=background). Default: 1"},
+					"budget":   map[string]interface{}{"type": "string", "enum": []string{"low", "medium", "high"}, "description": "Budget tier override — low (local only), medium (local+subscription+cli), high (all). Omit for dynamic routing."},
 				},
 				"required": []string{"agent"},
 			},
@@ -963,6 +1046,42 @@ func toolDefs() []ToolDef {
 					"all":   map[string]interface{}{"type": "boolean", "description": "Set true to return all squads' standups for today."},
 				},
 				"required": []string{},
+			},
+		},
+		{
+			Name:        "budget_status",
+			Description: "View agent budget(s). Pass an agent name for a single record, or omit to list all agents with budgets. Returns spent, remaining, run count, and paused status.",
+			InputSchema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"agent": map[string]string{"type": "string", "description": "Agent name (e.g. 'sr-kernel-01'). Omit to list all."},
+				},
+				"required": []string{},
+			},
+		},
+		{
+			Name:        "budget_set",
+			Description: "Provision or update an agent's monthly budget. Merges into the existing record — spent and run counts are preserved. Use this to onboard a new agent or change their spending limit.",
+			InputSchema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"agent":                map[string]string{"type": "string", "description": "Agent name"},
+					"budget_monthly_cents": map[string]interface{}{"type": "number", "description": "Monthly budget in cents (e.g. 770 = $7.70)"},
+					"driver":               map[string]string{"type": "string", "description": "Driver type (e.g. 'claude-code', 'codex')"},
+					"box":                  map[string]string{"type": "string", "description": "Hostname/box the agent runs on"},
+				},
+				"required": []string{"agent", "budget_monthly_cents"},
+			},
+		},
+		{
+			Name:        "budget_reset",
+			Description: "Monthly reset for an agent: zeros spent, zeros run count, clears paused flag. Call at the start of each billing cycle.",
+			InputSchema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"agent": map[string]string{"type": "string", "description": "Agent name to reset"},
+				},
+				"required": []string{"agent"},
 			},
 		},
 	}


### PR DESCRIPTION
## Summary

- **Timestamp fix**: `CheckAndIncrement` was hardcoding `last_run_at = "2026-03-30T00:00:00Z"` — now uses `time.Now().UTC().Format(time.RFC3339)`
- **`budget_status`** MCP tool: view one agent's budget record or list all agents
- **`budget_set`** MCP tool: provision/update monthly budget ceiling (merges into existing record, preserving `spent_monthly_cents` and `runs_this_month`)
- **`budget_reset`** MCP tool: monthly cycle reset — zeros spent, zeros runs, clears `paused`
- **`dispatch_trigger` schema fix**: `budget` field was accepted by the handler but missing from the toolDef; now exposed so agents know to use it
- **`ListAll`** added to `BudgetStore`: scans namespace for all budget keys — used by `budget_status` with no agent arg
- **`TestListAll`**: verifies multi-agent scan returns correct records

## Root cause fixed

Agents were silently skipped with `"budget exhausted or below priority threshold"` even on first run because `CheckAndIncrement` returns `denied` when no budget key exists. With `budget_set` now available via MCP, agents can be provisioned before their first dispatch tick.

## Test plan

- [ ] `go build ./...` passes (verified)
- [ ] `go vet ./...` passes (verified)
- [ ] `TestListAll` passes when Redis is available (`OCTI_REDIS_URL=redis://localhost:6379 go test ./internal/budget/...`)
- [ ] Existing budget tests still pass
- [ ] `budget_status` returns empty list when no budgets provisioned
- [ ] `budget_set` creates record; second call with same agent merges (preserves spent)
- [ ] `budget_reset` zeros spent/runs, clears paused, preserves budget ceiling

Closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)