### PR TITLE
feat(slack): budget override command + action button + exhaustion alert

### DIFF
--- a/cmd/octi-pulpo/main.go
+++ b/cmd/octi-pulpo/main.go
@@ -124,10 +124,12 @@ func main() {
 			evHandler := dispatch.NewSlackEventHandler(slackSecret, slackBotToken, dispatcher)
 			evHandler.SetSprintStore(sprintStore)
 			evHandler.SetBenchmark(benchmark)
+			evHandler.SetBudgetStore(budgetStore)
 			if slackURL := os.Getenv("SLACK_WEBHOOK_URL"); slackURL != "" {
 				evHandler.SetNotifier(dispatch.NewNotifier(slackURL))
 			}
 			ws.SetSlackEvents(evHandler)
+			ws.SetBudgetStore(budgetStore)
 			fmt.Fprintf(os.Stderr, "octi-pulpo: slack events handler registered on /slack/events\n")
 		}
 

--- a/internal/dispatch/slack.go
+++ b/internal/dispatch/slack.go
@@ -287,6 +287,36 @@ func (n *Notifier) PostStuckAgentAlert(ctx context.Context, agent string, consec
 	return n.post(ctx, map[string]interface{}{"text": text})
 }
 
+// PostBudgetExhaustedAlert sends an interactive Block Kit message when an agent's
+// monthly budget is exhausted and it has been auto-paused. The message includes
+// an [Override] button that the CTO can click to immediately reset the budget
+// and resume dispatch. The button posts back to /slack/actions with action_id
+// "budget_override" and value set to the agent name.
+func (n *Notifier) PostBudgetExhaustedAlert(ctx context.Context, agent string, spentCents, budgetCents int) error {
+	if !n.Enabled() {
+		return nil
+	}
+
+	pct := 0
+	if budgetCents > 0 {
+		pct = spentCents * 100 / budgetCents
+	}
+	msg := fmt.Sprintf(
+		"💸 *Budget Exhausted: `%s`*\nSpent: $%.2f of $%.2f (%d%%) — agent auto-paused.\nDispatch is blocked until budget is reset or overridden.",
+		agent, float64(spentCents)/100, float64(budgetCents)/100, pct,
+	)
+
+	blocks := []map[string]interface{}{
+		blockSection(msg),
+		blockActions(
+			slackButton("budget_override", agent, "Override", "primary"),
+			slackButton("ignore_alert", agent, "Ignore", ""),
+		),
+	}
+
+	return n.postBlocks(ctx, blocks)
+}
+
 // PostInactiveSquadAlert sends a Slack alert when a squad has had no dispatch activity
 // for more than 24 hours.
 func (n *Notifier) PostInactiveSquadAlert(ctx context.Context, squad string, idleHours int) error {

--- a/internal/dispatch/slack_actions_test.go
+++ b/internal/dispatch/slack_actions_test.go
@@ -13,7 +13,26 @@ import (
 	"net/url"
 	"strings"
 	"testing"
+
+	"github.com/AgentGuardHQ/octi-pulpo/internal/budget"
 )
+
+// newTestBudgetStore creates a BudgetStore sharing the dispatcher's Redis client and namespace.
+func newTestBudgetStore(t *testing.T, d *Dispatcher) *budget.BudgetStore {
+	t.Helper()
+	return budget.NewBudgetStore(d.RedisClient(), d.Namespace())
+}
+
+// testAgentBudget returns a minimal AgentBudget record for test setup.
+func testAgentBudget(agent string, paused bool) budget.AgentBudget {
+	return budget.AgentBudget{
+		Agent:              agent,
+		BudgetMonthlyCents: 1000,
+		SpentMonthlyCents:  950,
+		RunsThisMonth:      5,
+		Paused:             paused,
+	}
+}
 
 // --- Block Kit message tests ---
 
@@ -352,5 +371,94 @@ func TestRouteSlackAction_Context(t *testing.T) {
 		if !strings.Contains(ack, "testuser") {
 			t.Errorf("routeSlackAction(%q) ack missing actor: %q", actionID, ack)
 		}
+	}
+}
+
+// TestRouteSlackAction_BudgetOverride_NoBudgetStore verifies graceful noop when store missing.
+func TestRouteSlackAction_BudgetOverride_NoBudgetStore(t *testing.T) {
+	d, ctx := testSetup(t)
+	ws := NewWebhookServer(d, "")
+	// budgetStore intentionally not set
+
+	ack, err := ws.routeSlackAction(ctx, "budget_override", "octi-pulpo-sr", "cto")
+	if err != nil {
+		t.Fatalf("expected no error when budget store missing, got: %v", err)
+	}
+	if !strings.Contains(ack, "not configured") {
+		t.Errorf("expected 'not configured' message, got: %q", ack)
+	}
+}
+
+// TestRouteSlackAction_BudgetOverride_WithStore verifies a successful budget reset via action button.
+func TestRouteSlackAction_BudgetOverride_WithStore(t *testing.T) {
+	d, ctx := testSetup(t)
+	ws := NewWebhookServer(d, "")
+
+	// Wire a real budget store backed by the test Redis instance.
+	bs := newTestBudgetStore(t, d)
+	ws.SetBudgetStore(bs)
+
+	// Seed a paused budget record for the agent.
+	if err := bs.SetBudget(ctx, testAgentBudget("octi-pulpo-sr", true)); err != nil {
+		t.Fatalf("seed budget: %v", err)
+	}
+
+	ack, err := ws.routeSlackAction(ctx, "budget_override", "octi-pulpo-sr", "cto")
+	if err != nil {
+		t.Fatalf("routeSlackAction budget_override: %v", err)
+	}
+	if !strings.Contains(ack, "octi-pulpo-sr") {
+		t.Errorf("expected agent name in ack, got: %q", ack)
+	}
+	if !strings.Contains(ack, "cto") {
+		t.Errorf("expected actor in ack, got: %q", ack)
+	}
+
+	// Verify the budget is no longer paused.
+	b, err := bs.GetBudget(ctx, "octi-pulpo-sr")
+	if err != nil {
+		t.Fatalf("get budget after override: %v", err)
+	}
+	if b.Paused {
+		t.Error("expected agent to be unpaused after budget override")
+	}
+	if b.SpentMonthlyCents != 0 {
+		t.Errorf("expected spent=0 after reset, got %d", b.SpentMonthlyCents)
+	}
+}
+
+// TestNotifier_PostBudgetExhaustedAlert_ContainsButton verifies the alert has an Override button.
+func TestNotifier_PostBudgetExhaustedAlert_ContainsButton(t *testing.T) {
+	var received []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		received, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	ctx := context.Background()
+	n := NewNotifier(srv.URL)
+
+	if err := n.PostBudgetExhaustedAlert(ctx, "kernel-sr", 850, 1000); err != nil {
+		t.Fatalf("PostBudgetExhaustedAlert: %v", err)
+	}
+
+	raw := string(received)
+	if !strings.Contains(raw, "budget_override") {
+		t.Error("expected budget_override action_id in payload")
+	}
+	if !strings.Contains(raw, "kernel-sr") {
+		t.Error("expected agent name in payload")
+	}
+	if !strings.Contains(raw, "Override") {
+		t.Error("expected Override button text in payload")
+	}
+}
+
+// TestNotifier_PostBudgetExhaustedAlert_Noop verifies no-op when webhook not configured.
+func TestNotifier_PostBudgetExhaustedAlert_Noop(t *testing.T) {
+	n := NewNotifier("")
+	if err := n.PostBudgetExhaustedAlert(context.Background(), "agent", 100, 1000); err != nil {
+		t.Fatalf("expected no error for disabled notifier, got: %v", err)
 	}
 }

