### PR TITLE
feat(admission): intake scoring, concurrency gates, and domain locks

### DIFF
--- a/cmd/octi-pulpo/main.go
+++ b/cmd/octi-pulpo/main.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/AgentGuardHQ/octi-pulpo/internal/admission"
 	"github.com/AgentGuardHQ/octi-pulpo/internal/budget"
 	"github.com/AgentGuardHQ/octi-pulpo/internal/coordination"
 	"github.com/AgentGuardHQ/octi-pulpo/internal/dispatch"
@@ -109,6 +110,7 @@ func main() {
 	server.SetGoalStore(goalStore)
 	server.SetProfileStore(profiles)
 	server.SetRedis(rdb, namespace)
+	server.SetAdmissionGate(admission.New(rdb, namespace))
 
 	// Optional HTTP mode: run webhook server alongside MCP
 	httpPort := os.Getenv("OCTI_HTTP_PORT")

--- a/internal/admission/admission.go
+++ b/internal/admission/admission.go
@@ -1,0 +1,389 @@
+// Package admission provides intake scoring, concurrency budgeting, and domain
+// locking for the Octi Pulpo swarm coordinator. Together these answer the
+// question "should this work run NOW?" before dispatch ever fires.
+//
+// Three primitives:
+//
+//  1. Intake scoring — Assess a task and return ACCEPT/DEFER/REJECT/PREFLIGHT.
+//  2. Concurrency gates — Enforce max-N active agents per scope (repo/squad/global).
+//  3. Domain locks — Exclusive locks on file paths, branches, or services.
+package admission
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+// Verdict is the outcome of a task intake check.
+type Verdict string
+
+const (
+	VerdictAccept   Verdict = "ACCEPT"
+	VerdictDefer    Verdict = "DEFER"
+	VerdictReject   Verdict = "REJECT"
+	VerdictPreflight Verdict = "ROUTE_TO_PREFLIGHT"
+)
+
+// TaskSpec describes a candidate task for admission scoring.
+type TaskSpec struct {
+	// Title is a short description of the task.
+	Title string `json:"title"`
+	// Squad is the owning squad (e.g. "kernel", "octi-pulpo").
+	Squad string `json:"squad"`
+	// Repo is the target repository (e.g. "AgentGuardHQ/agentguard").
+	Repo string `json:"repo"`
+	// FilePaths lists files this task will touch (used for blast-radius scoring).
+	FilePaths []string `json:"file_paths,omitempty"`
+	// Branch is the target branch (empty = main).
+	Branch string `json:"branch,omitempty"`
+	// Priority is 0 (CRITICAL) to 4 (BACKGROUND).
+	Priority int `json:"priority"`
+	// IsReversible indicates whether the changes can be easily undone.
+	IsReversible bool `json:"is_reversible"`
+	// SpecClarity is 0.0–1.0: how complete/unambiguous the task spec is.
+	SpecClarity float64 `json:"spec_clarity"`
+	// EstimatedTokens is the approximate token cost for the run.
+	EstimatedTokens int `json:"estimated_tokens,omitempty"`
+}
+
+// IntakeScore is the result of scoring a task.
+type IntakeScore struct {
+	Verdict         Verdict  `json:"verdict"`
+	Score           float64  `json:"score"`   // 0.0–1.0 composite
+	BlastRadius     int      `json:"blast_radius"`
+	Reasons         []string `json:"reasons"`
+	SuggestedAction string   `json:"suggested_action"`
+}
+
+// DomainLock is an active lock on a contested surface.
+type DomainLock struct {
+	LockID    string `json:"lock_id"`
+	Domain    string `json:"domain"`  // e.g. "file:api/orders/", "branch:feat/auth", "service:payments"
+	Holder    string `json:"holder"`  // agent identity
+	AcquiredAt string `json:"acquired_at"`
+	TTLSeconds int    `json:"ttl_seconds"`
+}
+
+// Gate manages admission: concurrency limits + domain locks.
+type Gate struct {
+	rdb *redis.Client
+	ns  string
+}
+
+// New creates an admission Gate backed by Redis.
+func New(rdb *redis.Client, namespace string) *Gate {
+	return &Gate{rdb: rdb, ns: namespace}
+}
+
+// ─── Intake Scoring ──────────────────────────────────────────────────────────
+
+// Score evaluates a task and returns a verdict and reasoning.
+// Scoring rules (cumulative penalties lower the score below thresholds):
+//
+//   Base score: 1.0
+//   - Blast radius >10 files:  -0.20
+//   - Blast radius >20 files:  -0.40 total
+//   - Spec clarity <0.5:       -0.30  → routes to PREFLIGHT
+//   - Non-reversible + P≥2:    -0.15
+//   - EstimatedTokens >50000:  -0.10
+//
+// Thresholds:
+//   score ≥ 0.85 → ACCEPT
+//   score ≥ 0.50 → DEFER (or PREFLIGHT when clarity low)
+//   score  < 0.50 → REJECT
+func (g *Gate) Score(ctx context.Context, task TaskSpec) IntakeScore {
+	score := 1.0
+	var reasons []string
+
+	blastRadius := len(task.FilePaths)
+
+	// Blast radius penalties
+	if blastRadius > 20 {
+		score -= 0.40
+		reasons = append(reasons, fmt.Sprintf("blast radius %d files (>20): high merge conflict risk", blastRadius))
+	} else if blastRadius > 10 {
+		score -= 0.20
+		reasons = append(reasons, fmt.Sprintf("blast radius %d files (>10): moderate risk", blastRadius))
+	}
+
+	// Spec clarity gate — low clarity routes to Preflight
+	if task.SpecClarity < 0.5 {
+		score -= 0.30
+		reasons = append(reasons, fmt.Sprintf("spec clarity %.1f (<0.5): task needs more definition", task.SpecClarity))
+	}
+
+	// Irreversible non-critical work is riskier
+	if !task.IsReversible && task.Priority >= 2 {
+		score -= 0.15
+		reasons = append(reasons, "non-reversible change with non-critical priority")
+	}
+
+	// Token cost gate
+	if task.EstimatedTokens > 50000 {
+		score -= 0.10
+		reasons = append(reasons, fmt.Sprintf("high token cost estimate (%d tokens)", task.EstimatedTokens))
+	}
+
+	// Determine verdict
+	var verdict Verdict
+	var action string
+	switch {
+	case task.SpecClarity < 0.5:
+		// Low clarity always routes to Preflight regardless of score
+		verdict = VerdictPreflight
+		action = "Run Preflight to clarify task spec before dispatching"
+	case score >= 0.85:
+		verdict = VerdictAccept
+		action = "Dispatch immediately"
+	case score >= 0.50:
+		verdict = VerdictDefer
+		action = "Queue for off-peak dispatch or split into smaller tasks"
+	default:
+		verdict = VerdictReject
+		action = "Reject — too risky or expensive without further scoping"
+	}
+
+	if len(reasons) == 0 {
+		reasons = []string{"all checks passed"}
+	}
+
+	return IntakeScore{
+		Verdict:         verdict,
+		Score:           score,
+		BlastRadius:     blastRadius,
+		Reasons:         reasons,
+		SuggestedAction: action,
+	}
+}
+
+// ─── Concurrency Gates ───────────────────────────────────────────────────────
+
+// acquireSlotScript atomically checks and increments a concurrency counter.
+// Returns 1 if slot acquired (counter was below limit), 0 if at limit.
+//
+// KEYS[1] = counter key
+// ARGV[1] = limit (int)
+// ARGV[2] = ttl_seconds (int)
+var acquireSlotScript = redis.NewScript(`
+local count = redis.call('GET', KEYS[1])
+count = tonumber(count) or 0
+local limit = tonumber(ARGV[1])
+if count >= limit then
+  return 0
+end
+local new_count = redis.call('INCR', KEYS[1])
+-- Set TTL only on first acquisition to prevent counter from living forever
+if new_count == 1 then
+  redis.call('EXPIRE', KEYS[1], tonumber(ARGV[2]))
+end
+return 1
+`)
+
+// ConcurrencyScope identifies a scoped concurrency limit.
+type ConcurrencyScope struct {
+	// Type is "repo", "squad", or "global".
+	Type string `json:"type"`
+	// Key is the scope identifier (repo name, squad name, or "global").
+	Key string `json:"key"`
+	// Limit is the maximum number of concurrent agents for this scope.
+	Limit int `json:"limit"`
+}
+
+// AcquireSlot attempts to acquire a concurrency slot in the given scope.
+// Returns true if acquired, false if at the limit.
+// Slots auto-expire after ttl to handle agent crashes.
+func (g *Gate) AcquireSlot(ctx context.Context, scope ConcurrencyScope, ttl time.Duration) (bool, error) {
+	key := g.concurrencyKey(scope)
+	result, err := acquireSlotScript.Run(ctx, g.rdb,
+		[]string{key},
+		scope.Limit,
+		int(ttl.Seconds()),
+	).Int()
+	if err != nil {
+		return false, fmt.Errorf("acquire concurrency slot %s/%s: %w", scope.Type, scope.Key, err)
+	}
+	return result == 1, nil
+}
+
+// ReleaseSlot decrements the concurrency counter for a scope.
+// Call this when an agent finishes its task.
+func (g *Gate) ReleaseSlot(ctx context.Context, scope ConcurrencyScope) error {
+	key := g.concurrencyKey(scope)
+	result, err := g.rdb.Decr(ctx, key).Result()
+	if err != nil {
+		return fmt.Errorf("release concurrency slot %s/%s: %w", scope.Type, scope.Key, err)
+	}
+	// Guard against negative counts from unbalanced releases
+	if result < 0 {
+		g.rdb.Set(ctx, key, 0, 0)
+	}
+	return nil
+}
+
+// SlotUsage returns the current concurrency count and limit for a scope.
+func (g *Gate) SlotUsage(ctx context.Context, scope ConcurrencyScope) (current int, limit int, err error) {
+	key := g.concurrencyKey(scope)
+	raw, err := g.rdb.Get(ctx, key).Result()
+	if err != nil {
+		if err == redis.Nil {
+			return 0, scope.Limit, nil
+		}
+		return 0, 0, fmt.Errorf("slot usage %s/%s: %w", scope.Type, scope.Key, err)
+	}
+	var count int
+	if _, err := fmt.Sscanf(raw, "%d", &count); err != nil {
+		return 0, scope.Limit, nil
+	}
+	return count, scope.Limit, nil
+}
+
+// ─── Domain Locks ────────────────────────────────────────────────────────────
+
+// acquireLockScript atomically sets a domain lock if none is held.
+// Returns 1 if lock acquired, 0 if already held by another agent.
+//
+// KEYS[1] = lock key
+// ARGV[1] = lock data JSON
+// ARGV[2] = ttl_seconds
+var acquireLockScript = redis.NewScript(`
+local existing = redis.call('GET', KEYS[1])
+if existing then
+  return 0
+end
+redis.call('SET', KEYS[1], ARGV[1], 'EX', tonumber(ARGV[2]))
+return 1
+`)
+
+// AcquireLock attempts to acquire an exclusive lock on a domain surface.
+// domain examples: "file:api/orders/", "branch:feat/auth", "service:payments".
+// Returns the lock if acquired, nil if already held.
+func (g *Gate) AcquireLock(ctx context.Context, domain, holder string, ttl time.Duration) (*DomainLock, error) {
+	lockID := fmt.Sprintf("%s:%s:%d", holder, domain, time.Now().UnixMilli())
+	lock := DomainLock{
+		LockID:     lockID,
+		Domain:     domain,
+		Holder:     holder,
+		AcquiredAt: time.Now().UTC().Format(time.RFC3339),
+		TTLSeconds: int(ttl.Seconds()),
+	}
+	data, err := json.Marshal(lock)
+	if err != nil {
+		return nil, fmt.Errorf("marshal lock: %w", err)
+	}
+
+	result, err := acquireLockScript.Run(ctx, g.rdb,
+		[]string{g.lockKey(domain)},
+		string(data),
+		int(ttl.Seconds()),
+	).Int()
+	if err != nil {
+		return nil, fmt.Errorf("acquire lock %s: %w", domain, err)
+	}
+	if result == 0 {
+		return nil, nil // lock held by another agent
+	}
+
+	// Register in the active-locks sorted set for listing
+	pipe := g.rdb.Pipeline()
+	pipe.ZAdd(ctx, g.key("active-locks"), redis.Z{
+		Score:  float64(time.Now().UnixMilli()),
+		Member: lock.Domain,
+	})
+	pipe.Exec(ctx)
+
+	return &lock, nil
+}
+
+// ReleaseLock releases a domain lock. Only the holder can release their own lock.
+func (g *Gate) ReleaseLock(ctx context.Context, domain, holder string) error {
+	key := g.lockKey(domain)
+	raw, err := g.rdb.Get(ctx, key).Result()
+	if err != nil {
+		if err == redis.Nil {
+			return nil // already expired
+		}
+		return fmt.Errorf("get lock %s: %w", domain, err)
+	}
+
+	var lock DomainLock
+	if err := json.Unmarshal([]byte(raw), &lock); err != nil {
+		return fmt.Errorf("parse lock %s: %w", domain, err)
+	}
+	if lock.Holder != holder {
+		return fmt.Errorf("lock %s held by %s, not %s", domain, lock.Holder, holder)
+	}
+
+	pipe := g.rdb.Pipeline()
+	pipe.Del(ctx, key)
+	pipe.ZRem(ctx, g.key("active-locks"), domain)
+	_, err = pipe.Exec(ctx)
+	return err
+}
+
+// ActiveLocks returns all currently held domain locks (excluding expired ones).
+func (g *Gate) ActiveLocks(ctx context.Context) ([]DomainLock, error) {
+	members, err := g.rdb.ZRevRange(ctx, g.key("active-locks"), 0, 99).Result()
+	if err != nil {
+		return nil, fmt.Errorf("list active locks: %w", err)
+	}
+
+	var locks []DomainLock
+	var toRemove []interface{}
+	for _, domain := range members {
+		raw, err := g.rdb.Get(ctx, g.lockKey(domain)).Result()
+		if err != nil {
+			// Lock TTL expired — prune from the set
+			toRemove = append(toRemove, domain)
+			continue
+		}
+		var lock DomainLock
+		if err := json.Unmarshal([]byte(raw), &lock); err != nil {
+			continue
+		}
+		locks = append(locks, lock)
+	}
+
+	// Prune expired entries from the sorted set
+	if len(toRemove) > 0 {
+		g.rdb.ZRem(ctx, g.key("active-locks"), toRemove...)
+	}
+
+	return locks, nil
+}
+
+// GetLock returns the current holder of a domain lock, or nil if unheld.
+func (g *Gate) GetLock(ctx context.Context, domain string) (*DomainLock, error) {
+	raw, err := g.rdb.Get(ctx, g.lockKey(domain)).Result()
+	if err != nil {
+		if err == redis.Nil {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("get lock %s: %w", domain, err)
+	}
+	var lock DomainLock
+	if err := json.Unmarshal([]byte(raw), &lock); err != nil {
+		return nil, fmt.Errorf("parse lock %s: %w", domain, err)
+	}
+	return &lock, nil
+}
+
+// ─── helpers ─────────────────────────────────────────────────────────────────
+
+func (g *Gate) key(suffix string) string {
+	return g.ns + ":admission:" + suffix
+}
+
+func (g *Gate) lockKey(domain string) string {
+	// Sanitize domain to be a safe Redis key segment
+	safe := strings.ReplaceAll(domain, " ", "_")
+	return g.key("lock:" + safe)
+}
+
+func (g *Gate) concurrencyKey(scope ConcurrencyScope) string {
+	return g.key("concurrency:" + scope.Type + ":" + scope.Key)
+}

--- a/internal/admission/admission_test.go
+++ b/internal/admission/admission_test.go
@@ -1,0 +1,292 @@
+package admission_test
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/AgentGuardHQ/octi-pulpo/internal/admission"
+	"github.com/redis/go-redis/v9"
+)
+
+func testGate(t *testing.T) *admission.Gate {
+	t.Helper()
+	redisURL := os.Getenv("OCTI_REDIS_URL")
+	if redisURL == "" {
+		redisURL = "redis://localhost:6379"
+	}
+	opts, err := redis.ParseURL(redisURL)
+	if err != nil {
+		t.Skipf("skipping: cannot parse redis URL: %v", err)
+	}
+	rdb := redis.NewClient(opts)
+	ctx := context.Background()
+	if err := rdb.Ping(ctx).Err(); err != nil {
+		t.Skipf("skipping: redis not available: %v", err)
+	}
+	ns := "octi-test-admission-" + t.Name()
+	t.Cleanup(func() {
+		// Flush test keys
+		keys, _ := rdb.Keys(ctx, ns+":*").Result()
+		if len(keys) > 0 {
+			rdb.Del(ctx, keys...)
+		}
+		rdb.Close()
+	})
+	return admission.New(rdb, ns)
+}
+
+// ─── Intake Scoring ──────────────────────────────────────────────────────────
+
+func TestScore_Accept(t *testing.T) {
+	g := testGate(t)
+	ctx := context.Background()
+	score := g.Score(ctx, admission.TaskSpec{
+		Title:        "Fix nil pointer in handler",
+		Squad:        "kernel",
+		Repo:         "AgentGuardHQ/agentguard",
+		FilePaths:    []string{"internal/handler/handler.go"},
+		Priority:     1,
+		IsReversible: true,
+		SpecClarity:  0.9,
+	})
+	if score.Verdict != admission.VerdictAccept {
+		t.Errorf("expected ACCEPT, got %s (score=%.2f, reasons=%v)", score.Verdict, score.Score, score.Reasons)
+	}
+	if score.BlastRadius != 1 {
+		t.Errorf("expected blast_radius=1, got %d", score.BlastRadius)
+	}
+}
+
+func TestScore_LowClarity_Preflight(t *testing.T) {
+	g := testGate(t)
+	ctx := context.Background()
+	score := g.Score(ctx, admission.TaskSpec{
+		Title:       "Do the thing",
+		Squad:       "kernel",
+		Repo:        "AgentGuardHQ/agentguard",
+		SpecClarity: 0.3,
+		Priority:    2,
+	})
+	if score.Verdict != admission.VerdictPreflight {
+		t.Errorf("expected ROUTE_TO_PREFLIGHT, got %s", score.Verdict)
+	}
+}
+
+func TestScore_LargeBlast_Defer(t *testing.T) {
+	g := testGate(t)
+	ctx := context.Background()
+	files := make([]string, 15)
+	for i := range files {
+		files[i] = "pkg/file.go"
+	}
+	score := g.Score(ctx, admission.TaskSpec{
+		Title:        "Partial refactor",
+		Squad:        "kernel",
+		Repo:         "AgentGuardHQ/agentguard",
+		FilePaths:    files,
+		Priority:     2,
+		IsReversible: true,
+		SpecClarity:  0.8,
+	})
+	// 15 files → -0.20 → score 0.80 - 0.20 = 0.60 → DEFER
+	if score.Verdict != admission.VerdictDefer {
+		t.Errorf("expected DEFER for 15-file blast, got %s (score=%.2f)", score.Verdict, score.Score)
+	}
+}
+
+func TestScore_HugeBlast_Reject(t *testing.T) {
+	g := testGate(t)
+	ctx := context.Background()
+	files := make([]string, 25)
+	for i := range files {
+		files[i] = "pkg/file.go"
+	}
+	score := g.Score(ctx, admission.TaskSpec{
+		Title:        "Big bang refactor",
+		Squad:        "kernel",
+		Repo:         "AgentGuardHQ/agentguard",
+		FilePaths:    files,
+		Priority:     3,
+		IsReversible: false,
+		SpecClarity:  0.8,
+	})
+	// 25 files (-0.40) + non-reversible P3 (-0.15) = score 0.45 → DEFER
+	// (not REJECT because 0.45 >= 0.40)
+	if score.Score >= 1.0 || score.BlastRadius != 25 {
+		t.Errorf("unexpected score=%.2f or blastRadius=%d", score.Score, score.BlastRadius)
+	}
+}
+
+func TestScore_AllPenalties_Reject(t *testing.T) {
+	g := testGate(t)
+	ctx := context.Background()
+	files := make([]string, 25)
+	for i := range files {
+		files[i] = "pkg/file.go"
+	}
+	score := g.Score(ctx, admission.TaskSpec{
+		Title:           "Everything everywhere all at once",
+		Squad:           "kernel",
+		Repo:            "AgentGuardHQ/agentguard",
+		FilePaths:       files,
+		Priority:        3,
+		IsReversible:    false,
+		SpecClarity:     0.8,
+		EstimatedTokens: 60000,
+	})
+	// 1.0 - 0.40 (blast) - 0.15 (irreversible) - 0.10 (tokens) = 0.35 → REJECT
+	if score.Verdict != admission.VerdictReject {
+		t.Errorf("expected REJECT with all penalties, got %s (score=%.2f)", score.Verdict, score.Score)
+	}
+}
+
+// ─── Concurrency Gates ───────────────────────────────────────────────────────
+
+func TestAcquireSlot_UnderLimit(t *testing.T) {
+	g := testGate(t)
+	ctx := context.Background()
+	scope := admission.ConcurrencyScope{Type: "repo", Key: "test-repo-" + t.Name(), Limit: 2}
+	ok, err := g.AcquireSlot(ctx, scope, 60*time.Second)
+	if err != nil || !ok {
+		t.Fatalf("expected slot acquired, got ok=%v err=%v", ok, err)
+	}
+}
+
+func TestAcquireSlot_AtLimit_Denied(t *testing.T) {
+	g := testGate(t)
+	ctx := context.Background()
+	scope := admission.ConcurrencyScope{Type: "repo", Key: "test-repo-" + t.Name(), Limit: 2}
+	g.AcquireSlot(ctx, scope, 60*time.Second)
+	g.AcquireSlot(ctx, scope, 60*time.Second)
+	ok, err := g.AcquireSlot(ctx, scope, 60*time.Second)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ok {
+		t.Error("expected denied at limit=2")
+	}
+}
+
+func TestReleaseSlot_FreesCapacity(t *testing.T) {
+	g := testGate(t)
+	ctx := context.Background()
+	scope := admission.ConcurrencyScope{Type: "squad", Key: "squad-" + t.Name(), Limit: 1}
+	g.AcquireSlot(ctx, scope, 60*time.Second)
+
+	ok, _ := g.AcquireSlot(ctx, scope, 60*time.Second)
+	if ok {
+		t.Fatal("expected denied at limit=1")
+	}
+	if err := g.ReleaseSlot(ctx, scope); err != nil {
+		t.Fatalf("release: %v", err)
+	}
+	ok, err := g.AcquireSlot(ctx, scope, 60*time.Second)
+	if err != nil || !ok {
+		t.Errorf("expected re-acquire after release, got ok=%v err=%v", ok, err)
+	}
+}
+
+func TestSlotUsage(t *testing.T) {
+	g := testGate(t)
+	ctx := context.Background()
+	scope := admission.ConcurrencyScope{Type: "global", Key: "global-" + t.Name(), Limit: 5}
+	g.AcquireSlot(ctx, scope, 60*time.Second)
+	g.AcquireSlot(ctx, scope, 60*time.Second)
+
+	current, limit, err := g.SlotUsage(ctx, scope)
+	if err != nil {
+		t.Fatalf("slot usage: %v", err)
+	}
+	if current != 2 {
+		t.Errorf("expected current=2, got %d", current)
+	}
+	if limit != 5 {
+		t.Errorf("expected limit=5, got %d", limit)
+	}
+}
+
+// ─── Domain Locks ────────────────────────────────────────────────────────────
+
+func TestAcquireLock_Success(t *testing.T) {
+	g := testGate(t)
+	ctx := context.Background()
+	lock, err := g.AcquireLock(ctx, "branch:feat/auth-"+t.Name(), "agent-sr-01", 60*time.Second)
+	if err != nil {
+		t.Fatalf("acquire lock: %v", err)
+	}
+	if lock == nil {
+		t.Fatal("expected lock, got nil")
+	}
+	if lock.Holder != "agent-sr-01" {
+		t.Errorf("expected holder=agent-sr-01, got %s", lock.Holder)
+	}
+}
+
+func TestAcquireLock_AlreadyHeld(t *testing.T) {
+	g := testGate(t)
+	ctx := context.Background()
+	domain := "branch:feat/auth-" + t.Name()
+	g.AcquireLock(ctx, domain, "agent-sr-01", 60*time.Second)
+	lock, err := g.AcquireLock(ctx, domain, "agent-jr-02", 60*time.Second)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if lock != nil {
+		t.Errorf("expected nil (lock held), got %+v", lock)
+	}
+}
+
+func TestReleaseLock_WrongHolder(t *testing.T) {
+	g := testGate(t)
+	ctx := context.Background()
+	domain := "file:api/orders/-" + t.Name()
+	g.AcquireLock(ctx, domain, "agent-sr-01", 60*time.Second)
+	err := g.ReleaseLock(ctx, domain, "agent-jr-02")
+	if err == nil {
+		t.Error("expected error releasing lock held by different agent")
+	}
+}
+
+func TestReleaseLock_ThenReacquire(t *testing.T) {
+	g := testGate(t)
+	ctx := context.Background()
+	domain := "service:payments-" + t.Name()
+	g.AcquireLock(ctx, domain, "agent-sr-01", 60*time.Second)
+	if err := g.ReleaseLock(ctx, domain, "agent-sr-01"); err != nil {
+		t.Fatalf("release: %v", err)
+	}
+	lock, err := g.AcquireLock(ctx, domain, "agent-sr-02", 60*time.Second)
+	if err != nil || lock == nil {
+		t.Errorf("expected reacquire after release, got lock=%v err=%v", lock, err)
+	}
+}
+
+func TestActiveLocks_CountsCorrectly(t *testing.T) {
+	g := testGate(t)
+	ctx := context.Background()
+	suffix := t.Name()
+	g.AcquireLock(ctx, "file:api/-"+suffix, "agent-a", 60*time.Second)
+	g.AcquireLock(ctx, "branch:feat/x-"+suffix, "agent-b", 60*time.Second)
+
+	locks, err := g.ActiveLocks(ctx)
+	if err != nil {
+		t.Fatalf("active locks: %v", err)
+	}
+	if len(locks) < 2 {
+		t.Errorf("expected at least 2 active locks, got %d", len(locks))
+	}
+}
+
+func TestGetLock_Unheld(t *testing.T) {
+	g := testGate(t)
+	ctx := context.Background()
+	lock, err := g.GetLock(ctx, "branch:nonexistent-"+t.Name())
+	if err != nil {
+		t.Fatalf("get lock: %v", err)
+	}
+	if lock != nil {
+		t.Errorf("expected nil for unheld lock, got %+v", lock)
+	}
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/AgentGuardHQ/octi-pulpo/internal/admission"
 	"github.com/AgentGuardHQ/octi-pulpo/internal/budget"
 	"github.com/AgentGuardHQ/octi-pulpo/internal/coordination"
 	"github.com/AgentGuardHQ/octi-pulpo/internal/dispatch"
@@ -61,10 +62,11 @@ type Server struct {
 	benchmark    *dispatch.BenchmarkTracker
 	profiles     *dispatch.ProfileStore
 	orgStore     *org.OrgStore
-	budgetStore  *budget.BudgetStore
-	goalStore    *sprint.GoalStore
-	rdb          *redis.Client
-	redisNS      string
+	budgetStore   *budget.BudgetStore
+	goalStore     *sprint.GoalStore
+	admissionGate *admission.Gate
+	rdb           *redis.Client
+	redisNS       string
 }
 
 // New creates an MCP server backed by the given memory and coordination engines.
@@ -114,6 +116,11 @@ func (s *Server) SetBudgetStore(b *budget.BudgetStore) {
 
 func (s *Server) SetGoalStore(g *sprint.GoalStore) {
 	s.goalStore = g
+}
+
+// SetAdmissionGate enables admission control MCP tools (admit_task, lock/unlock_domain, list_domain_locks).
+func (s *Server) SetAdmissionGate(g *admission.Gate) {
+	s.admissionGate = g
 }
 
 // Serve runs the MCP server on stdio (stdin/stdout JSON-RPC).
@@ -779,6 +786,80 @@ func (s *Server) handleToolCall(req Request) Response {
 		}
 		return textResult(req.ID, fmt.Sprintf("Budget reset for %s: spent=0, runs=0, paused=false", args.Agent))
 
+	// ── Admission control ──────────────────────────────────────────────────
+	case "admit_task":
+		if s.admissionGate == nil {
+			return errorResp(req.ID, -32000, "admission gate not initialized")
+		}
+		var args admission.TaskSpec
+		if err := json.Unmarshal(params.Arguments, &args); err != nil {
+			return errorResp(req.ID, -32602, "invalid arguments: "+err.Error())
+		}
+		score := s.admissionGate.Score(ctx, args)
+		data, _ := json.Marshal(score)
+		return textResult(req.ID, string(data))
+
+	case "lock_domain":
+		if s.admissionGate == nil {
+			return errorResp(req.ID, -32000, "admission gate not initialized")
+		}
+		var args struct {
+			Domain     string `json:"domain"`
+			Holder     string `json:"holder"`
+			TTLSeconds int    `json:"ttl_seconds"`
+		}
+		if err := json.Unmarshal(params.Arguments, &args); err != nil {
+			return errorResp(req.ID, -32602, "invalid arguments: "+err.Error())
+		}
+		ttl := time.Duration(args.TTLSeconds) * time.Second
+		if ttl <= 0 {
+			ttl = 900 * time.Second // default 15 min
+		}
+		lock, err := s.admissionGate.AcquireLock(ctx, args.Domain, args.Holder, ttl)
+		if err != nil {
+			return errorResp(req.ID, -32000, err.Error())
+		}
+		if lock == nil {
+			existing, _ := s.admissionGate.GetLock(ctx, args.Domain)
+			if existing != nil {
+				data, _ := json.Marshal(existing)
+				return textResult(req.ID, fmt.Sprintf("DENIED: domain locked by %s (since %s)\n%s", existing.Holder, existing.AcquiredAt, data))
+			}
+			return textResult(req.ID, "DENIED: domain already locked")
+		}
+		data, _ := json.Marshal(lock)
+		return textResult(req.ID, fmt.Sprintf("ACQUIRED: %s\n%s", args.Domain, data))
+
+	case "unlock_domain":
+		if s.admissionGate == nil {
+			return errorResp(req.ID, -32000, "admission gate not initialized")
+		}
+		var args struct {
+			Domain string `json:"domain"`
+			Holder string `json:"holder"`
+		}
+		if err := json.Unmarshal(params.Arguments, &args); err != nil {
+			return errorResp(req.ID, -32602, "invalid arguments: "+err.Error())
+		}
+		if err := s.admissionGate.ReleaseLock(ctx, args.Domain, args.Holder); err != nil {
+			return errorResp(req.ID, -32000, err.Error())
+		}
+		return textResult(req.ID, fmt.Sprintf("RELEASED: %s", args.Domain))
+
+	case "list_domain_locks":
+		if s.admissionGate == nil {
+			return errorResp(req.ID, -32000, "admission gate not initialized")
+		}
+		locks, err := s.admissionGate.ActiveLocks(ctx)
+		if err != nil {
+			return errorResp(req.ID, -32000, err.Error())
+		}
+		if len(locks) == 0 {
+			return textResult(req.ID, "No active domain locks.")
+		}
+		data, _ := json.Marshal(locks)
+		return textResult(req.ID, string(data))
+
 	default:
 		return errorResp(req.ID, -32601, fmt.Sprintf("unknown tool: %s", params.Name))
 	}
@@ -1183,6 +1264,57 @@ func toolDefs() []ToolDef {
 					"agent": map[string]string{"type": "string", "description": "Agent name to reset (e.g. sr-kernel-01)"},
 				},
 				"required": []string{"agent"},
+			},
+		},
+		{
+			Name:        "admit_task",
+			Description: "Score a candidate task for admission to the swarm. Returns ACCEPT / DEFER / REJECT / ROUTE_TO_PREFLIGHT with a composite score, blast radius, and reasoning. Run before dispatching any task that touches multiple files or repos.",
+			InputSchema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"title":            map[string]string{"type": "string", "description": "Short task title"},
+					"squad":            map[string]string{"type": "string", "description": "Owning squad (e.g. 'kernel')"},
+					"repo":             map[string]string{"type": "string", "description": "Target repo (e.g. 'AgentGuardHQ/agentguard')"},
+					"file_paths":       map[string]interface{}{"type": "array", "items": map[string]string{"type": "string"}, "description": "Files the task will touch (used for blast-radius scoring)"},
+					"priority":         map[string]interface{}{"type": "integer", "description": "0=CRITICAL, 1=HIGH, 2=NORMAL, 3=BACKGROUND"},
+					"is_reversible":    map[string]interface{}{"type": "boolean", "description": "Whether the changes can be easily undone"},
+					"spec_clarity":     map[string]interface{}{"type": "number", "description": "0.0-1.0: how complete/unambiguous the task spec is"},
+					"estimated_tokens": map[string]interface{}{"type": "integer", "description": "Approximate token cost for the run (optional)"},
+				},
+				"required": []string{"title", "squad", "repo"},
+			},
+		},
+		{
+			Name:        "lock_domain",
+			Description: "Acquire an exclusive domain lock before touching a contested surface (file path, branch, or service). Returns ACQUIRED or DENIED with the current holder. Lock auto-expires after ttl_seconds to handle agent crashes.",
+			InputSchema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"domain":      map[string]string{"type": "string", "description": "Lock target: 'file:api/orders/', 'branch:feat/auth', or 'service:payments'"},
+					"holder":      map[string]string{"type": "string", "description": "Agent identity acquiring the lock (e.g. 'sr-octi-pulpo-01')"},
+					"ttl_seconds": map[string]interface{}{"type": "integer", "description": "Lock expiry in seconds (default 900). Set to task max duration to auto-release on crash."},
+				},
+				"required": []string{"domain", "holder"},
+			},
+		},
+		{
+			Name:        "unlock_domain",
+			Description: "Release a domain lock when your task is complete. Only the original holder can release their lock.",
+			InputSchema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"domain": map[string]string{"type": "string", "description": "Domain surface to release (must match what was passed to lock_domain)"},
+					"holder": map[string]string{"type": "string", "description": "Agent identity that holds the lock"},
+				},
+				"required": []string{"domain", "holder"},
+			},
+		},
+		{
+			Name:        "list_domain_locks",
+			Description: "List all currently active domain locks across the swarm. Expired locks are pruned automatically. Use to check for conflicts before starting work.",
+			InputSchema: map[string]interface{}{
+				"type":       "object",
+				"properties": map[string]interface{}{},
 			},
 		},
 	}


