### PR TITLE
feat(budget): budget_status / budget_set / budget_reset MCP tools

### DIFF
--- a/internal/budget/budget.go
+++ b/internal/budget/budget.go
@@ -3,6 +3,7 @@ package budget
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 
@@ -173,6 +174,56 @@ func (bs *BudgetStore) MonthlyReset(ctx context.Context, agent string) error {
 	budget.Paused = false
 
 	return bs.SetBudget(ctx, budget)
+}
+
+// ListAll returns all budget records stored in this namespace.
+func (bs *BudgetStore) ListAll(ctx context.Context) ([]AgentBudget, error) {
+	pattern := bs.namespace + ":budget:*"
+	keys, err := bs.rdb.Keys(ctx, pattern).Result()
+	if err != nil {
+		return nil, fmt.Errorf("list budget keys: %w", err)
+	}
+	budgets := make([]AgentBudget, 0, len(keys))
+	for _, k := range keys {
+		raw, err := bs.rdb.Get(ctx, k).Result()
+		if err != nil {
+			continue // key may have disappeared between KEYS and GET
+		}
+		var b AgentBudget
+		if json.Unmarshal([]byte(raw), &b) != nil {
+			continue
+		}
+		budgets = append(budgets, b)
+	}
+	return budgets, nil
+}
+
+// UpsertBudget updates an agent's budget configuration while preserving runtime
+// state (spent, runs, last_run_at, paused). Creates a new record if none exists.
+func (bs *BudgetStore) UpsertBudget(ctx context.Context, update AgentBudget) (AgentBudget, error) {
+	existing, err := bs.GetBudget(ctx, update.Agent)
+	if err != nil {
+		if !errors.Is(err, redis.Nil) {
+			return AgentBudget{}, fmt.Errorf("upsert budget for %s: %w", update.Agent, err)
+		}
+		// No existing record — create fresh.
+		if err2 := bs.SetBudget(ctx, update); err2 != nil {
+			return AgentBudget{}, err2
+		}
+		return update, nil
+	}
+	// Merge: overwrite config fields, preserve runtime state.
+	existing.BudgetMonthlyCents = update.BudgetMonthlyCents
+	if update.Driver != "" {
+		existing.Driver = update.Driver
+	}
+	if update.Box != "" {
+		existing.Box = update.Box
+	}
+	if err2 := bs.SetBudget(ctx, existing); err2 != nil {
+		return AgentBudget{}, err2
+	}
+	return existing, nil
 }
 
 // key returns a namespaced Redis key for agent budgets.

--- a/internal/budget/budget_test.go
+++ b/internal/budget/budget_test.go
@@ -225,6 +225,78 @@ func TestCheckAndIncrement_PriorityThresholds(t *testing.T) {
 	}
 }
 
