### PR TITLE
feat(slack): budget override command + confidence-gated PAUSE buttons (#72)

### DIFF
--- a/internal/budget/budget.go
+++ b/internal/budget/budget.go
@@ -226,6 +226,17 @@ func (bs *BudgetStore) UpsertBudget(ctx context.Context, update AgentBudget) (Ag
 	return existing, nil
 }
 
+// Unpause clears the paused flag for an agent without resetting spent amounts.
+// Use this for operator budget overrides when a paused agent should resume.
+func (bs *BudgetStore) Unpause(ctx context.Context, agent string) error {
+	budget, err := bs.GetBudget(ctx, agent)
+	if err != nil {
+		return err
+	}
+	budget.Paused = false
+	return bs.SetBudget(ctx, budget)
+}
+
 // key returns a namespaced Redis key for agent budgets.
 func (bs *BudgetStore) key(agent string) string {
 	return bs.namespace + ":budget:" + agent

--- a/internal/budget/budget_test.go
+++ b/internal/budget/budget_test.go
@@ -297,6 +297,43 @@ func TestUpsertBudget(t *testing.T) {
 	}
 }
 
+func TestUnpause(t *testing.T) {
+	bs, ctx := budgetTestSetup(t)
+
+	budget := AgentBudget{
+		Agent:              "sr-kernel-unpause",
+		Driver:             "claude-code",
+		Box:                "jared",
+		BudgetMonthlyCents: 500,
+		SpentMonthlyCents:  500,
+		RunsThisMonth:      20,
+		Paused:             true,
+	}
+	if err := bs.SetBudget(ctx, budget); err != nil {
+		t.Fatalf("set budget: %v", err)
+	}
+
+	if err := bs.Unpause(ctx, "sr-kernel-unpause"); err != nil {
+		t.Fatalf("unpause: %v", err)
+	}
+
+	got, err := bs.GetBudget(ctx, "sr-kernel-unpause")
+	if err != nil {
+		t.Fatalf("get budget: %v", err)
+	}
+
+	if got.Paused {
+		t.Error("expected paused=false after Unpause")
+	}
+	// Spent and runs should be preserved (not reset)
+	if got.SpentMonthlyCents != 500 {
+		t.Errorf("expected spent=500 preserved after Unpause, got %d", got.SpentMonthlyCents)
+	}
+	if got.RunsThisMonth != 20 {
+		t.Errorf("expected runs=20 preserved after Unpause, got %d", got.RunsThisMonth)
+	}
+}
+
 func TestMonthlyReset(t *testing.T) {
 	bs, ctx := budgetTestSetup(t)
 

--- a/internal/dispatch/slack.go
+++ b/internal/dispatch/slack.go
@@ -287,6 +287,27 @@ func (n *Notifier) PostStuckAgentAlert(ctx context.Context, agent string, consec
 	return n.post(ctx, map[string]interface{}{"text": text})
 }
 
+// PostBudgetPausedAlert sends an interactive Block Kit message when an agent is
+// auto-paused due to budget exhaustion. It includes [Override Budget] and [Dismiss]
+// action buttons so operators can unpause directly from Slack.
+func (n *Notifier) PostBudgetPausedAlert(ctx context.Context, agent string) error {
+	if !n.Enabled() {
+		return nil
+	}
+	msg := fmt.Sprintf(
+		"💸 *Budget Exhausted: `%s`*\nMonthly spend limit reached — agent is paused.\nApprove override to resume dispatching.",
+		agent,
+	)
+	blocks := []map[string]interface{}{
+		blockSection(msg),
+		blockActions(
+			slackButton("override_budget", agent, "Override Budget", "primary"),
+			slackButton("dismiss_budget_alert", agent, "Dismiss", ""),
+		),
+	}
+	return n.postBlocks(ctx, blocks)
+}
+
 // PostInactiveSquadAlert sends a Slack alert when a squad has had no dispatch activity
 // for more than 24 hours.
 func (n *Notifier) PostInactiveSquadAlert(ctx context.Context, squad string, idleHours int) error {

--- a/internal/dispatch/slack_actions_test.go
+++ b/internal/dispatch/slack_actions_test.go
@@ -129,6 +129,32 @@ func TestNotifier_PostSprintGoalAlert(t *testing.T) {
 	}
 }
 
+func TestNotifier_PostBudgetPausedAlert(t *testing.T) {
+	var received []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		received, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	ctx := context.Background()
+	n := NewNotifier(srv.URL)
+
+	if err := n.PostBudgetPausedAlert(ctx, "octi-pulpo-sr"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	raw := string(received)
+	for _, actionID := range []string{"override_budget", "dismiss_budget_alert"} {
+		if !strings.Contains(raw, actionID) {
+			t.Errorf("expected action_id %q in budget paused alert", actionID)
+		}
+	}
+	if !strings.Contains(raw, "octi-pulpo-sr") {
+		t.Error("expected agent name in budget paused alert")
+	}
+}
+
 func TestNotifier_BlockKit_NoopWhenDisabled(t *testing.T) {
 	ctx := context.Background()
 	n := NewNotifier("")
@@ -141,6 +167,9 @@ func TestNotifier_BlockKit_NoopWhenDisabled(t *testing.T) {
 	}
 	if err := n.PostSprintGoalAlert(ctx, "squad", "goal"); err != nil {
 		t.Fatalf("PostSprintGoalAlert: %v", err)
+	}
+	if err := n.PostBudgetPausedAlert(ctx, "some-agent"); err != nil {
+		t.Fatalf("PostBudgetPausedAlert: %v", err)
 	}
 }
 
@@ -352,5 +381,62 @@ func TestRouteSlackAction_Context(t *testing.T) {
 		if !strings.Contains(ack, "testuser") {
 			t.Errorf("routeSlackAction(%q) ack missing actor: %q", actionID, ack)
 		}
+	}
+}
+
+// TestRouteSlackAction_DismissBudgetAlert verifies dismiss is a no-op acknowledgement.
+func TestRouteSlackAction_DismissBudgetAlert(t *testing.T) {
+	d, ctx := testSetup(t)
+	ws := NewWebhookServer(d, "")
+
+	ack, err := ws.routeSlackAction(ctx, "dismiss_budget_alert", "octi-pulpo-sr", "jared")
+	if err != nil {
+		t.Fatalf("routeSlackAction(dismiss_budget_alert): %v", err)
+	}
+	if !strings.Contains(ack, "octi-pulpo-sr") {
+		t.Errorf("expected agent name in ack, got %q", ack)
+	}
+	if !strings.Contains(ack, "jared") {
+		t.Errorf("expected actor name in ack, got %q", ack)
+	}
+	if !strings.Contains(strings.ToLower(ack), "paused") {
+		t.Errorf("expected 'paused' in dismiss ack, got %q", ack)
+	}
+}
+
+// TestRouteSlackAction_OverrideBudget_NoBudgetStore verifies an error is returned
+// when the budget store is not configured.
+func TestRouteSlackAction_OverrideBudget_NoBudgetStore(t *testing.T) {
+	d, ctx := testSetup(t)
+	ws := NewWebhookServer(d, "")
+	// No budget store set
+
+	_, err := ws.routeSlackAction(ctx, "override_budget", "octi-pulpo-sr", "jared")
+	if err == nil {
+		t.Fatal("expected error when budget store is not configured")
+	}
+}
+
+// TestWebhookServer_SlackActions_DismissBudgetAlert verifies full HTTP round-trip.
+func TestWebhookServer_SlackActions_DismissBudgetAlert(t *testing.T) {
+	d, _ := testSetup(t)
+	ws := NewWebhookServer(d, "")
+
+	body := makeSlackPayload("dismiss_budget_alert", "octi-pulpo-sr", "jared")
+	req := httptest.NewRequest(http.MethodPost, "/slack/actions", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rr := httptest.NewRecorder()
+
+	ws.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+	var resp map[string]string
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatalf("invalid JSON response: %v", err)
+	}
+	if !strings.Contains(resp["text"], "octi-pulpo-sr") {
+		t.Errorf("expected agent name in response, got %q", resp["text"])
 	}
 }

--- a/internal/dispatch/slack_events.go
+++ b/internal/dispatch/slack_events.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/AgentGuardHQ/octi-pulpo/internal/budget"
 	"github.com/AgentGuardHQ/octi-pulpo/internal/sprint"
 )
 
@@ -62,6 +63,7 @@ type SlackEventHandler struct {
 	benchmark     *BenchmarkTracker
 	notifier      *Notifier
 	brain         *Brain
+	budgetStore   *budget.BudgetStore
 	log           *log.Logger
 	client        *http.Client
 }
@@ -90,6 +92,9 @@ func (h *SlackEventHandler) SetNotifier(n *Notifier) { h.notifier = n }
 
 // SetBrain enables constraint-aware replies.
 func (h *SlackEventHandler) SetBrain(b *Brain) { h.brain = b }
+
+// SetBudgetStore enables budget override commands.
+func (h *SlackEventHandler) SetBudgetStore(bs *budget.BudgetStore) { h.budgetStore = bs }
 
 // Handle processes a Slack Events API HTTP request.
 // It ACKs immediately and dispatches command handling in a goroutine
@@ -183,6 +188,8 @@ func (h *SlackEventHandler) parseCommand(text string) (cmd, args string) {
 		return "pause", strings.TrimSpace(strings.TrimPrefix(text, "pause "))
 	case strings.HasPrefix(text, "resume "):
 		return "resume", strings.TrimSpace(strings.TrimPrefix(text, "resume "))
+	case strings.HasPrefix(text, "budget override "):
+		return "budget_override", strings.TrimSpace(strings.TrimPrefix(text, "budget override "))
 	}
 	return "", ""
 }
