### PR TITLE
feat(sprint): bidirectional GitHub write-back — close issue on complete, create issue on create

### DIFF
--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -393,15 +393,25 @@ func (s *Server) handleToolCall(req Request) Response {
 			return errorResp(req.ID, -32000, "sprint store not initialized")
 		}
 		var args struct {
-			Repo      string `json:"repo"`
-			IssueNum  int    `json:"issue_num"`
-			Title     string `json:"title"`
-			Priority  int    `json:"priority"`
-			DependsOn []int  `json:"depends_on"`
-			AssignTo  string `json:"assign_to"`
-			Squad     string `json:"squad"`
+			Repo                string `json:"repo"`
+			IssueNum            int    `json:"issue_num"`
+			Title               string `json:"title"`
+			Priority            int    `json:"priority"`
+			DependsOn           []int  `json:"depends_on"`
+			AssignTo            string `json:"assign_to"`
+			Squad               string `json:"squad"`
+			CreateGitHubIssue   bool   `json:"create_github_issue"`
+			Body                string `json:"body"`
+			Labels              string `json:"labels"`
 		}
 		json.Unmarshal(params.Arguments, &args)
+		if args.CreateGitHubIssue && args.Repo != "" && args.IssueNum == 0 {
+			num, err := sprint.CreateIssue(ctx, args.Repo, args.Title, args.Body, args.Labels)
+			if err != nil {
+				return errorResp(req.ID, -32000, fmt.Sprintf("create GitHub issue: %v", err))
+			}
+			args.IssueNum = num
+		}
 		item := sprint.SprintItem{
 			Repo:      args.Repo,
 			IssueNum:  args.IssueNum,
@@ -461,6 +471,7 @@ func (s *Server) handleToolCall(req Request) Response {
 		var args struct {
 			Repo     string `json:"repo"`
 			IssueNum int    `json:"issue_num"`
+			Summary  string `json:"summary"`
 		}
 		json.Unmarshal(params.Arguments, &args)
 		if args.IssueNum == 0 {
@@ -479,6 +490,13 @@ func (s *Server) handleToolCall(req Request) Response {
 						}
 						msg += fmt.Sprintf("; unblocked: %s", strings.Join(nums, ", "))
 					}
+					if args.Summary != "" {
+						if err := sprint.CloseIssue(ctx, repo, args.IssueNum, args.Summary); err != nil {
+							msg += fmt.Sprintf("; warning: could not close GitHub issue: %v", err)
+						} else {
+							msg += "; GitHub issue closed"
+						}
+					}
 					return textResult(req.ID, msg)
 				}
 			}
@@ -495,6 +513,13 @@ func (s *Server) handleToolCall(req Request) Response {
 				nums[i] = fmt.Sprintf("#%d", n)
 			}
 			msg += fmt.Sprintf("; unblocked: %s", strings.Join(nums, ", "))
+		}
+		if args.Summary != "" {
+			if err := sprint.CloseIssue(ctx, args.Repo, args.IssueNum, args.Summary); err != nil {
+				msg += fmt.Sprintf("; warning: could not close GitHub issue: %v", err)
+			} else {
+				msg += "; GitHub issue closed"
+			}
 		}
 		return textResult(req.ID, msg)
 