--- a/internal/dispatch/slack_events.go
+++ b/internal/dispatch/slack_events.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/AgentGuardHQ/octi-pulpo/internal/budget"
 	"github.com/AgentGuardHQ/octi-pulpo/internal/sprint"
 )
 
@@ -62,6 +63,7 @@ type SlackEventHandler struct {
 	benchmark     *BenchmarkTracker
 	notifier      *Notifier
 	brain         *Brain
+	budgetStore   *budget.BudgetStore
 	log           *log.Logger
 	client        *http.Client
 }
@@ -90,6 +92,9 @@ func (h *SlackEventHandler) SetNotifier(n *Notifier) { h.notifier = n }
 
 // SetBrain enables constraint-aware replies.
 func (h *SlackEventHandler) SetBrain(b *Brain) { h.brain = b }
+
+// SetBudgetStore enables budget override commands.
+func (h *SlackEventHandler) SetBudgetStore(bs *budget.BudgetStore) { h.budgetStore = bs }
 
 // Handle processes a Slack Events API HTTP request.
 // It ACKs immediately and dispatches command handling in a goroutine
@@ -183,6 +188,10 @@ func (h *SlackEventHandler) parseCommand(text string) (cmd, args string) {
 		return "pause", strings.TrimSpace(strings.TrimPrefix(text, "pause "))
 	case strings.HasPrefix(text, "resume "):
 		return "resume", strings.TrimSpace(strings.TrimPrefix(text, "resume "))
+	case strings.HasPrefix(text, "budget override "):
+		return "budget_override", strings.TrimSpace(strings.TrimPrefix(text, "budget override "))
+	case text == "budget":
+		return "budget_override", ""
 	}
 	return "", ""
 }