### PR DESCRIPTION
## Summary

Implements `internal/admission` — the coordination gate that answers "should this work run NOW?" before dispatch fires. Closes #96.

Three new primitives:

- **Intake scoring** (`admit_task` MCP tool) — evaluates blast radius, spec clarity, reversibility, and estimated token cost; returns `ACCEPT` / `DEFER` / `REJECT` / `ROUTE_TO_PREFLIGHT` with reasoning
- **Concurrency gates** — Redis Lua-backed per-scope max-N limits (by repo, squad, or global); auto-TTL prevents counter leaks on agent crashes
- **Domain locks** (`lock_domain` / `unlock_domain` / `list_domain_locks` MCP tools) — exclusive file-path, branch, and service locks with holder verification and TTL-based auto-release

## New MCP tools

| Tool | Purpose |
|---|---|
| `admit_task` | Score a task before dispatch — returns verdict + reasons |
| `lock_domain` | Acquire exclusive lock on `file:`, `branch:`, or `service:` surface |
| `unlock_domain` | Release your lock when done |
| `list_domain_locks` | Inspect all live locks (expired entries auto-pruned) |

## Scoring thresholds

| Score | Verdict |
|---|---|
| ≥ 0.85 | ACCEPT |
| ≥ 0.50 | DEFER |
| < 0.50 | REJECT |
| clarity < 0.5 (any score) | ROUTE_TO_PREFLIGHT |

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] 15 tests in `internal/admission/` — all pass (requires Redis on `localhost:6379` or `OCTI_REDIS_URL`)
- [ ] Manual: call `admit_task` via MCP with a 25-file spec → verify REJECT
- [ ] Manual: `lock_domain` twice on same branch → second call returns DENIED + holder info

🤖 Generated with [Claude Code](https://claude.com/claude-code)