@@ -201,6 +208,8 @@ func (h *SlackEventHandler) handleCommand(ctx context.Context, cmd, args, channe
 		blocks = h.buildPauseBlocks(ctx, args)
 	case "resume":
 		blocks = h.buildResumeBlocks(ctx, args)
+	case "budget_override":
+		blocks = h.buildBudgetOverrideBlocks(ctx, args)
 	case "help":
 		blocks = h.buildHelpBlocks()
 	default:
@@ -372,6 +381,21 @@ func (h *SlackEventHandler) buildResumeBlocks(ctx context.Context, squad string)
 	return slackTextBlocks(fmt.Sprintf(":arrow_forward: *%s squad resumed.* Directive broadcast.", squad))
 }
 
+// buildBudgetOverrideBlocks unpauses a budget-exhausted agent and returns a
+// Block Kit confirmation. The agent name comes from args.
+func (h *SlackEventHandler) buildBudgetOverrideBlocks(ctx context.Context, agent string) []interface{} {
+	if agent == "" {
+		return slackTextBlocks(":x: Usage: `budget override <agent>`")
+	}
+	if h.budgetStore == nil {
+		return slackTextBlocks(":x: Budget store not available")
+	}
+	if err := h.budgetStore.Unpause(ctx, agent); err != nil {
+		return slackTextBlocks(fmt.Sprintf(":x: Could not override budget for `%s`: %s", agent, err))
+	}
+	return slackTextBlocks(fmt.Sprintf(":white_check_mark: Budget override applied — `%s` is unpaused and will resume on next dispatch.", agent))
+}
+
 // buildHelpBlocks returns a Block Kit help card listing all supported commands.
 func (h *SlackEventHandler) buildHelpBlocks() []interface{} {
 	text := "*Octi Pulpo Bot Commands*\n\n" +
@@ -381,6 +405,7 @@ func (h *SlackEventHandler) buildHelpBlocks() []interface{} {
 		"`dispatch <agent> at #<issue>` — trigger with issue context\n" +
 		"`pause <squad>` — broadcast pause directive to squad agents\n" +
 		"`resume <squad>` — broadcast resume directive to squad agents\n" +
+		"`budget override <agent>` — unpause a budget-exhausted agent\n" +
 		"`help` — show this message"
 	return slackTextBlocks(text)
 }

--- a/internal/dispatch/slack_events_test.go
+++ b/internal/dispatch/slack_events_test.go
@@ -357,6 +357,62 @@ func (t *testURLRewriter) RoundTrip(req *http.Request) (*http.Response, error) {
 	return rt.RoundTrip(req2)
 }
 
+// TestParseCommand_BudgetOverride verifies budget override command parsing.
+func TestParseCommand_BudgetOverride(t *testing.T) {
+	h := newTestSlackHandler()
+
+	cases := []struct {
+		input    string
+		wantCmd  string
+		wantArgs string
+	}{
+		{"budget override octi-pulpo-sr", "budget_override", "octi-pulpo-sr"},
+		{"budget override kernel-sr-01", "budget_override", "kernel-sr-01"},
+		// budget without subcommand should not match
+		{"budget", "", ""},
+		// budget with unknown subcommand should not match
+		{"budget reset agent", "", ""},
+	}
+
+	for _, tc := range cases {
+		cmd, args := h.parseCommand(tc.input)
+		if cmd != tc.wantCmd || args != tc.wantArgs {
+			t.Errorf("parseCommand(%q) = (%q, %q), want (%q, %q)",
+				tc.input, cmd, args, tc.wantCmd, tc.wantArgs)
+		}
+	}
+}
+
+// TestBuildBudgetOverrideBlocks_NoAgent verifies usage error when agent is empty.
+func TestBuildBudgetOverrideBlocks_NoAgent(t *testing.T) {
+	h := newTestSlackHandler()
+	blocks := h.buildBudgetOverrideBlocks(context.Background(), "")
+	data, _ := json.Marshal(blocks)
+	if !strings.Contains(string(data), "Usage") {
+		t.Errorf("expected usage hint for empty agent, got %s", data)
+	}
+}
+
+// TestBuildBudgetOverrideBlocks_NoBudgetStore verifies error when store is nil.
+func TestBuildBudgetOverrideBlocks_NoBudgetStore(t *testing.T) {
+	h := newTestSlackHandler() // no budget store set
+	blocks := h.buildBudgetOverrideBlocks(context.Background(), "some-agent")
+	data, _ := json.Marshal(blocks)
+	if !strings.Contains(string(data), "not available") {
+		t.Errorf("expected 'not available' error for nil budget store, got %s", data)
+	}
+}
+
+// TestBuildHelpBlocks_IncludesBudgetOverride verifies the help text lists the new command.
+func TestBuildHelpBlocks_IncludesBudgetOverride(t *testing.T) {
+	h := newTestSlackHandler()
+	blocks := h.buildHelpBlocks()
+	data, _ := json.Marshal(blocks)
+	if !strings.Contains(string(data), "budget override") {
+		t.Errorf("help blocks should list 'budget override' command, got %s", data)
+	}
+}
+
 // TestWebhookServer_SetSlackEvents verifies the /slack/events route is registered.
 func TestWebhookServer_SetSlackEvents(t *testing.T) {
 	// Create a minimal dispatcher to satisfy constructor requirements.

--- a/internal/dispatch/webhook.go
+++ b/internal/dispatch/webhook.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/AgentGuardHQ/octi-pulpo/internal/budget"
 	"github.com/AgentGuardHQ/octi-pulpo/internal/sprint"
 )
 
@@ -30,6 +31,7 @@ type WebhookServer struct {
 	sprintStore        *sprint.Store
 	benchmark          *BenchmarkTracker
 	slackEvents        *SlackEventHandler
+	budgetStore        *budget.BudgetStore
 }
 
 // NewWebhookServer creates a webhook handler backed by the dispatcher.
@@ -338,6 +340,11 @@ func (ws *WebhookServer) SetSlackSigningSecret(secret []byte) {
 	ws.slackSigningSecret = secret
 }
 
+// SetBudgetStore enables budget override actions in /slack/actions.
+func (ws *WebhookServer) SetBudgetStore(bs *budget.BudgetStore) {
+	ws.budgetStore = bs
+}
+
 // handleSlackActions receives interactive action callbacks from Slack (Block Kit buttons).
 // Slack POSTs application/x-www-form-urlencoded with a "payload" field containing JSON.
 //
@@ -483,6 +490,20 @@ func (ws *WebhookServer) routeSlackAction(ctx context.Context, actionID, value, 
 			return "", fmt.Errorf("publish goal-rejected signal: %w", err)
 		}
 		return fmt.Sprintf("🔄 Changes requested for `%s` by @%s", value, actor), nil
+
+	case "override_budget":
+		// Unpause a budget-exhausted agent.
+		if ws.budgetStore == nil {
+			return "", fmt.Errorf("budget store not configured")
+		}
+		if err := ws.budgetStore.Unpause(ctx, value); err != nil {
+			return "", fmt.Errorf("unpause budget for %s: %w", value, err)
+		}
+		return fmt.Sprintf("✅ Budget override — `%s` unpaused by @%s", value, actor), nil
+
+	case "dismiss_budget_alert":
+		// Acknowledged — agent stays paused.
+		return fmt.Sprintf("👍 Budget alert dismissed by @%s — `%s` remains paused", actor, value), nil
 
 	case "ignore_alert", "review_pr", "skip_pr":
 		// Acknowledged — no further action needed.


### PR DESCRIPTION
## Summary

Completes the remaining inbound-command items from the Slack control plane feature (#72):

- **`budget override <agent>`** — new Slack message command that calls `BudgetStore.Unpause()` and replies with a confirmation; unlike `monthly_reset` this preserves spent amounts so observability data isn't wiped
- **`PostBudgetPausedAlert`** — Block Kit message with `[Override Budget]` and `[Dismiss]` buttons, to be fired when an agent auto-pauses on budget exhaustion (confidence-gated PAUSE approval flow)
- **`override_budget` / `dismiss_budget_alert` action routes** — webhook handler processes button clicks from the alert; override calls `BudgetStore.Unpause`; dismiss is a no-op ack keeping the agent paused
- **Help text updated** — `budget override <agent>` listed in bot command reference

## Architecture

Three-layer change matching the existing Slack control plane design:
1. `internal/budget` — `Unpause()` (read-modify-write, preserves runtime state)
2. `internal/dispatch/slack.go` — `PostBudgetPausedAlert()` (outbound Block Kit)
3. `internal/dispatch/slack_events.go` — command parsing + `buildBudgetOverrideBlocks()`
4. `internal/dispatch/webhook.go` — action routing for button callbacks

## Test plan

- [ ] `TestUnpause` — verifies paused=false, spent/runs preserved
- [ ] `TestNotifier_PostBudgetPausedAlert` — Block Kit payload contains both action IDs and agent name
- [ ] `TestParseCommand_BudgetOverride` — command parsed correctly; non-matching inputs return empty
- [ ] `TestBuildBudgetOverrideBlocks_NoAgent` — usage hint returned for empty agent
- [ ] `TestBuildBudgetOverrideBlocks_NoBudgetStore` — error returned when store is nil
- [ ] `TestBuildHelpBlocks_IncludesBudgetOverride` — help text lists the new command
- [ ] `TestRouteSlackAction_DismissBudgetAlert` — no-op ack with agent + actor in response
- [ ] `TestRouteSlackAction_OverrideBudget_NoBudgetStore` — error when store not configured
- [ ] `TestWebhookServer_SlackActions_DismissBudgetAlert` — full HTTP round-trip
- [ ] All 11 packages pass: `go test ./... -count=1 -timeout 60s`

Closes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)