### PR TITLE
fix(sprint): tombstone stale items when open-issues list is complete

### DIFF
--- a/internal/sprint/store.go
+++ b/internal/sprint/store.go
@@ -96,16 +96,24 @@ func parseIssueRefs(body string) []int {
 	return nums
 }
 
+// syncOpenLimit is the maximum number of open issues fetched per sync.
+// When fewer than this many issues are returned, the list is complete and
+// tombstoneFromOpenSet can safely mark any Redis items outside that set as done.
+const syncOpenLimit = 200
+
 // Sync fetches open issues from a GitHub repo and stores them in Redis.
 // Issues labeled "sprint" get priority 0, others get priority 2.
 // After syncing issues it calls SyncPRs to mark items with open PRs as "pr_open",
 // preventing the brain from dispatching agents to re-implement in-flight work.
+// When the returned issue count is below syncOpenLimit (i.e. we received the
+// complete open list), tombstoneFromOpenSet runs to catch closed issues that
+// fall outside SyncClosed's window.
 func (s *Store) Sync(ctx context.Context, repo string) error {
 	cmd := exec.CommandContext(ctx, "gh", "issue", "list",
 		"-R", repo,
 		"--state", "open",
 		"--json", "number,title,labels,assignees",
-		"-L", "50",
+		"-L", strconv.Itoa(syncOpenLimit),
 	)
 	out, err := cmd.Output()
 	if err != nil {
@@ -191,6 +199,12 @@ func (s *Store) Sync(ctx context.Context, repo string) error {
 
 	s.log.Printf("synced %d issues from %s", len(issues), repo)
 
+	// Build the set of open issue numbers for tombstone and PR sync.
+	openNums := make(map[int]bool, len(issues))
+	for _, issue := range issues {
+		openNums[issue.Number] = true
+	}
+
 	// Promote items that already have open PRs so the brain doesn't re-dispatch.
 	if err := s.SyncPRs(ctx, repo); err != nil {
 		s.log.Printf("sync PRs for %s: %v", repo, err)
@@ -198,6 +212,12 @@ func (s *Store) Sync(ctx context.Context, repo string) error {
 	// Sync closed issues so items that shipped don't stay status="open" in Redis.
 	if err := s.SyncClosed(ctx, repo); err != nil {
 		s.log.Printf("sync closed issues for %s: %v", repo, err)
+	}
+	// Tombstone stale items: when we received fewer than syncOpenLimit results the
+	// open-issues list is complete, so any tracked item absent from that list must
+	// be closed in GitHub.  This catches issues closed before the SyncClosed window.
+	if len(issues) < syncOpenLimit {
+		s.tombstoneFromOpenSet(ctx, repo, openNums)
 	}
 	return nil
 }
@@ -448,12 +468,13 @@ func (s *Store) getByRepo(ctx context.Context, repo string) ([]SprintItem, error
 // SyncClosed fetches recently closed issues from a GitHub repo and marks
 // any matching sprint items as "done". This prevents the brain from
 // re-dispatching work that has already shipped.
+// The limit matches syncOpenLimit so the window is consistent with the open-issue sync.
 func (s *Store) SyncClosed(ctx context.Context, repo string) error {
 	cmd := exec.CommandContext(ctx, "gh", "issue", "list",
 		"-R", repo,
 		"--state", "closed",
 		"--json", "number",
-		"-L", "50",
+		"-L", strconv.Itoa(syncOpenLimit),
 	)
 	out, err := cmd.Output()
 	if err != nil {
@@ -504,6 +525,45 @@ func (s *Store) markClosedItems(ctx context.Context, repo string, issueNums []in
 		marked++
 	}
 	return marked
+}
+
+// tombstoneFromOpenSet marks sprint items as "done" when their issue number is
+// absent from openNums (the complete set of currently-open GitHub issues for the
+// repo).  Only items with status "open" or "pr_open" are affected — claimed,
+// in_progress, and done items are left untouched.
+//
+// This is called from Sync only when len(openIssues) < syncOpenLimit, i.e. when
+// the list is known to be complete.  For repos with more open issues than the
+// limit, tombstoning is skipped to avoid false-marking genuinely-open items.
+func (s *Store) tombstoneFromOpenSet(ctx context.Context, repo string, openNums map[int]bool) {
+	existing, err := s.getByRepo(ctx, repo)
+	if err != nil {
+		s.log.Printf("tombstone: get items for %s: %v", repo, err)
+		return
+	}
+	now := time.Now().UTC().Format(time.RFC3339)
+	var tombstoned int
+	for _, item := range existing {
+		if openNums[item.IssueNum] {
+			continue // still open in GitHub
+		}
+		// Only tombstone items that appear open from the sprint store's perspective
+		// but are absent from the current GitHub open-issues list.
+		if item.Status != "open" && item.Status != "pr_open" {
+			continue
+		}
+		item.Status = "done"
+		item.UpdatedAt = now
+		data, _ := json.Marshal(item)
+		if err := s.rdb.Set(ctx, s.itemKey(repo, item.IssueNum), data, 0).Err(); err != nil {
+			s.log.Printf("tombstone %s#%d: %v", repo, item.IssueNum, err)
+			continue
+		}
+		tombstoned++
+	}
+	if tombstoned > 0 {
+		s.log.Printf("tombstoned %d stale items in %s", tombstoned, repo)
+	}
 }
 
 // Reprioritize updates the priority of a sprint item identified by repo + issue number.

--- a/internal/sprint/store_test.go
+++ b/internal/sprint/store_test.go
@@ -632,3 +632,93 @@ func TestInferSquadFromRepo(t *testing.T) {
 		}
 	}
 }
+
+// TestTombstoneFromOpenSet_MarksStaleItems verifies that items tracked in Redis
+// but absent from the current open-issues list get tombstoned as "done".
+// This covers the case where SyncClosed misses old closed issues (e.g. octi-pulpo#10).
+func TestTombstoneFromOpenSet_MarksStaleItems(t *testing.T) {
+	s, ctx := testStore(t)
+
+	repo := "AgentGuardHQ/octi-pulpo"
+	s.rdb.SAdd(ctx, s.key("sprint-repos"), repo)
+
+	items := []SprintItem{
+		{Squad: "octi-pulpo", IssueNum: 10, Repo: repo, Title: "NotebookLM pipeline", Priority: 0, Status: "open"},    // closed in GitHub, stale in Redis
+		{Squad: "octi-pulpo", IssueNum: 44, Repo: repo, Title: "Async standups", Priority: 0, Status: "open"},         // still open
+		{Squad: "octi-pulpo", IssueNum: 72, Repo: repo, Title: "Slack control plane", Priority: 2, Status: "pr_open", PRNumber: 90}, // pr_open but closed in GitHub
+		{Squad: "octi-pulpo", IssueNum: 73, Repo: repo, Title: "Ticket ingestion", Priority: 2, Status: "done"},        // already done — must not change
+	}
+	for _, item := range items {
+		data, _ := json.Marshal(item)
+		s.rdb.Set(ctx, s.itemKey(repo, item.IssueNum), data, 0)
+	}
+
+	// GitHub reports only issues #44 as currently open.
+	openNums := map[int]bool{44: true}
+	s.tombstoneFromOpenSet(ctx, repo, openNums)
+
+	all, _ := s.GetAll(ctx)
+	byNum := make(map[int]SprintItem, len(all))
+	for _, item := range all {
+		byNum[item.IssueNum] = item
+	}
+
+	// #10: was "open", not in openNums → must be tombstoned
+	if byNum[10].Status != "done" {
+		t.Errorf("issue #10: expected done (tombstoned), got %s", byNum[10].Status)
+	}
+	// #44: still open in GitHub → must remain open
+	if byNum[44].Status != "open" {
+		t.Errorf("issue #44: expected open (still active), got %s", byNum[44].Status)
+	}
+	// #72: was pr_open, not in openNums → must be tombstoned
+	if byNum[72].Status != "done" {
+		t.Errorf("issue #72: expected done (tombstoned), got %s", byNum[72].Status)
+	}
+	// #73: already done → must stay done, untouched
+	if byNum[73].Status != "done" {
+		t.Errorf("issue #73: expected done (preserved), got %s", byNum[73].Status)
+	}
+}
+
+// TestTombstoneFromOpenSet_SkipsInProgressAndClaimed ensures that claimed and
+// in_progress items are never tombstoned — they may be actively worked on even
+// when the issue was just recently closed by a merged PR.
+func TestTombstoneFromOpenSet_SkipsInProgressAndClaimed(t *testing.T) {
+	s, ctx := testStore(t)
+
+	repo := "AgentGuardHQ/octi-pulpo"
+	s.rdb.SAdd(ctx, s.key("sprint-repos"), repo)
+
+	items := []SprintItem{
+		{Squad: "octi-pulpo", IssueNum: 55, Repo: repo, Title: "Claimed work", Priority: 1, Status: "claimed"},
+		{Squad: "octi-pulpo", IssueNum: 56, Repo: repo, Title: "In-flight work", Priority: 1, Status: "in_progress"},
+	}
+	for _, item := range items {
+		data, _ := json.Marshal(item)
+		s.rdb.Set(ctx, s.itemKey(repo, item.IssueNum), data, 0)
+	}
+
+	// Both items are absent from openNums (simulating recently-closed issues).
+	s.tombstoneFromOpenSet(ctx, repo, map[int]bool{})
+
+	all, _ := s.GetAll(ctx)
+	byNum := make(map[int]SprintItem, len(all))
+	for _, item := range all {
+		byNum[item.IssueNum] = item
+	}
+
+	if byNum[55].Status != "claimed" {
+		t.Errorf("issue #55: expected claimed (preserved), got %s", byNum[55].Status)
+	}
+	if byNum[56].Status != "in_progress" {
+		t.Errorf("issue #56: expected in_progress (preserved), got %s", byNum[56].Status)
+	}
+}
+
+// TestTombstoneFromOpenSet_EmptyStore is a no-op guard.
+func TestTombstoneFromOpenSet_EmptyStore(t *testing.T) {
+	s, ctx := testStore(t)
+	// No panic, no error when store has no items.
+	s.tombstoneFromOpenSet(ctx, "AgentGuardHQ/octi-pulpo", map[int]bool{1: true, 2: true})
+}


### PR DESCRIPTION
## Summary

- **Root cause**: `SyncClosed` fetched only the 50 most-recently-closed GitHub issues. Any issue closed earlier than that window (e.g. `octi-pulpo#10`, an early low-numbered issue) stayed as `status="open"` in Redis indefinitely. The brain treated it as a dispatchable P0 item and repeatedly dispatched `octi-pulpo-sr` to ghost work — observed on 2026-03-30 with 5+ consecutive dispatch attempts to `octi-pulpo#10`.
- **Fix 1 — wider SyncClosed window**: raise the shared `syncOpenLimit` constant to 200, used for both `Sync` and `SyncClosed`. Consistent window; covers small repos (octi-pulpo, shellforge) completely.
- **Fix 2 — tombstone from open set**: after syncing open issues, if `len(openIssues) < syncOpenLimit` (meaning the list is *complete*), tombstone any Redis items for that repo that are absent from the open set and have status `open` or `pr_open`. Items with status `claimed`, `in_progress`, or `done` are preserved. Repos with 200+ open issues (agentguard) skip tombstoning entirely — no risk of false-marking.

## Test plan

- [x] `TestTombstoneFromOpenSet_MarksStaleItems` — stale `open` and `pr_open` items get tombstoned; still-open item preserved; already-`done` item preserved
- [x] `TestTombstoneFromOpenSet_SkipsInProgressAndClaimed` — `claimed` and `in_progress` items never tombstoned
- [x] `TestTombstoneFromOpenSet_EmptyStore` — no panic when store has no items
- [x] All 13 packages pass: `go test ./... -timeout 90s`

Closes #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)