@@ -201,6 +210,8 @@ func (h *SlackEventHandler) handleCommand(ctx context.Context, cmd, args, channe
 		blocks = h.buildPauseBlocks(ctx, args)
 	case "resume":
 		blocks = h.buildResumeBlocks(ctx, args)
+	case "budget_override":
+		blocks = h.buildBudgetOverrideBlocks(ctx, args)
 	case "help":
 		blocks = h.buildHelpBlocks()
 	default:
@@ -372,6 +383,29 @@ func (h *SlackEventHandler) buildResumeBlocks(ctx context.Context, squad string)
 	return slackTextBlocks(fmt.Sprintf(":arrow_forward: *%s squad resumed.* Directive broadcast.", squad))
 }
 
+// buildBudgetOverrideBlocks resets a budget-exhausted agent's monthly spend counter
+// and clears its paused flag so dispatch resumes. Requires a budget store.
+func (h *SlackEventHandler) buildBudgetOverrideBlocks(ctx context.Context, agent string) []interface{} {
+	if agent == "" {
+		return slackTextBlocks(":x: Usage: `budget override <agent>`")
+	}
+	if h.budgetStore == nil {
+		return slackTextBlocks(":x: Budget store not configured — cannot override")
+	}
+	if err := h.budgetStore.MonthlyReset(ctx, agent); err != nil {
+		return slackTextBlocks(fmt.Sprintf(":x: Budget override failed for `%s`: %s", agent, err))
+	}
+	return []interface{}{
+		slackSection(fmt.Sprintf(":white_check_mark: *Budget override applied for `%s`.*\nSpend counter reset and pause cleared — dispatch will resume on next tick.", agent)),
+		map[string]interface{}{
+			"type": "actions",
+			"elements": []interface{}{
+				slackButton("view_status", "view_status", "View Status", "primary"),
+			},
+		},
+	}
+}
+
 // buildHelpBlocks returns a Block Kit help card listing all supported commands.
 func (h *SlackEventHandler) buildHelpBlocks() []interface{} {
 	text := "*Octi Pulpo Bot Commands*\n\n" +
@@ -381,6 +415,7 @@ func (h *SlackEventHandler) buildHelpBlocks() []interface{} {
 		"`dispatch <agent> at #<issue>` — trigger with issue context\n" +
 		"`pause <squad>` — broadcast pause directive to squad agents\n" +
 		"`resume <squad>` — broadcast resume directive to squad agents\n" +
+		"`budget override <agent>` — unpause a budget-exhausted agent\n" +
 		"`help` — show this message"
 	return slackTextBlocks(text)
 }

--- a/internal/dispatch/slack_events_test.go
+++ b/internal/dispatch/slack_events_test.go
@@ -117,6 +117,9 @@ func TestParseCommand(t *testing.T) {
 		{"pause cloud squad", "pause", "cloud squad"},
 		{"resume kernel", "resume", "kernel"},
 		{"resume kernel squad", "resume", "kernel squad"},
+		{"budget override octi-pulpo-sr", "budget_override", "octi-pulpo-sr"},
+		{"budget override kernel-sr", "budget_override", "kernel-sr"},
+		{"budget", "budget_override", ""},
 		{"unknown gibberish here", "", ""},
 		{"", "", ""},
 	}
@@ -239,7 +242,7 @@ func TestBuildHelpBlocks(t *testing.T) {
 	}
 	data, _ := json.Marshal(blocks)
 	text := string(data)
-	for _, keyword := range []string{"status", "constraint", "dispatch", "pause", "resume", "help"} {
+	for _, keyword := range []string{"status", "constraint", "dispatch", "pause", "resume", "budget override", "help"} {
 		if !strings.Contains(text, keyword) {
 			t.Errorf("help blocks missing keyword %q", keyword)
 		}
@@ -374,5 +377,25 @@ func TestWebhookServer_SetSlackEvents(t *testing.T) {
 	ws.mux.ServeHTTP(w, req)
 	if w.Code == http.StatusNotFound {
 		t.Error("expected /slack/events to be registered, got 404")
+	}
+}
+
+// TestBuildBudgetOverrideBlocks_NoBudgetStore verifies error text when no store is wired.
+func TestBuildBudgetOverrideBlocks_NoBudgetStore(t *testing.T) {
+	h := newTestSlackHandler()
+	blocks := h.buildBudgetOverrideBlocks(context.Background(), "octi-pulpo-sr")
+	data, _ := json.Marshal(blocks)
+	if !strings.Contains(string(data), "not configured") {
+		t.Errorf("expected 'not configured' error, got: %s", data)
+	}
+}
+
+// TestBuildBudgetOverrideBlocks_EmptyAgent verifies usage hint when agent is empty.
+func TestBuildBudgetOverrideBlocks_EmptyAgent(t *testing.T) {
+	h := newTestSlackHandler()
+	blocks := h.buildBudgetOverrideBlocks(context.Background(), "")
+	data, _ := json.Marshal(blocks)
+	if !strings.Contains(string(data), "Usage") {
+		t.Errorf("expected usage hint, got: %s", data)
 	}
 }

--- a/internal/dispatch/webhook.go
+++ b/internal/dispatch/webhook.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/AgentGuardHQ/octi-pulpo/internal/budget"
 	"github.com/AgentGuardHQ/octi-pulpo/internal/sprint"
 )
 
@@ -30,6 +31,7 @@ type WebhookServer struct {
 	sprintStore        *sprint.Store
 	benchmark          *BenchmarkTracker
 	slackEvents        *SlackEventHandler
+	budgetStore        *budget.BudgetStore
 }
 
 // NewWebhookServer creates a webhook handler backed by the dispatcher.
@@ -338,6 +340,11 @@ func (ws *WebhookServer) SetSlackSigningSecret(secret []byte) {
 	ws.slackSigningSecret = secret
 }
 
+// SetBudgetStore enables budget override actions at /slack/actions.
+func (ws *WebhookServer) SetBudgetStore(bs *budget.BudgetStore) {
+	ws.budgetStore = bs
+}
+
 // handleSlackActions receives interactive action callbacks from Slack (Block Kit buttons).
 // Slack POSTs application/x-www-form-urlencoded with a "payload" field containing JSON.
 //
@@ -483,6 +490,15 @@ func (ws *WebhookServer) routeSlackAction(ctx context.Context, actionID, value, 
 			return "", fmt.Errorf("publish goal-rejected signal: %w", err)
 		}
 		return fmt.Sprintf("🔄 Changes requested for `%s` by @%s", value, actor), nil
+
+	case "budget_override":
+		if ws.budgetStore == nil {
+			return fmt.Sprintf("⚠️ Budget store not configured — cannot override `%s`", value), nil
+		}
+		if err := ws.budgetStore.MonthlyReset(ctx, value); err != nil {
+			return "", fmt.Errorf("budget override for %s: %w", value, err)
+		}
+		return fmt.Sprintf("✅ Budget override applied for `%s` by @%s — dispatch will resume on next tick", value, actor), nil
 
 	case "ignore_alert", "review_pr", "skip_pr":
 		// Acknowledged — no further action needed.


### PR DESCRIPTION
## Summary

- Adds `budget override <agent>` text command to Slack bot — resets an agent's monthly spend counter and clears its `paused` flag so dispatch resumes on the next tick
- Adds `budget_override` interactive action handler in `/slack/actions` — handles the [Override] button click from Block Kit messages
- Adds `PostBudgetExhaustedAlert` to `Notifier` — posts a Block Kit alert with [Override] and [Ignore] buttons when an agent is auto-paused due to budget exhaustion
- Wires `BudgetStore` into `SlackEventHandler` and `WebhookServer` in `main.go`

This completes the inbound control surface for issue #72. All existing inbound commands (`status`, `constraint`, `dispatch`, `pause`, `resume`) were already implemented; this PR adds the missing budget override path.

## Test plan

- [x] `TestParseCommand` — verifies `budget override <agent>` and bare `budget` are parsed correctly
- [x] `TestBuildBudgetOverrideBlocks_NoBudgetStore` — returns error text when store not wired
- [x] `TestBuildBudgetOverrideBlocks_EmptyAgent` — returns usage hint when agent is empty
- [x] `TestBuildHelpBlocks` — verifies `budget override` appears in help output
- [x] `TestRouteSlackAction_BudgetOverride_NoBudgetStore` — graceful noop, no error
- [x] `TestRouteSlackAction_BudgetOverride_WithStore` — seeds paused budget, clicks override, verifies `paused=false` and `spent=0`
- [x] `TestNotifier_PostBudgetExhaustedAlert_ContainsButton` — verifies `budget_override` action_id and [Override] text in payload
- [x] `TestNotifier_PostBudgetExhaustedAlert_Noop` — verifies disabled notifier returns nil

Closes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)