### PR TITLE
feat(pipeline): QA parallelism, fast-path expansion, spec quality gate (#102 #103 #104)

### DIFF
--- a/cmd/octi-pipeline/main.go
+++ b/cmd/octi-pipeline/main.go
@@ -25,7 +25,7 @@ func main() {
 		},
 		MaxSessions: map[pipeline.Stage]int{
 			pipeline.StageArchitect: 3, pipeline.StageImplement: 8,
-			pipeline.StageQA: 4, pipeline.StageReview: 3,
+			pipeline.StageQA: 8, pipeline.StageReview: 3,
 		},
 		ScaleUpThreshold: map[pipeline.Stage]int{
 			pipeline.StageArchitect: 3, pipeline.StageImplement: 5,

--- a/internal/admission/spec_quality.go
+++ b/internal/admission/spec_quality.go
@@ -1,0 +1,135 @@
+package admission
+
+import "strings"
+
+// ArchitectSpec is the output produced by the architect stage that must be
+// validated before a task advances to stage:implement.
+type ArchitectSpec struct {
+	// Title is the original issue/task title.
+	Title string `json:"title"`
+	// AcceptanceCriteria lists the conditions that must be true for the task
+	// to be considered complete. Required — must have at least one entry.
+	AcceptanceCriteria []string `json:"acceptance_criteria"`
+	// FilesTouched lists the files the implementor is expected to modify.
+	// Required — prevents blind blast-radius surprises.
+	FilesTouched []string `json:"files_touched"`
+	// BlastRadiusEstimate is the architect's estimate of files changed.
+	// Required — used by the admission gate to set concurrency limits.
+	BlastRadiusEstimate int `json:"blast_radius_estimate"`
+	// Approach is a prose description of the implementation strategy.
+	// Required — must be non-empty and specific (no generic placeholder text).
+	Approach string `json:"approach"`
+}
+
+// SpecQualityResult is the output of ScoreSpec.
+type SpecQualityResult struct {
+	// Ready is true when the spec passes all quality checks.
+	Ready bool `json:"ready"`
+	// Score is a 0.0–1.0 composite where 1.0 means all fields are present
+	// and complete. Score < 0.7 routes back to stage:architect with feedback.
+	Score float64 `json:"score"`
+	// Missing lists the field names that are absent or incomplete.
+	Missing []string `json:"missing,omitempty"`
+	// Feedback is a human-readable message to send back to the architect agent.
+	Feedback string `json:"feedback"`
+}
+
+// ambiguousPlaceholders are strings that indicate an architect placeholder rather
+// than a real approach description.
+var ambiguousPlaceholders = []string{
+	"tbd", "todo", "n/a", "see issue", "fix it", "implement it",
+	"as needed", "per spec", "standard approach",
+}
+
+// ScoreSpec evaluates an architect's output spec and returns a quality verdict.
+// A spec must pass all four required-field checks to be Ready:
+//  1. At least one acceptance criterion
+//  2. At least one file listed in files_touched
+//  3. A non-zero blast radius estimate
+//  4. A non-empty, non-placeholder approach description
+//
+// Score < 0.7 → send back to stage:architect with Feedback.
+// Score ≥ 0.7 → advance to stage:implement.
+func ScoreSpec(spec ArchitectSpec) SpecQualityResult {
+	score := 1.0
+	var missing []string
+
+	if len(spec.AcceptanceCriteria) == 0 {
+		score -= 0.30
+		missing = append(missing, "acceptance_criteria")
+	}
+
+	if len(spec.FilesTouched) == 0 {
+		score -= 0.25
+		missing = append(missing, "files_touched")
+	}
+
+	if spec.BlastRadiusEstimate == 0 {
+		score -= 0.20
+		missing = append(missing, "blast_radius_estimate")
+	}
+
+	if isAmbiguousApproach(spec.Approach) {
+		score -= 0.25
+		missing = append(missing, "approach")
+	}
+
+	ready := len(missing) == 0 && score >= 0.7
+	feedback := buildFeedback(spec.Title, missing)
+
+	return SpecQualityResult{
+		Ready:    ready,
+		Score:    score,
+		Missing:  missing,
+		Feedback: feedback,
+	}
+}
+
+// isAmbiguousApproach returns true when the approach is empty or contains only
+// generic placeholder text that provides no real implementation guidance.
+func isAmbiguousApproach(approach string) bool {
+	trimmed := strings.TrimSpace(approach)
+	if trimmed == "" {
+		return true
+	}
+	lower := strings.ToLower(trimmed)
+	for _, placeholder := range ambiguousPlaceholders {
+		if strings.Contains(lower, placeholder) {
+			return true
+		}
+	}
+	// Very short approaches (< 20 chars) are likely placeholders
+	return len(trimmed) < 20
+}
+
+func buildFeedback(title string, missing []string) string {
+	if len(missing) == 0 {
+		return "spec is complete — ready for stage:implement"
+	}
+	var b strings.Builder
+	b.WriteString("spec for ")
+	if title != "" {
+		b.WriteString("\"")
+		b.WriteString(title)
+		b.WriteString("\" ")
+	}
+	b.WriteString("is incomplete — missing: ")
+	b.WriteString(strings.Join(missing, ", "))
+	b.WriteString(". Please add: ")
+	for i, field := range missing {
+		switch field {
+		case "acceptance_criteria":
+			b.WriteString("at least one acceptance criterion")
+		case "files_touched":
+			b.WriteString("list of files the implementor should modify")
+		case "blast_radius_estimate":
+			b.WriteString("estimated number of files changed")
+		case "approach":
+			b.WriteString("a specific implementation approach (not a placeholder)")
+		}
+		if i < len(missing)-1 {
+			b.WriteString("; ")
+		}
+	}
+	return b.String()
+}

--- a/internal/admission/spec_quality_test.go
+++ b/internal/admission/spec_quality_test.go
@@ -1,0 +1,151 @@
+package admission
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestScoreSpec_AllFieldsPresent(t *testing.T) {
+	spec := ArchitectSpec{
+		Title:               "Add rate limiting to API",
+		AcceptanceCriteria:  []string{"requests over limit return 429", "headers include X-RateLimit-*"},
+		FilesTouched:        []string{"internal/api/middleware.go", "internal/api/middleware_test.go"},
+		BlastRadiusEstimate: 2,
+		Approach:            "Implement a token-bucket middleware using Redis INCR with a 60s expiry key per user.",
+	}
+	result := ScoreSpec(spec)
+	if !result.Ready {
+		t.Errorf("expected Ready=true, got feedback: %s", result.Feedback)
+	}
+	if result.Score < 0.99 {
+		t.Errorf("expected score ~1.0, got %.2f", result.Score)
+	}
+	if len(result.Missing) != 0 {
+		t.Errorf("expected no missing fields, got %v", result.Missing)
+	}
+}
+
+func TestScoreSpec_MissingAcceptanceCriteria(t *testing.T) {
+	spec := ArchitectSpec{
+		Title:               "Fix login bug",
+		AcceptanceCriteria:  nil,
+		FilesTouched:        []string{"internal/auth/login.go"},
+		BlastRadiusEstimate: 1,
+		Approach:            "Check the session token expiry logic in validateSession and extend the window.",
+	}
+	result := ScoreSpec(spec)
+	if result.Ready {
+		t.Error("expected Ready=false when acceptance_criteria is empty")
+	}
+	if !contains(result.Missing, "acceptance_criteria") {
+		t.Errorf("expected 'acceptance_criteria' in Missing, got %v", result.Missing)
+	}
+}
+
+func TestScoreSpec_MissingFilesTouched(t *testing.T) {
+	spec := ArchitectSpec{
+		Title:               "Refactor DB layer",
+		AcceptanceCriteria:  []string{"all queries use prepared statements"},
+		FilesTouched:        nil,
+		BlastRadiusEstimate: 5,
+		Approach:            "Replace raw sql.Query calls with sqlx.NamedQuery across the repository layer.",
+	}
+	result := ScoreSpec(spec)
+	if result.Ready {
+		t.Error("expected Ready=false when files_touched is empty")
+	}
+	if !contains(result.Missing, "files_touched") {
+		t.Errorf("expected 'files_touched' in Missing, got %v", result.Missing)
+	}
+}
+
+func TestScoreSpec_ZeroBlastRadius(t *testing.T) {
+	spec := ArchitectSpec{
+		Title:               "Update config",
+		AcceptanceCriteria:  []string{"config loads correctly"},
+		FilesTouched:        []string{"config/app.yaml"},
+		BlastRadiusEstimate: 0,
+		Approach:            "Add a new timeout_seconds field to the YAML config and wire it through AppConfig.",
+	}
+	result := ScoreSpec(spec)
+	if result.Ready {
+		t.Error("expected Ready=false when blast_radius_estimate is 0")
+	}
+	if !contains(result.Missing, "blast_radius_estimate") {
+		t.Errorf("expected 'blast_radius_estimate' in Missing, got %v", result.Missing)
+	}
+}
+
+func TestScoreSpec_AmbiguousApproach(t *testing.T) {
+	tests := []struct {
+		approach string
+		desc     string
+	}{
+		{"", "empty"},
+		{"TBD", "TBD placeholder"},
+		{"fix it", "generic fix it"},
+		{"TODO", "TODO placeholder"},
+		{"short", "too short"},
+		{"As needed", "as needed placeholder"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.desc, func(t *testing.T) {
+			spec := ArchitectSpec{
+				Title:               "Do something",
+				AcceptanceCriteria:  []string{"it works"},
+				FilesTouched:        []string{"main.go"},
+				BlastRadiusEstimate: 1,
+				Approach:            tc.approach,
+			}
+			result := ScoreSpec(spec)
+			if result.Ready {
+				t.Errorf("expected Ready=false for ambiguous approach %q", tc.approach)
+			}
+			if !contains(result.Missing, "approach") {
+				t.Errorf("expected 'approach' in Missing for %q, got %v", tc.approach, result.Missing)
+			}
+		})
+	}
+}
+
+func TestScoreSpec_FeedbackMessageWhenIncomplete(t *testing.T) {
+	spec := ArchitectSpec{
+		Title: "Add caching",
+	}
+	result := ScoreSpec(spec)
+	if result.Ready {
+		t.Error("expected Ready=false for empty spec")
+	}
+	if result.Feedback == "" {
+		t.Error("expected non-empty feedback when spec is incomplete")
+	}
+	if !strings.Contains(result.Feedback, "acceptance_criteria") {
+		t.Error("expected feedback to mention acceptance_criteria")
+	}
+}
+
+func TestScoreSpec_FeedbackWhenComplete(t *testing.T) {
+	spec := ArchitectSpec{
+		Title:               "Migrate DB schema",
+		AcceptanceCriteria:  []string{"migration runs idempotently", "rollback reverts all changes"},
+		FilesTouched:        []string{"migrations/003_add_index.sql", "internal/db/migrate.go"},
+		BlastRadiusEstimate: 2,
+		Approach:            "Write an up/down migration for the new composite index; wire into the CLI migrate command.",
+	}
+	result := ScoreSpec(spec)
+	if !result.Ready {
+		t.Errorf("expected Ready=true, got: %s", result.Feedback)
+	}
+	if !strings.Contains(result.Feedback, "ready for stage:implement") {
+		t.Errorf("expected success feedback, got: %s", result.Feedback)
+	}
+}
+
+func contains(ss []string, s string) bool {
+	for _, v := range ss {
+		if v == s {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -799,6 +799,15 @@ func (s *Server) handleToolCall(req Request) Response {
 		data, _ := json.Marshal(score)
 		return textResult(req.ID, string(data))
 
+	case "score_spec":
+		var args admission.ArchitectSpec
+		if err := json.Unmarshal(params.Arguments, &args); err != nil {
+			return errorResp(req.ID, -32602, "invalid arguments: "+err.Error())
+		}
+		result := admission.ScoreSpec(args)
+		data, _ := json.Marshal(result)
+		return textResult(req.ID, string(data))
+
 	case "lock_domain":
 		if s.admissionGate == nil {
 			return errorResp(req.ID, -32000, "admission gate not initialized")
@@ -1282,6 +1291,21 @@ func toolDefs() []ToolDef {
 					"estimated_tokens": map[string]interface{}{"type": "integer", "description": "Approximate token cost for the run (optional)"},
 				},
 				"required": []string{"title", "squad", "repo"},
+			},
+		},
+		{
+			Name:        "score_spec",
+			Description: "Score an architect-stage spec for completeness before advancing to stage:implement. Checks for acceptance criteria, files to touch, blast radius estimate, and a non-ambiguous approach. Returns Ready=true when all fields pass; Ready=false includes a Feedback message to send back to the architect agent.",
+			InputSchema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"title":                map[string]string{"type": "string", "description": "Original issue/task title"},
+					"acceptance_criteria":  map[string]interface{}{"type": "array", "items": map[string]string{"type": "string"}, "description": "Conditions that must be true for the task to be complete (at least one required)"},
+					"files_touched":        map[string]interface{}{"type": "array", "items": map[string]string{"type": "string"}, "description": "Files the implementor should modify (at least one required)"},
+					"blast_radius_estimate": map[string]interface{}{"type": "integer", "description": "Architect's estimate of total files changed"},
+					"approach":             map[string]string{"type": "string", "description": "Specific implementation strategy (not a placeholder)"},
+				},
+				"required": []string{"title"},
 			},
 		},
 		{

--- a/internal/sprint/fastpath_test.go
+++ b/internal/sprint/fastpath_test.go
@@ -1,0 +1,76 @@
+package sprint
+
+import "testing"
+
+func TestClassifyFastPath_LabelMatch(t *testing.T) {
+	cases := []struct {
+		labels []string
+		want   bool
+		desc   string
+	}{
+		{[]string{"dependency"}, true, "dependency label"},
+		{[]string{"dependencies"}, true, "dependencies label"},
+		{[]string{"test"}, true, "test label"},
+		{[]string{"tests"}, true, "tests label"},
+		{[]string{"documentation"}, true, "documentation label"},
+		{[]string{"doc"}, true, "doc label"},
+		{[]string{"docs"}, true, "docs label"},
+		{[]string{"lint"}, true, "lint label"},
+		{[]string{"good-first-issue"}, true, "good-first-issue label"},
+		{[]string{"chore"}, true, "chore label"},
+		{[]string{"formatting"}, true, "formatting label"},
+		{[]string{"bug", "P1"}, false, "no fast-path label"},
+		{[]string{}, false, "no labels"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.desc, func(t *testing.T) {
+			got := classifyFastPath("some issue title", tc.labels)
+			if got != tc.want {
+				t.Errorf("classifyFastPath(%v) = %v, want %v", tc.labels, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestClassifyFastPath_TitleMatch(t *testing.T) {
+	cases := []struct {
+		title string
+		want  bool
+		desc  string
+	}{
+		{"bump go-redis to v9.4.0", true, "bump dependency"},
+		{"upgrade redis client", true, "upgrade dependency"},
+		{"update dependency versions", true, "update dependency"},
+		{"add tests for auth module", true, "add tests"},
+		{"add test coverage for budget store", true, "add test coverage"},
+		{"increase coverage for internal/mcp", true, "increase coverage"},
+		{"fix typo in README", true, "fix typo"},
+		{"fix comment in dispatch.go", true, "fix comment"},
+		{"update readme with new API", true, "update readme"},
+		{"add documentation for routing", true, "add documentation"},
+		{"lint fix for internal packages", true, "lint fix"},
+		{"format internal/sprint package", true, "format"},
+		{"implement new feature X", false, "regular feature"},
+		{"refactor dispatch layer", false, "refactor"},
+		{"fix critical bug in auth", false, "bug fix (not titled as fast-path)"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.desc, func(t *testing.T) {
+			got := classifyFastPath(tc.title, nil)
+			if got != tc.want {
+				t.Errorf("classifyFastPath(%q, nil) = %v, want %v", tc.title, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestIsFastPath_DelegatesToField(t *testing.T) {
+	fp := SprintItem{FastPath: true}
+	if !IsFastPath(fp) {
+		t.Error("expected IsFastPath=true for item with FastPath=true")
+	}
+	notFp := SprintItem{FastPath: false}
+	if IsFastPath(notFp) {
+		t.Error("expected IsFastPath=false for item with FastPath=false")
+	}
+}

--- a/internal/sprint/store.go
+++ b/internal/sprint/store.go
@@ -35,6 +35,59 @@ type SprintItem struct {
 	GoalID       string   `json:"goal_id,omitempty"`
 	ParentGoalID string   `json:"parent_goal_id,omitempty"`
 	GoalAncestry []string `json:"goal_ancestry,omitempty"`
+	// FastPath marks items that can skip the architect stage and go directly
+	// to stage:implement at Mid/Light tier. Detected from GitHub labels and
+	// title patterns during Sync.
+	FastPath bool `json:"fast_path,omitempty"`
+}
+
+// fastPathLabels are GitHub label names that qualify an issue for the fast-path.
+// These tasks have well-understood patterns and don't need architect-stage planning.
+var fastPathLabels = map[string]bool{
+	"dependency":     true,
+	"dependencies":   true,
+	"test":           true,
+	"tests":          true,
+	"documentation":  true,
+	"doc":            true,
+	"docs":           true,
+	"lint":           true,
+	"formatting":     true,
+	"good-first-issue": true,
+	"chore":          true,
+}
+
+// fastPathTitleKeywords are substrings in an issue title that indicate a fast-path task.
+var fastPathTitleKeywords = []string{
+	"bump ", "upgrade ", "update dependency", "update dependencies",
+	"add test", "add tests", "test coverage", "increase coverage",
+	"fix typo", "fix comment", "update comment", "update docs",
+	"update readme", "add docs", "add documentation",
+	"lint fix", "fix lint", "run linter", "format ",
+}
+
+// IsFastPath reports whether a sprint item can skip the architect stage.
+// Items are fast-path when labeled as dependency/test/doc/lint/good-first-issue,
+// or when the title matches a known low-complexity pattern.
+func IsFastPath(item SprintItem) bool {
+	return item.FastPath
+}
+
+// classifyFastPath detects whether an issue should be treated as fast-path
+// based on its GitHub labels and title.
+func classifyFastPath(title string, labels []string) bool {
+	titleLower := strings.ToLower(title)
+	for _, kw := range fastPathTitleKeywords {
+		if strings.Contains(titleLower, kw) {
+			return true
+		}
+	}
+	for _, lbl := range labels {
+		if fastPathLabels[strings.ToLower(lbl)] {
+			return true
+		}
+	}
+	return false
 }
 
 // Store manages sprint items in Redis, synced from GitHub issues.
@@ -150,6 +203,12 @@ func (s *Store) Sync(ctx context.Context, repo string) error {
 		// Infer squad from repo
 		squad := inferSquadFromRepo(repo)
 
+		// Collect label names for fast-path detection
+		labelNames := make([]string, len(issue.Labels))
+		for i, lbl := range issue.Labels {
+			labelNames[i] = lbl.Name
+		}
+
 		// Check if item already exists (preserve status)
 		key := s.itemKey(repo, issue.Number)
 		existing, _ := s.rdb.Get(ctx, key).Result()
@@ -163,6 +222,7 @@ func (s *Store) Sync(ctx context.Context, repo string) error {
 			AssignTo:  assignTo,
 			Status:    "open",
 			UpdatedAt: now,
+			FastPath:  classifyFastPath(issue.Title, labelNames),
 		}
 
 		// Preserve status from existing item if it was already tracked
@@ -367,6 +427,50 @@ func (s *Store) NextDispatchable(ctx context.Context) ([]SprintItem, error) {
 	})
 
 	return dispatchable, nil
+}
+
+// NextFastPath returns open sprint items that can skip the architect stage
+// (dependency bumps, test additions, doc updates, lint fixes, good-first-issues).
+// Results are sorted by priority then issue number. These items go directly to
+// stage:implement at Mid/Light tier, freeing Frontier budget for complex work.
+func (s *Store) NextFastPath(ctx context.Context) ([]SprintItem, error) {
+	all, err := s.GetAll(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	doneSet := make(map[int]bool)
+	for _, item := range all {
+		if item.Status == "done" {
+			doneSet[item.IssueNum] = true
+		}
+	}
+
+	var fastPath []SprintItem
+	for _, item := range all {
+		if item.Status != "open" || !item.FastPath {
+			continue
+		}
+		depsMet := true
+		for _, dep := range item.DependsOn {
+			if !doneSet[dep] {
+				depsMet = false
+				break
+			}
+		}
+		if depsMet {
+			fastPath = append(fastPath, item)
+		}
+	}
+
+	sort.Slice(fastPath, func(i, j int) bool {
+		if fastPath[i].Priority != fastPath[j].Priority {
+			return fastPath[i].Priority < fastPath[j].Priority
+		}
+		return fastPath[i].IssueNum < fastPath[j].IssueNum
+	})
+
+	return fastPath, nil
 }
 
 // UpdateStatus updates the status of a sprint item.


### PR DESCRIPTION
## Summary

Addresses three "do first" issues from pipeline benchmark analysis:

- **#104** — QA max sessions 4→8: free tier, near-zero cost. Eliminates the QA→Review bottleneck that starves Review stage.
- **#103** — Fast-path expansion: `SprintItem.FastPath` flag set during `Sync()` from GitHub labels (`dependency`, `test`, `doc`, `lint`, `chore`, `good-first-issue`) and title keywords (`bump`, `add tests`, `fix typo`, etc.). `NextFastPath()` lets the brain dispatch these directly to `stage:implement` at Mid/Light tier — architect Frontier budget preserved for complex work.
- **#102** — Spec quality gate: `admission.ScoreSpec()` validates architect output (acceptance criteria, files to touch, blast radius estimate, non-ambiguous approach) before `stage:implement` transition. Exposed as `score_spec` MCP tool. Returns structured `Feedback` to route incomplete specs back to architect.

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] 467 tests pass (+44 new vs baseline of 423)
- [x] `TestScoreSpec_*` — 7 cases covering all missing fields + feedback messages
- [x] `TestClassifyFastPath_*` — label + title detection, 28 sub-cases
- [x] `TestIsFastPath_DelegatesToField` — contract test

Closes #102
Closes #103
Closes #104

🤖 Generated with [Claude Code](https://claude.com/claude-code)