@@ -905,19 +930,22 @@ func toolDefs() []ToolDef {
 		},
 		{
 			Name:        "sprint_create",
-			Description: "Manually create or upsert a sprint item. Use when an agent identifies work during brainstorm/research that should flow into the sprint backlog, or to pre-load items with explicit priority and dependency chains before sprint_sync runs.",
+			Description: "Manually create or upsert a sprint item. Use when an agent identifies work during brainstorm/research that should flow into the sprint backlog, or to pre-load items with explicit priority and dependency chains before sprint_sync runs. Set create_github_issue=true to also open a real GitHub issue.",
 			InputSchema: map[string]interface{}{
 				"type": "object",
 				"properties": map[string]interface{}{
-					"repo":       map[string]string{"type": "string", "description": "Repo (e.g. AgentGuardHQ/octi-pulpo)"},
-					"issue_num":  map[string]interface{}{"type": "number", "description": "GitHub issue number. Use 0 if not backed by a GitHub issue."},
-					"title":      map[string]string{"type": "string", "description": "Sprint item title"},
-					"priority":   map[string]interface{}{"type": "number", "enum": []int{0, 1, 2}, "description": "Priority: 0=P0 critical, 1=P1 high, 2=P2 normal"},
-					"depends_on": map[string]interface{}{"type": "array", "items": map[string]string{"type": "number"}, "description": "Issue numbers that must complete before this item can be dispatched"},
-					"assign_to":  map[string]string{"type": "string", "description": "Agent name to assign (e.g. sr-kernel-01). Leave empty for auto-dispatch."},
-					"squad":      map[string]string{"type": "string", "description": "Squad name. Inferred from repo if omitted."},
+					"repo":                 map[string]string{"type": "string", "description": "Repo (e.g. AgentGuardHQ/octi-pulpo)"},
+					"issue_num":            map[string]interface{}{"type": "number", "description": "GitHub issue number. Use 0 (or omit) when create_github_issue=true to let the tool assign one."},
+					"title":                map[string]string{"type": "string", "description": "Sprint item title"},
+					"priority":             map[string]interface{}{"type": "number", "enum": []int{0, 1, 2}, "description": "Priority: 0=P0 critical, 1=P1 high, 2=P2 normal"},
+					"depends_on":           map[string]interface{}{"type": "array", "items": map[string]string{"type": "number"}, "description": "Issue numbers that must complete before this item can be dispatched"},
+					"assign_to":            map[string]string{"type": "string", "description": "Agent name to assign (e.g. sr-kernel-01). Leave empty for auto-dispatch."},
+					"squad":                map[string]string{"type": "string", "description": "Squad name. Inferred from repo if omitted."},
+					"create_github_issue":  map[string]interface{}{"type": "boolean", "description": "When true, creates a real GitHub issue in the repo and uses the returned number. Only effective when issue_num is 0."},
+					"body":                 map[string]string{"type": "string", "description": "Issue body / description. Used only when create_github_issue=true."},
+					"labels":               map[string]string{"type": "string", "description": "Comma-separated label names to apply. Used only when create_github_issue=true."},
 				},
-				"required": []string{"repo", "issue_num", "title"},
+				"required": []string{"repo", "title"},
 			},
 		},
 		{
@@ -935,12 +963,13 @@ func toolDefs() []ToolDef {
 		},
 		{
 			Name:        "sprint_complete",
-			Description: "Mark a sprint item as done. Unblocks any dependent items. Call after merging a PR or closing an issue outside of the normal sync cycle.",
+			Description: "Mark a sprint item as done and optionally close the GitHub issue with a comment. Unblocks any dependent items. Call after merging a PR or closing an issue outside of the normal sync cycle.",
 			InputSchema: map[string]interface{}{
 				"type": "object",
 				"properties": map[string]interface{}{
 					"issue_num": map[string]interface{}{"type": "number", "description": "GitHub issue number to mark done"},
 					"repo":      map[string]string{"type": "string", "description": "Repo (e.g. AgentGuardHQ/octi-pulpo). If omitted, all tracked repos are searched."},
+					"summary":   map[string]string{"type": "string", "description": "Optional run summary. When provided, closes the GitHub issue and posts this text as a comment. Leave empty to only update Redis without touching GitHub."},
 				},
 				"required": []string{"issue_num"},
 			},

--- a/internal/sprint/writeback.go
+++ b/internal/sprint/writeback.go
@@ -1,0 +1,57 @@
+package sprint
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+// CloseIssue closes a GitHub issue and posts an optional comment.
+// comment may be empty to close without a comment.
+func CloseIssue(ctx context.Context, repo string, issueNum int, comment string) error {
+	args := []string{"issue", "close", "-R", repo, strconv.Itoa(issueNum)}
+	if comment != "" {
+		args = append(args, "--comment", comment)
+	}
+	out, err := exec.CommandContext(ctx, "gh", args...).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("gh issue close %s#%d: %w — %s", repo, issueNum, err, strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+// CreateIssue creates a new GitHub issue and returns the issue number.
+// labels is a comma-separated list of label names (may be empty).
+func CreateIssue(ctx context.Context, repo, title, body, labels string) (int, error) {
+	args := []string{
+		"issue", "create",
+		"-R", repo,
+		"--title", title,
+	}
+	if body != "" {
+		args = append(args, "--body", body)
+	}
+	if labels != "" {
+		args = append(args, "--label", labels)
+	}
+	// gh issue create prints the URL of the new issue to stdout.
+	out, err := exec.CommandContext(ctx, "gh", args...).Output()
+	if err != nil {
+		return 0, fmt.Errorf("gh issue create in %s: %w", repo, err)
+	}
+
+	// Parse issue number from URL: https://github.com/owner/repo/issues/123
+	url := strings.TrimSpace(string(out))
+	parts := strings.Split(url, "/")
+	if len(parts) == 0 {
+		return 0, fmt.Errorf("unexpected gh output: %q", url)
+	}
+	numStr := parts[len(parts)-1]
+	num, err := strconv.Atoi(numStr)
+	if err != nil {
+		return 0, fmt.Errorf("parse issue number from %q: %w", url, err)
+	}
+	return num, nil
+}

--- a/internal/sprint/writeback_test.go
+++ b/internal/sprint/writeback_test.go
@@ -1,0 +1,36 @@
+package sprint
+
+import (
+	"context"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// ghAvailable returns true if the gh CLI is installed and authenticated.
+func ghAvailable() bool {
+	out, err := exec.Command("gh", "auth", "status").CombinedOutput()
+	return err == nil && strings.Contains(string(out), "Logged in")
+}
+
+func TestCloseIssue_RejectsInvalidRepo(t *testing.T) {
+	if !ghAvailable() {
+		t.Skip("gh not available or not authenticated")
+	}
+	ctx := context.Background()
+	err := CloseIssue(ctx, "not-a-real-repo/does-not-exist", 99999, "")
+	if err == nil {
+		t.Fatal("expected error for non-existent repo, got nil")
+	}
+}
+
+func TestCreateIssue_RejectsInvalidRepo(t *testing.T) {
+	if !ghAvailable() {
+		t.Skip("gh not available or not authenticated")
+	}
+	ctx := context.Background()
+	_, err := CreateIssue(ctx, "not-a-real-repo/does-not-exist", "test title", "", "")
+	if err == nil {
+		t.Fatal("expected error for non-existent repo, got nil")
+	}
+}


### PR DESCRIPTION
## Summary

- **`sprint_complete` write-back**: new optional `summary` param — when provided, calls `gh issue close -R <repo> <num> --comment <summary>` after marking the sprint item done in Redis. GitHub close failures are non-fatal (logged as warnings in the response).
- **`sprint_create` issue creation**: new optional `create_github_issue` + `body` + `labels` params — when `create_github_issue=true` and `issue_num=0`, creates a real GitHub issue first and uses the returned number for the sprint item.
- **New `internal/sprint/writeback.go`**: `CloseIssue` and `CreateIssue` functions using the same `gh` CLI pattern as the rest of the sprint package.
- **Updated tool schemas**: all new params documented with descriptions.

## Architecture

Both write-back operations shell out to `gh` (same pattern used throughout `store.go`). Failures are surfaced as warnings rather than errors on `sprint_complete` — the Redis state is always updated first.

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `TestCloseIssue_RejectsInvalidRepo` — errors on non-existent repo (skips if gh unavailable)
- [x] `TestCreateIssue_RejectsInvalidRepo` — errors on non-existent repo (skips if gh unavailable)

Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)