### PR TITLE
feat: auto-promote Copilot draft PRs to ready-for-review

### DIFF
--- a/internal/dispatch/draft_converter.go
+++ b/internal/dispatch/draft_converter.go
@@ -67,14 +67,31 @@ func ShouldConvert(author, title string, isDraft bool, action string) bool {
 }
 
 // containsWIP returns true if the title contains a WIP marker.
-// Recognised patterns: "WIP", "wip", "[WIP]", "[wip]".
+// Recognised patterns: standalone "WIP" / "wip" word or bracketed "[WIP]" / "[wip]" prefix.
 func containsWIP(title string) bool {
-	return strings.Contains(strings.ToLower(title), "wip")
+	lower := strings.ToLower(title)
+	// Match "[wip]" anywhere in the title (bracketed form).
+	if strings.Contains(lower, "[wip]") {
+		return true
+	}
+	// Match "wip" as a standalone word or colon-prefixed marker (e.g. "wip: ..." or "wip ").
+	for _, part := range strings.Fields(lower) {
+		// Strip trailing punctuation common in prefixes like "wip:"
+		word := strings.TrimRight(part, ":,")
+		if word == "wip" {
+			return true
+		}
+	}
+	return false
 }
 
 // ConvertToReady promotes a draft PR to ready-for-review via the GitHub API.
 // This is equivalent to running `gh pr ready <number>` from the CLI.
 func (dc *DraftConverter) ConvertToReady(ctx context.Context, repo string, prNumber int) (*DraftConvertResult, error) {
+	if dc.ghToken == "" {
+		return nil, fmt.Errorf("GITHUB_TOKEN not set: cannot convert PR #%d to ready-for-review", prNumber)
+	}
+
 	result := &DraftConvertResult{
 		PRNumber: prNumber,
 		Repo:     repo,
@@ -83,7 +100,10 @@ func (dc *DraftConverter) ConvertToReady(ctx context.Context, repo string, prNum
 	// GitHub GraphQL convertPullRequestToDraft inverse: use the REST "ready for review" endpoint.
 	// PATCH /repos/{owner}/{repo}/pulls/{pull_number}  with {"draft": false}
 	apiURL := fmt.Sprintf("%s/repos/%s/pulls/%d", dc.baseURL, repo, prNumber)
-	body, _ := json.Marshal(map[string]bool{"draft": false})
+	body, err := json.Marshal(map[string]bool{"draft": false})
+	if err != nil {
+		return nil, fmt.Errorf("marshal body: %w", err)
+	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPatch, apiURL, bytes.NewReader(body))
 	if err != nil {

--- a/internal/dispatch/draft_converter_test.go
+++ b/internal/dispatch/draft_converter_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 )
 
@@ -114,7 +115,7 @@ func TestContainsWIP(t *testing.T) {
 		{"[WIP] something", true},
 		{"[wip] something", true},
 		{"feat: add something", false},
-		{"fix: wipeable bug", true}, // contains "wip" substring
+		{"fix: wipeable bug", false}, // "wip" is only a substring, not a standalone word
 		{"", false},
 	}
 	for _, c := range cases {
@@ -136,16 +137,21 @@ func newTestDraftConverter(serverURL, token string) *DraftConverter {
 
 // TestConvertToReady verifies the GitHub API call for converting a draft PR.
 func TestConvertToReady(t *testing.T) {
+	var mu sync.Mutex
 	var capturedMethod string
 	var capturedPath string
 	var capturedBody map[string]interface{}
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		capturedMethod = r.Method
-		capturedPath = r.URL.Path
-		if err := json.NewDecoder(r.Body).Decode(&capturedBody); err != nil {
+		var body map[string]interface{}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 			t.Errorf("decode body: %v", err)
 		}
+		mu.Lock()
+		capturedMethod = r.Method
+		capturedPath = r.URL.Path
+		capturedBody = body
+		mu.Unlock()
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		json.NewEncoder(w).Encode(map[string]interface{}{ //nolint:errcheck
@@ -167,15 +173,22 @@ func TestConvertToReady(t *testing.T) {
 	if result.PRNumber != 42 {
 		t.Errorf("PRNumber = %d, want 42", result.PRNumber)
 	}
-	if capturedMethod != http.MethodPatch {
-		t.Errorf("method = %s, want PATCH", capturedMethod)
+
+	mu.Lock()
+	method := capturedMethod
+	path := capturedPath
+	body := capturedBody
+	mu.Unlock()
+
+	if method != http.MethodPatch {
+		t.Errorf("method = %s, want PATCH", method)
 	}
-	if capturedPath != "/repos/AgentGuardHQ/octi-pulpo/pulls/42" {
-		t.Errorf("path = %s, want /repos/AgentGuardHQ/octi-pulpo/pulls/42", capturedPath)
+	if path != "/repos/AgentGuardHQ/octi-pulpo/pulls/42" {
+		t.Errorf("path = %s, want /repos/AgentGuardHQ/octi-pulpo/pulls/42", path)
 	}
-	draftVal, ok := capturedBody["draft"].(bool)
+	draftVal, ok := body["draft"].(bool)
 	if !ok || draftVal != false {
-		t.Errorf("body draft = %v, want false", capturedBody["draft"])
+		t.Errorf("body draft = %v, want false", body["draft"])
 	}
 }
 
@@ -192,6 +205,18 @@ func TestConvertToReadyAPIError(t *testing.T) {
 	_, err := dc.ConvertToReady(context.Background(), "AgentGuardHQ/octi-pulpo", 99)
 	if err == nil {
 		t.Fatal("expected error, got nil")
+	}
+}
+
+// TestConvertToReadyNoToken verifies that ConvertToReady returns an error when no token is set.
+func TestConvertToReadyNoToken(t *testing.T) {
+	dc := NewDraftConverter("") // no token, no GITHUB_TOKEN env var
+	// Unset any env-provided token to ensure the empty path is exercised.
+	dc.ghToken = ""
+
+	_, err := dc.ConvertToReady(context.Background(), "AgentGuardHQ/octi-pulpo", 1)
+	if err == nil {
+		t.Fatal("expected error for missing token, got nil")
 	}
 }
 

--- a/internal/dispatch/webhook.go
+++ b/internal/dispatch/webhook.go
@@ -232,7 +232,9 @@ func (ws *WebhookServer) handleWebhook(w http.ResponseWriter, r *http.Request) {
 
 		if ShouldConvert(author, title, isDraft, action) {
 			go func() {
-				result, err := ws.draftConverter.ConvertToReady(context.Background(), repo, prNumber)
+				ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+				defer cancel()
+				result, err := ws.draftConverter.ConvertToReady(ctx, repo, prNumber)
 				if err != nil {
 					fmt.Fprintf(os.Stderr, "[octi-pulpo] draft-convert error PR #%d: %v\n", prNumber, err)
 				} else {


### PR DESCRIPTION
- [x] Add early-return error when `ghToken` is empty in `ConvertToReady`
- [x] Handle `json.Marshal` error instead of ignoring it
- [x] Tighten `containsWIP` to avoid false positives (e.g. "wipeable") — use word-boundary/prefix patterns
- [x] Use `context.WithTimeout` (30s) instead of `context.Background()` for the goroutine in `webhook.go`
- [x] Fix race condition in `TestConvertToReady` — synchronize captured request data with mutex
- [x] Update `TestContainsWIP` to reflect tightened WIP matching (remove "wipeable" false-positive case)
- [x] Add `TestConvertToReadyNoToken` for empty-token path
- [x] All tests pass with race detector (`go test -race ./internal/dispatch/...`)