### PR TITLE
feat: budget MCP tools — budget_status, budget_set, budget_reset + timestamp fix

### DIFF
--- a/internal/budget/budget.go
+++ b/internal/budget/budget.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
+	"time"
 
 	"github.com/redis/go-redis/v9"
 )
@@ -147,7 +149,7 @@ func (bs *BudgetStore) CheckAndIncrement(ctx context.Context, agent string, cost
 		isCritical = 1
 	}
 
-	timestamp := "2026-03-30T00:00:00Z" // default; in production use time.Now()
+	timestamp := time.Now().UTC().Format(time.RFC3339)
 	result, err := checkAndIncrementScript.Run(ctx, bs.rdb,
 		[]string{bs.key(agent)},
 		costCents, threshold, timestamp, isCritical,
@@ -171,6 +173,37 @@ func (bs *BudgetStore) MonthlyReset(ctx context.Context, agent string) error {
 	budget.Paused = false
 
 	return bs.SetBudget(ctx, budget)
+}
+
+// ListBudgets returns all agent budgets stored in Redis under this namespace.
+func (bs *BudgetStore) ListBudgets(ctx context.Context) ([]AgentBudget, error) {
+	pattern := bs.namespace + ":budget:*"
+	var keys []string
+	var cursor uint64
+	for {
+		var batch []string
+		var err error
+		batch, cursor, err = bs.rdb.Scan(ctx, cursor, pattern, 100).Result()
+		if err != nil {
+			return nil, fmt.Errorf("scan budget keys: %w", err)
+		}
+		keys = append(keys, batch...)
+		if cursor == 0 {
+			break
+		}
+	}
+
+	budgets := make([]AgentBudget, 0, len(keys))
+	prefix := bs.namespace + ":budget:"
+	for _, k := range keys {
+		agent := strings.TrimPrefix(k, prefix)
+		b, err := bs.GetBudget(ctx, agent)
+		if err != nil {
+			continue
+		}
+		budgets = append(budgets, b)
+	}
+	return budgets, nil
 }
 
 // key returns a namespaced Redis key for agent budgets.

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -628,6 +628,86 @@ func (s *Server) handleToolCall(req Request) Response {
 		}
 		return textResult(req.ID, tree)
 
+	case "budget_status":
+		if s.budgetStore == nil {
+			return errorResp(req.ID, -32000, "budget store not initialized")
+		}
+		var args struct {
+			Agent string `json:"agent"`
+		}
+		json.Unmarshal(params.Arguments, &args)
+		if args.Agent != "" {
+			b, err := s.budgetStore.GetBudget(ctx, args.Agent)
+			if err != nil {
+				return errorResp(req.ID, -32000, err.Error())
+			}
+			data, _ := json.Marshal(b)
+			return textResult(req.ID, string(data))
+		}
+		budgets, err := s.budgetStore.ListBudgets(ctx)
+		if err != nil {
+			return errorResp(req.ID, -32000, err.Error())
+		}
+		if len(budgets) == 0 {
+			return textResult(req.ID, "No agent budgets found.")
+		}
+		data, _ := json.Marshal(budgets)
+		return textResult(req.ID, string(data))
+
+	case "budget_set":
+		if s.budgetStore == nil {
+			return errorResp(req.ID, -32000, "budget store not initialized")
+		}
+		var args struct {
+			Agent              string `json:"agent"`
+			Driver             string `json:"driver"`
+			Box                string `json:"box"`
+			BudgetMonthlyCents int    `json:"budget_monthly_cents"`
+			Paused             bool   `json:"paused"`
+		}
+		if err := json.Unmarshal(params.Arguments, &args); err != nil {
+			return errorResp(req.ID, -32602, "invalid arguments")
+		}
+		if args.Agent == "" {
+			return errorResp(req.ID, -32602, "agent is required")
+		}
+		if args.BudgetMonthlyCents <= 0 {
+			return errorResp(req.ID, -32602, "budget_monthly_cents must be positive")
+		}
+		b := budget.AgentBudget{
+			Agent:              args.Agent,
+			Driver:             args.Driver,
+			Box:                args.Box,
+			BudgetMonthlyCents: args.BudgetMonthlyCents,
+			Paused:             args.Paused,
+		}
+		// Preserve existing spent/runs if the budget already exists.
+		if existing, err := s.budgetStore.GetBudget(ctx, args.Agent); err == nil {
+			b.SpentMonthlyCents = existing.SpentMonthlyCents
+			b.RunsThisMonth = existing.RunsThisMonth
+			b.LastRunAt = existing.LastRunAt
+		}
+		if err := s.budgetStore.SetBudget(ctx, b); err != nil {
+			return errorResp(req.ID, -32000, err.Error())
+		}
+		return textResult(req.ID, fmt.Sprintf("Budget set for %s: %d cents/month", args.Agent, args.BudgetMonthlyCents))
+
+	case "budget_reset":
+		if s.budgetStore == nil {
+			return errorResp(req.ID, -32000, "budget store not initialized")
+		}
+		var args struct {
+			Agent string `json:"agent"`
+		}
+		json.Unmarshal(params.Arguments, &args)
+		if args.Agent == "" {
+			return errorResp(req.ID, -32602, "agent is required")
+		}
+		if err := s.budgetStore.MonthlyReset(ctx, args.Agent); err != nil {
+			return errorResp(req.ID, -32000, err.Error())
+		}
+		return textResult(req.ID, fmt.Sprintf("Budget reset for %s: spent and runs zeroed, unpaused.", args.Agent))
+
 	default:
 		return errorResp(req.ID, -32601, fmt.Sprintf("unknown tool: %s", params.Name))
 	}
