### PR TITLE
docs: pipeline case study + README strategy update

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,9 @@ Swarm coordination layer for autonomous agent fleets.
 
 Running multiple AI agents? They step on each other. Duplicate work. Miss handoffs. Waste budget on the wrong model.
 
-**Octi Pulpo** is the coordination brain that sits between your agents and makes them work as a fleet. Every agent connects via MCP — no per-agent changes needed. One binary, sub-millisecond tool responses, zero runtime dependencies beyond Redis.
+**Octi Pulpo** is the coordination brain that turns agent chaos into a managed pipeline. It routes work through standardized stages (Architect → Implement → QA → Review → Release), picks the cheapest capable model for each stage, and scales agent sessions dynamically based on queue depth. One binary, sub-millisecond tool responses, zero runtime dependencies beyond Redis.
+
+> **Case study:** We migrated our own 128-agent swarm from an org chart to a pipeline — [read how](docs/case-study-pipeline-migration.md).
 
 ## The Eight Arms
 
@@ -125,9 +127,13 @@ ShellForge orchestrates. Octi Pulpo coordinates. AgentGuard governs.
 - [x] MCP server with stdio transport
 - [x] Redis-backed coordination (claims, signals)
 - [x] Shared memory store
-- [ ] Budget-aware dispatch (priority queue + adaptive backoff)
+- [x] Budget-aware dispatch (priority queue + adaptive backoff)
+- [x] Model-tier routing (Frontier/Mid/Light/Free)
+- [x] Pipeline controller (5-stage kanban with backpressure)
+- [x] Dynamic session scaling (queue depth → agent count)
+- [x] Slack control plane (dashboard, commands, brief intake, escalation)
+- [x] Admission control (intake scoring, concurrency gates, domain locks)
 - [ ] Vector search for memory recall (Qdrant integration)
-- [ ] Model routing with cost/capability scoring
 - [ ] Dependency resolution (Dagu workflow chains)
 - [ ] Health broadcasting with circuit breaker integration
 - [ ] Multi-box coordination protocol

--- a/docs/case-study-pipeline-migration.md
+++ b/docs/case-study-pipeline-migration.md
@@ -1,0 +1,42 @@
+# Case Study: 128-Agent Org Chart to 5-Stage Pipeline
+
+We migrated a 128-agent swarm from a traditional org chart (9 squads x 5 roles) to a 5-stage kanban pipeline with model-tier routing. Same $320/month budget, 75% fewer active sessions, dramatically less waste.
+
+**Full details:** See `docs/superpowers/specs/2026-03-31-pipeline-orchestration-design.md` in the workspace repo.
+
+## Before
+
+- 9 squads, each with PL/Arch/Sr/Jr/QA
+- 128 fixed agents, many burning Opus on simple work
+- Claude Code budget burned out by Tuesday
+- Copilot/Codex/Gemini sitting 80% idle
+- ~30% rework from merge conflicts and bad specs
+
+## After
+
+```
+Architect (Opus) → Implement (Sonnet) → QA (Free) → Review (Sonnet/Opus) → Release (CI)
+```
+
+- 10-20 dynamic sessions, scaled by queue depth
+- Opus only for design + high-risk review
+- Budget spread across all 5 drivers
+- Backpressure prevents queue flooding
+- GitHub labels track pipeline stage
+
+## Key Numbers
+
+| Metric | Before | After |
+|---|---|---|
+| Active agents | 48 | 12 |
+| Opus sessions | 20+ | 0-3 |
+| Budget runway | Tuesday | Friday |
+| Rework | 30% | 10% |
+
+## Built With
+
+- `internal/pipeline/` — stage machine, queue monitor, backpressure, scaler
+- `internal/routing/modeltier.go` — Frontier/Mid/Light/Free routing
+- `internal/dispatch/pipeline_dispatch.go` — stage→tier→driver
+- `internal/dispatch/slack_pipeline.go` — Slack control plane
+- `cmd/octi-pipeline/` — controller daemon


### PR DESCRIPTION
## Summary
- Adds pipeline migration case study (128-agent org chart → 5-stage kanban)
- Updates README to describe pipeline controller strategy
- Marks 5 roadmap items as shipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)