### PR TITLE
feat: budget MCP tools — budget_status, budget_set, budget_reset + timestamp fix

### DIFF
--- a/internal/budget/budget.go
+++ b/internal/budget/budget.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"time"
 
 	"github.com/redis/go-redis/v9"
 )
@@ -147,7 +148,7 @@ func (bs *BudgetStore) CheckAndIncrement(ctx context.Context, agent string, cost
 		isCritical = 1
 	}
 
-	timestamp := "2026-03-30T00:00:00Z" // default; in production use time.Now()
+	timestamp := time.Now().UTC().Format(time.RFC3339)
 	result, err := checkAndIncrementScript.Run(ctx, bs.rdb,
 		[]string{bs.key(agent)},
 		costCents, threshold, timestamp, isCritical,
@@ -171,6 +172,37 @@ func (bs *BudgetStore) MonthlyReset(ctx context.Context, agent string) error {
 	budget.Paused = false
 
 	return bs.SetBudget(ctx, budget)
+}
+
+// ListAll returns all agent budgets stored in this namespace.
+// Uses SCAN to avoid blocking the Redis server on large keyspaces.
+func (bs *BudgetStore) ListAll(ctx context.Context) ([]AgentBudget, error) {
+	pattern := bs.namespace + ":budget:*"
+	var budgets []AgentBudget
+
+	var cursor uint64
+	for {
+		keys, next, err := bs.rdb.Scan(ctx, cursor, pattern, 100).Result()
+		if err != nil {
+			return nil, fmt.Errorf("scan budget keys: %w", err)
+		}
+		for _, k := range keys {
+			raw, err := bs.rdb.Get(ctx, k).Result()
+			if err != nil {
+				continue // key may have expired between SCAN and GET
+			}
+			var b AgentBudget
+			if err := json.Unmarshal([]byte(raw), &b); err != nil {
+				continue
+			}
+			budgets = append(budgets, b)
+		}
+		cursor = next
+		if cursor == 0 {
+			break
+		}
+	}
+	return budgets, nil
 }
 
 // key returns a namespaced Redis key for agent budgets.

--- a/internal/budget/budget_test.go
+++ b/internal/budget/budget_test.go
@@ -212,6 +212,39 @@ func TestCheckAndIncrement_PriorityThresholds(t *testing.T) {
 	}
 }
 