+func TestListAll(t *testing.T) {
+	bs, ctx := budgetTestSetup(t)
+
+	agents := []AgentBudget{
+		{Agent: "list-agent-01", Driver: "claude-code", Box: "jared", BudgetMonthlyCents: 500},
+		{Agent: "list-agent-02", Driver: "codex", Box: "jared", BudgetMonthlyCents: 300},
+	}
+	for _, a := range agents {
+		if err := bs.SetBudget(ctx, a); err != nil {
+			t.Fatalf("set budget: %v", err)
+		}
+	}
+
+	all, err := bs.ListAll(ctx)
+	if err != nil {
+		t.Fatalf("list all: %v", err)
+	}
+	if len(all) != len(agents) {
+		t.Errorf("expected %d budget records, got %d", len(agents), len(all))
+	}
+	found := map[string]bool{}
+	for _, b := range all {
+		found[b.Agent] = true
+	}
+	for _, a := range agents {
+		if !found[a.Agent] {
+			t.Errorf("expected agent %s in results", a.Agent)
+		}
+	}
+}
+
+func TestUpsertBudget(t *testing.T) {
+	bs, ctx := budgetTestSetup(t)
+
+	// Create via upsert — no pre-existing record.
+	created, err := bs.UpsertBudget(ctx, AgentBudget{
+		Agent:              "upsert-agent-01",
+		Driver:             "claude-code",
+		Box:                "jared",
+		BudgetMonthlyCents: 500,
+	})
+	if err != nil {
+		t.Fatalf("upsert (create): %v", err)
+	}
+	if created.BudgetMonthlyCents != 500 {
+		t.Errorf("expected budget=500, got %d", created.BudgetMonthlyCents)
+	}
+
+	// Simulate spending.
+	if _, err := bs.CheckAndIncrement(ctx, "upsert-agent-01", 100, "NORMAL"); err != nil {
+		t.Fatalf("check and increment: %v", err)
+	}
+
+	// Update budget limit — spent and driver should be preserved.
+	updated, err := bs.UpsertBudget(ctx, AgentBudget{
+		Agent:              "upsert-agent-01",
+		BudgetMonthlyCents: 1000,
+	})
+	if err != nil {
+		t.Fatalf("upsert (update): %v", err)
+	}
+	if updated.BudgetMonthlyCents != 1000 {
+		t.Errorf("expected budget=1000, got %d", updated.BudgetMonthlyCents)
+	}
+	if updated.SpentMonthlyCents != 100 {
+		t.Errorf("expected spent preserved at 100, got %d", updated.SpentMonthlyCents)
+	}
+	if updated.Driver != "claude-code" {
+		t.Errorf("expected driver preserved as claude-code, got %s", updated.Driver)
+	}
+}
+
 func TestMonthlyReset(t *testing.T) {
 	bs, ctx := budgetTestSetup(t)
 

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -685,6 +685,75 @@ func (s *Server) handleToolCall(req Request) Response {
 		data, _ := json.Marshal(newState)
 		return textResult(req.ID, msg+"\n"+string(data))
 
+	case "budget_status":
+		if s.budgetStore == nil {
+			return errorResp(req.ID, -32000, "budget store not initialized")
+		}
+		var args struct {
+			Agent string `json:"agent"`
+		}
+		json.Unmarshal(params.Arguments, &args)
+		if args.Agent != "" {
+			b, err := s.budgetStore.GetBudget(ctx, args.Agent)
+			if err != nil {
+				return errorResp(req.ID, -32000, err.Error())
+			}
+			data, _ := json.Marshal(b)
+			return textResult(req.ID, string(data))
+		}
+		all, err := s.budgetStore.ListAll(ctx)
+		if err != nil {
+			return errorResp(req.ID, -32000, err.Error())
+		}
+		if len(all) == 0 {
+			return textResult(req.ID, "No budget records found.")
+		}
+		data, _ := json.Marshal(all)
+		return textResult(req.ID, string(data))
+
+	case "budget_set":
+		if s.budgetStore == nil {
+			return errorResp(req.ID, -32000, "budget store not initialized")
+		}
+		var args struct {
+			Agent              string `json:"agent"`
+			BudgetMonthlyCents int    `json:"budget_monthly_cents"`
+			Driver             string `json:"driver"`
+			Box                string `json:"box"`
+		}
+		json.Unmarshal(params.Arguments, &args)
+		if args.Agent == "" {
+			return errorResp(req.ID, -32602, "agent is required")
+		}
+		result, err := s.budgetStore.UpsertBudget(ctx, budget.AgentBudget{
+			Agent:              args.Agent,
+			Driver:             args.Driver,
+			Box:                args.Box,
+			BudgetMonthlyCents: args.BudgetMonthlyCents,
+		})
+		if err != nil {
+			return errorResp(req.ID, -32000, err.Error())
+		}
+		data, _ := json.Marshal(result)
+		return textResult(req.ID, fmt.Sprintf("Budget set for %s: $%.2f/month\n%s",
+			args.Agent, float64(result.BudgetMonthlyCents)/100.0, string(data)))
+
+	case "budget_reset":
+		if s.budgetStore == nil {
+			return errorResp(req.ID, -32000, "budget store not initialized")
+		}
+		var args struct {
+			Agent string `json:"agent"`
+		}
+		json.Unmarshal(params.Arguments, &args)
+		if args.Agent == "" {
+			return errorResp(req.ID, -32602, "agent is required")
+		}
+		if err := s.budgetStore.MonthlyReset(ctx, args.Agent); err != nil {
+			return errorResp(req.ID, -32000, err.Error())
+		}
+		return textResult(req.ID, fmt.Sprintf("Budget reset for %s: spent=0, runs=0, paused=false", args.Agent))
+
 	default:
 		return errorResp(req.ID, -32601, fmt.Sprintf("unknown tool: %s", params.Name))
 	}
@@ -1050,6 +1119,41 @@ func toolDefs() []ToolDef {
 					"note":   map[string]string{"type": "string", "description": "Optional reason for the manual reset (logged in the response for audit purposes)."},
 				},
 				"required": []string{"driver"},
+			},
+		},
+		{
+			Name:        "budget_status",
+			Description: "View budget for a specific agent or all agents. Shows monthly budget limit, amount spent, run count, and paused status.",
+			InputSchema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"agent": map[string]string{"type": "string", "description": "Agent name (e.g. sr-kernel-01). Omit to list all agents with budget records."},
+				},
+			},
+		},
+		{
+			Name:        "budget_set",
+			Description: "Provision or update an agent's monthly budget. Preserves existing spent/runs history when updating an existing record. Use to onboard a new agent or change their spending limit.",
+			InputSchema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"agent":                map[string]string{"type": "string", "description": "Agent name (e.g. sr-kernel-01)"},
+					"budget_monthly_cents": map[string]interface{}{"type": "number", "description": "Monthly budget limit in cents (e.g. 770 = $7.70)"},
+					"driver":               map[string]string{"type": "string", "description": "Driver name (e.g. claude-code). Optional when updating an existing record."},
+					"box":                  map[string]string{"type": "string", "description": "Box/host the agent runs on. Optional when updating an existing record."},
+				},
+				"required": []string{"agent", "budget_monthly_cents"},
+			},
+		},
+		{
+			Name:        "budget_reset",
+			Description: "Monthly reset for an agent: zeroes spent, zeroes run count, and clears the paused flag. Use at the start of each billing cycle or to manually unblock a paused agent.",
+			InputSchema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"agent": map[string]string{"type": "string", "description": "Agent name to reset (e.g. sr-kernel-01)"},
+				},
+				"required": []string{"agent"},
 			},
 		},
 	}


### PR DESCRIPTION
## Summary

- **`budget_status`** — view budget for one agent or all agents; returns `AgentBudget` JSON with monthly limit, spent, runs, and paused flag
- **`budget_set`** — provision or update an agent's monthly budget; preserves existing `spent_monthly_cents`, `runs_this_month`, `last_run_at`, and `paused` when updating
- **`budget_reset`** — monthly reset: zeroes spent, zeroes run count, clears paused flag; use at start of billing cycle or to unblock a paused agent

Underlying budget package additions:
- `ListAll(ctx)` — scans Redis for all `<ns>:budget:*` keys and returns the parsed records
- `UpsertBudget(ctx, update)` — merges config fields (limit, driver, box) onto an existing record, or creates fresh if none exists

## Test plan

- [ ] `go build ./...` passes
- [ ] `go vet ./...` passes
- [ ] `TestListAll` — verifies 2 records created, both returned by ListAll
- [ ] `TestUpsertBudget` — verifies create-on-missing, and that budget limit update preserves spent/driver

Closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)