### PR TITLE
fix(main): wire BudgetStore into WebhookServer and SlackEventHandler

### DIFF
--- a/cmd/octi-pulpo/main.go
+++ b/cmd/octi-pulpo/main.go
@@ -119,6 +119,7 @@ func main() {
 		ws := dispatch.NewWebhookServer(dispatcher, secretFile)
 		ws.SetSprintStore(sprintStore)
 		ws.SetBenchmark(benchmark)
+		ws.SetBudgetStore(budgetStore)
 
 		// Wire Slack Events API command handler when credentials are set.
 		if slackSecret := os.Getenv("SLACK_SIGNING_SECRET"); slackSecret != "" {
@@ -126,6 +127,7 @@ func main() {
 			evHandler := dispatch.NewSlackEventHandler(slackSecret, slackBotToken, dispatcher)
 			evHandler.SetSprintStore(sprintStore)
 			evHandler.SetBenchmark(benchmark)
+			evHandler.SetBudgetStore(budgetStore)
 			if slackURL := os.Getenv("SLACK_WEBHOOK_URL"); slackURL != "" {
 				evHandler.SetNotifier(dispatch.NewNotifier(slackURL))
 			}


### PR DESCRIPTION
## Summary

Follow-up from #89 (budget override command + confidence-gated PAUSE buttons, closes #72).

- Wire `budgetStore` into `WebhookServer` via `ws.SetBudgetStore(budgetStore)`
- Wire `budgetStore` into `SlackEventHandler` via `evHandler.SetBudgetStore(budgetStore)`

Without this wiring, both `budgetStore` fields were `nil` at runtime, causing Slack budget override commands (`/budget set`, `/budget reset`, PAUSE buttons) to fail silently.

## Root cause

PR #89 added `SetBudgetStore` methods to both `WebhookServer` and `SlackEventHandler`, and wired them in tests — but the corresponding calls in `main.go` were missed. The EM flagged this in the merge note for #89.

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [ ] Deploy with `OCTI_HTTP_PORT` + `SLACK_SIGNING_SECRET` set; issue `/budget status` from Slack — should return budget data, not a silent nil-store failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)