+func TestListAll(t *testing.T) {
+	bs, ctx := budgetTestSetup(t)
+
+	agents := []AgentBudget{
+		{Agent: "list-agent-01", Driver: "claude-code", Box: "jared", BudgetMonthlyCents: 500},
+		{Agent: "list-agent-02", Driver: "copilot", Box: "readybench", BudgetMonthlyCents: 300},
+		{Agent: "list-agent-03", Driver: "codex", Box: "jared", BudgetMonthlyCents: 200},
+	}
+	for _, b := range agents {
+		if err := bs.SetBudget(ctx, b); err != nil {
+			t.Fatalf("set budget %s: %v", b.Agent, err)
+		}
+	}
+
+	all, err := bs.ListAll(ctx)
+	if err != nil {
+		t.Fatalf("list all: %v", err)
+	}
+	if len(all) != 3 {
+		t.Errorf("expected 3 budgets, got %d", len(all))
+	}
+
+	found := make(map[string]bool)
+	for _, b := range all {
+		found[b.Agent] = true
+	}
+	for _, b := range agents {
+		if !found[b.Agent] {
+			t.Errorf("missing agent %s in ListAll result", b.Agent)
+		}
+	}
+}
+
 func TestMonthlyReset(t *testing.T) {
 	bs, ctx := budgetTestSetup(t)
 

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -358,6 +358,71 @@ func (s *Server) handleToolCall(req Request) Response {
 		data, _ := json.Marshal(result)
 		return textResult(req.ID, string(data))
 
+	case "budget_status":
+		if s.budgetStore == nil {
+			return errorResp(req.ID, -32000, "budget store not initialized")
+		}
+		var args struct {
+			Agent string `json:"agent"`
+		}
+		json.Unmarshal(params.Arguments, &args)
+		if args.Agent != "" {
+			b, err := s.budgetStore.GetBudget(ctx, args.Agent)
+			if err != nil {
+				return errorResp(req.ID, -32000, err.Error())
+			}
+			data, _ := json.Marshal(b)
+			return textResult(req.ID, string(data))
+		}
+		all, err := s.budgetStore.ListAll(ctx)
+		if err != nil {
+			return errorResp(req.ID, -32000, err.Error())
+		}
+		data, _ := json.Marshal(all)
+		return textResult(req.ID, string(data))
+
+	case "budget_set":
+		if s.budgetStore == nil {
+			return errorResp(req.ID, -32000, "budget store not initialized")
+		}
+		var args struct {
+			Agent              string `json:"agent"`
+			Driver             string `json:"driver"`
+			Box                string `json:"box"`
+			BudgetMonthlyCents int    `json:"budget_monthly_cents"`
+		}
+		if err := json.Unmarshal(params.Arguments, &args); err != nil || args.Agent == "" {
+			return errorResp(req.ID, -32602, "agent and budget_monthly_cents are required")
+		}
+		// Merge into existing record to preserve spent/runs.
+		existing, err := s.budgetStore.GetBudget(ctx, args.Agent)
+		if err != nil {
+			// New agent — start fresh.
+			existing = budget.AgentBudget{Agent: args.Agent}
+		}
+		existing.Driver = args.Driver
+		existing.Box = args.Box
+		existing.BudgetMonthlyCents = args.BudgetMonthlyCents
+		if err := s.budgetStore.SetBudget(ctx, existing); err != nil {
+			return errorResp(req.ID, -32000, err.Error())
+		}
+		return textResult(req.ID, fmt.Sprintf("budget set for %s: %d cents/month", args.Agent, args.BudgetMonthlyCents))
+
+	case "budget_reset":
+		if s.budgetStore == nil {
+			return errorResp(req.ID, -32000, "budget store not initialized")
+		}
+		var args struct {
+			Agent string `json:"agent"`
+		}
+		if err := json.Unmarshal(params.Arguments, &args); err != nil || args.Agent == "" {
+			return errorResp(req.ID, -32602, "agent is required")
+		}
+		if err := s.budgetStore.MonthlyReset(ctx, args.Agent); err != nil {
+			return errorResp(req.ID, -32000, err.Error())
+		}
+		return textResult(req.ID, fmt.Sprintf("budget reset for %s: spent=0, runs=0, paused=false", args.Agent))
+
 	case "sprint_status":
 		if s.sprintStore == nil {
 			return errorResp(req.ID, -32000, "sprint store not initialized")
@@ -825,6 +890,7 @@ func toolDefs() []ToolDef {
 				"properties": map[string]interface{}{
 					"agent":    map[string]string{"type": "string", "description": "Agent name to trigger"},
 					"priority": map[string]interface{}{"type": "number", "description": "Priority (0=critical, 1=high, 2=normal, 3=background). Default: 1"},
+					"budget":   map[string]interface{}{"type": "string", "enum": []string{"low", "medium", "high"}, "description": "Budget tier override — low (local only), medium (local+subscription+cli), high (all). Omit for dynamic routing."},
 				},
 				"required": []string{"agent"},
 			},
@@ -963,6 +1029,41 @@ func toolDefs() []ToolDef {
 					"all":   map[string]interface{}{"type": "boolean", "description": "Set true to return all squads' standups for today."},
 				},
 				"required": []string{},
+			},
+		},
+		{
+			Name:        "budget_status",
+			Description: "View budget state for one or all agents. Pass agent name for a specific agent, or omit to list all agents with their monthly budget, spent, runs, and paused state.",
+			InputSchema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"agent": map[string]string{"type": "string", "description": "Agent name to query (e.g. 'sr-kernel-01'). Omit to list all."},
+				},
+			},
+		},
+		{
+			Name:        "budget_set",
+			Description: "Provision or update an agent's monthly budget. Merges into the existing record — spent and runs are preserved. Use to onboard new agents or adjust limits.",
+			InputSchema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"agent":               map[string]string{"type": "string", "description": "Agent name (e.g. 'sr-kernel-01')"},
+					"budget_monthly_cents": map[string]interface{}{"type": "number", "description": "Monthly budget cap in cents (e.g. 770 = $7.70)"},
+					"driver":              map[string]string{"type": "string", "description": "Driver type (e.g. 'claude-code', 'copilot')"},
+					"box":                 map[string]string{"type": "string", "description": "Box identifier (e.g. 'jared', 'readybench')"},
+				},
+				"required": []string{"agent", "budget_monthly_cents"},
+			},
+		},
+		{
+			Name:        "budget_reset",
+			Description: "Monthly reset for an agent's budget — zeros spent and run count, clears the paused flag. Use at the start of each billing cycle.",
+			InputSchema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"agent": map[string]string{"type": "string", "description": "Agent name to reset (e.g. 'sr-kernel-01')"},
+				},
+				"required": []string{"agent"},
 			},
 		},
 	}


### PR DESCRIPTION
## Summary

Closes #79

- **Timestamp fix**: `CheckAndIncrement` was writing a hardcoded `"2026-03-30T00:00:00Z"` to `last_run_at` on every run. Now uses `time.Now().UTC().Format(time.RFC3339)` so observability data is accurate.
- **`ListAll`**: Added to `BudgetStore` — uses Redis `SCAN` (non-blocking) to enumerate all agent budgets in the namespace. Gracefully skips keys that expire between `SCAN` and `GET`.
- **`budget_status`** MCP tool: Query one agent by name or omit `agent` to list all budgets with spent/runs/paused state.
- **`budget_set`** MCP tool: Provision or update an agent's monthly budget. Merges into existing record so spent/runs are preserved — prevents the "denied before ever running" silent-skip bug.
- **`budget_reset`** MCP tool: Monthly reset — zeros spent, zeros runs, clears paused flag.
- **`dispatch_trigger` toolDef fix**: The handler already accepted a `budget` field but it wasn't in the schema. Agents can now see and use the budget tier override.
- **`TestListAll`**: Stores 3 agents, lists all, asserts correct count and all agents present.

## Test plan
- [ ] `go build ./...` passes ✅
- [ ] `go vet ./...` passes ✅
- [ ] `TestListAll` passes against live Redis
- [ ] `budget_status` (all) returns list of all budgets
- [ ] `budget_set` for a new agent creates a budget record with zero spent/runs
- [ ] `budget_set` for an existing agent preserves spent/runs
- [ ] `budget_reset` zeroes spent/runs and unpauses
- [ ] `dispatch_trigger` with `budget` field routes through `DispatchBudget`

🤖 Generated with [Claude Code](https://claude.com/claude-code)