@@ -963,6 +1043,42 @@ func toolDefs() []ToolDef {
 					"all":   map[string]interface{}{"type": "boolean", "description": "Set true to return all squads' standups for today."},
 				},
 				"required": []string{},
+			},
+		},
+		{
+			Name:        "budget_status",
+			Description: "Show per-agent monthly budget: limit, spent, runs, paused state, and last run timestamp. Pass agent name to get a single agent; omit to list all.",
+			InputSchema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"agent": map[string]string{"type": "string", "description": "Agent name (e.g. 'sr-kernel-01'). Omit to list all agents."},
+				},
+			},
+		},
+		{
+			Name:        "budget_set",
+			Description: "Create or update an agent's monthly budget. Preserves existing spent/runs when updating.",
+			InputSchema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"agent":                map[string]string{"type": "string", "description": "Agent name (e.g. 'sr-kernel-01')"},
+					"budget_monthly_cents": map[string]interface{}{"type": "number", "description": "Monthly budget in cents (e.g. 770 = $7.70)"},
+					"driver":               map[string]string{"type": "string", "description": "Driver name (e.g. 'claude-code', 'codex')"},
+					"box":                  map[string]string{"type": "string", "description": "Box/host name (e.g. 'jared')"},
+					"paused":               map[string]interface{}{"type": "boolean", "description": "Pause this agent (blocks all non-CRITICAL runs)"},
+				},
+				"required": []string{"agent", "budget_monthly_cents"},
+			},
+		},
+		{
+			Name:        "budget_reset",
+			Description: "Reset an agent's monthly budget counters: zeroes spent and run count, clears paused flag. Use at the start of each billing cycle.",
+			InputSchema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"agent": map[string]string{"type": "string", "description": "Agent name to reset (e.g. 'sr-kernel-01')"},
+				},
+				"required": []string{"agent"},
 			},
 		},
 	}


### PR DESCRIPTION
Closes #79

## Summary
- **`budget_status`** — list all agent budgets or get a single agent by name; returns limit, spent, runs, paused flag, and last-run timestamp
- **`budget_set`** — create or update an agent's monthly budget; preserves existing `spent_monthly_cents` / `runs_this_month` on update so a limit change doesn't accidentally wipe accounting history
- **`budget_reset`** — zero spent + run count and clear `paused` for monthly billing-cycle rollover
- **`BudgetStore.ListBudgets`** — Redis `SCAN`-based enumeration backing `budget_status`
- **Timestamp fix** — `CheckAndIncrement` was writing the hardcoded string `"2026-03-30T00:00:00Z"` as `last_run_at`; replaced with `time.Now().UTC().Format(time.RFC3339)`

## Test plan
- [ ] `go build ./...` and `go vet ./...` pass (verified locally)
- [ ] `budget_status` returns all budgets when no agent arg is passed
- [ ] `budget_set` creates a new budget; calling again updates limit without resetting spent
- [ ] `budget_reset` zeroes spent/runs and clears paused
- [ ] `last_run_at` on CheckAndIncrement now reflects actual run time

🤖 Generated with [Claude Code](https://claude.com/claude-code)