### PR TITLE
fix(budget): allow dispatch when no record exists + timestamp + dispatch_trigger schema

### DIFF
--- a/internal/budget/budget.go
+++ b/internal/budget/budget.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"time"
 
 	"github.com/redis/go-redis/v9"
 )
@@ -52,10 +53,11 @@ func NewBudgetStore(rdb *redis.Client, namespace string) *BudgetStore {
 // ARGV[4] = is_critical (1 or 0)
 //
 // Returns 1 if allowed, 0 if denied.
+// If no budget record exists the agent is allowed — budget enforcement is opt-in.
 var checkAndIncrementScript = redis.NewScript(`
 local raw = redis.call('GET', KEYS[1])
 if not raw then
-  return 0
+  return 1
 end
 
 local data = cjson.decode(raw)
@@ -147,7 +149,7 @@ func (bs *BudgetStore) CheckAndIncrement(ctx context.Context, agent string, cost
 		isCritical = 1
 	}
 
-	timestamp := "2026-03-30T00:00:00Z" // default; in production use time.Now()
+	timestamp := time.Now().UTC().Format(time.RFC3339)
 	result, err := checkAndIncrementScript.Run(ctx, bs.rdb,
 		[]string{bs.key(agent)},
 		costCents, threshold, timestamp, isCritical,

--- a/internal/budget/budget_test.go
+++ b/internal/budget/budget_test.go
@@ -43,6 +43,19 @@ func budgetTestSetup(t *testing.T) (*BudgetStore, context.Context) {
 	return NewBudgetStore(rdb, ns), ctx
 }
 
+func TestCheckAndIncrement_NoBudgetRecord(t *testing.T) {
+	bs, ctx := budgetTestSetup(t)
+
+	// Agent with no budget record should be allowed — budget enforcement is opt-in.
+	allowed, err := bs.CheckAndIncrement(ctx, "unregistered-agent", 50, "NORMAL")
+	if err != nil {
+		t.Fatalf("check and increment: %v", err)
+	}
+	if !allowed {
+		t.Fatal("expected allowed=true when no budget record exists (opt-in enforcement)")
+	}
+}
+
 func TestCheckAndIncrement_Allowed(t *testing.T) {
 	bs, ctx := budgetTestSetup(t)
 

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -825,6 +825,7 @@ func toolDefs() []ToolDef {
 				"properties": map[string]interface{}{
 					"agent":    map[string]string{"type": "string", "description": "Agent name to trigger"},
 					"priority": map[string]interface{}{"type": "number", "description": "Priority (0=critical, 1=high, 2=normal, 3=background). Default: 1"},
+					"budget":   map[string]interface{}{"type": "string", "enum": []string{"low", "medium", "high"}, "description": "Budget tier override — low (local only), medium (local+subscription+cli), high (all). Omit to use dynamic routing."},
 				},
 				"required": []string{"agent"},
 			},


### PR DESCRIPTION
## Summary

- **Budget opt-in enforcement**: the Lua check-and-increment script was returning `0` (deny) when no budget key existed in Redis. Agents that had never had a budget provisioned were silently blocked with `"budget exhausted or below priority threshold"`. Changed to return `1` (allow) — budget enforcement is now opt-in. An agent runs freely until someone calls `budget_set` to cap it.
- **Timestamp fix**: `last_run_at` was always written as the hardcoded string `"2026-03-30T00:00:00Z"`. Now uses `time.Now().UTC().Format(time.RFC3339)`, so `secs_since_last_run` metrics in health reports are accurate.
- **`dispatch_trigger` schema**: the `budget` override parameter was accepted by the handler (`DispatchBudget`) but absent from the MCP `InputSchema`. Agents had no way to discover or use it. Added `budget` field with enum `["low","medium","high"]`.

## Why opt-in vs opt-out matters

The previous deny-by-default meant every new agent was broken until an operator manually provisioned a budget record. In practice this meant the swarm had a 0% dispatch rate for any agent not explicitly provisioned — a silent config tax. Opt-in means: ship agents, they work; add budget caps later when you want to constrain them.

## Files changed

| File | Change |
|------|--------|
| `internal/budget/budget.go` | Lua no-record branch: `return 0` → `return 1`; fix hardcoded timestamp |
| `internal/budget/budget_test.go` | Add `TestCheckAndIncrement_NoBudgetRecord` |
| `internal/mcp/server.go` | Add `budget` field to `dispatch_trigger` InputSchema |

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] 286 tests pass (`go test ./...`)
- [x] `TestCheckAndIncrement_NoBudgetRecord` — verifies allow when no record

Note: this is distinct from PRs #82–85 (which add `budget_status`/`budget_set`/`budget_reset` MCP tools). These changes are complementary and non-overlapping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)