### PR TITLE
feat: Copilot fix loop — auto-post @copilot on review changes

### DIFF
--- a/internal/dispatch/copilot_fix.go
+++ b/internal/dispatch/copilot_fix.go
@@ -1,0 +1,127 @@
+package dispatch
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+
+	"github.com/redis/go-redis/v9"
+)
+
+const (
+	copilotFixComment   = "@copilot apply changes based on the comments in this thread"
+	copilotEscalComment = "⚠️ Copilot fix loop: 2 attempts failed. Needs human review."
+	defaultMaxAttempts  = 2
+)
+
+// copilotRedis is a narrow interface covering the Redis commands used by
+// CopilotFixLoop. *redis.Client and *redis.ClusterClient both satisfy it,
+// and it is easy to mock in tests without implementing the full redis.Cmdable.
+type copilotRedis interface {
+	Incr(ctx context.Context, key string) *redis.IntCmd
+	Del(ctx context.Context, keys ...string) *redis.IntCmd
+}
+
+// CopilotFixLoop auto-triggers Copilot fixes when PR reviews request changes.
+type CopilotFixLoop struct {
+	ghToken     string
+	rdb         copilotRedis // for tracking attempt counts
+	baseURL     string       // GitHub API base URL (for testing)
+	maxAttempts int
+}
+
+// NewCopilotFixLoop creates the fix loop handler.
+func NewCopilotFixLoop(ghToken string, rdb redis.Cmdable) *CopilotFixLoop {
+	return &CopilotFixLoop{
+		ghToken:     ghToken,
+		rdb:         rdb,
+		baseURL:     "https://api.github.com",
+		maxAttempts: defaultMaxAttempts,
+	}
+}
+
+// HandleReview processes a pull_request_review event.
+// If changes are requested, posts @copilot comment (up to maxAttempts).
+// If approved or merged, resets the counter.
+func (c *CopilotFixLoop) HandleReview(ctx context.Context, repo string, prNumber int, reviewState string) error {
+	switch reviewState {
+	case "approved":
+		return c.ResetAttempts(ctx, repo, prNumber)
+	case "changes_requested":
+		return c.handleChangesRequested(ctx, repo, prNumber)
+	default:
+		// "commented" or any other state — do nothing
+		return nil
+	}
+}
+
+func (c *CopilotFixLoop) handleChangesRequested(ctx context.Context, repo string, prNumber int) error {
+	key := c.attemptKey(repo, prNumber)
+
+	// Increment attempt counter atomically
+	count, err := c.rdb.Incr(ctx, key).Result()
+	if err != nil {
+		return fmt.Errorf("copilot-fix: increment attempt counter: %w", err)
+	}
+
+	if count > int64(c.maxAttempts) {
+		// Already posted escalation — do not spam
+		return nil
+	}
+
+	if count == int64(c.maxAttempts) {
+		// Exactly at the limit: post escalation comment
+		return c.postComment(ctx, repo, prNumber, copilotEscalComment)
+	}
+
+	// Under the limit: post the @copilot trigger comment
+	return c.postComment(ctx, repo, prNumber, copilotFixComment)
+}
+
+// ResetAttempts clears the fix counter (call when PR is approved or merged).
+func (c *CopilotFixLoop) ResetAttempts(ctx context.Context, repo string, prNumber int) error {
+	key := c.attemptKey(repo, prNumber)
+	if err := c.rdb.Del(ctx, key).Err(); err != nil {
+		return fmt.Errorf("copilot-fix: reset attempt counter: %w", err)
+	}
+	return nil
+}
+
+// postComment posts a comment on a PR via the GitHub API.
+func (c *CopilotFixLoop) postComment(ctx context.Context, repo string, prNumber int, body string) error {
+	url := fmt.Sprintf("%s/repos/%s/issues/%d/comments", c.baseURL, repo, prNumber)
+
+	payload, err := json.Marshal(map[string]string{"body": body})
+	if err != nil {
+		return fmt.Errorf("copilot-fix: marshal comment: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(payload))
+	if err != nil {
+		return fmt.Errorf("copilot-fix: build request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+c.ghToken)
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("copilot-fix: post comment: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 300 {
+		respBody, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("copilot-fix: GitHub API %d: %s", resp.StatusCode, string(respBody))
+	}
+	return nil
+}
+
+// attemptKey returns the Redis key for tracking fix attempts.
+func (c *CopilotFixLoop) attemptKey(repo string, prNumber int) string {
+	return "octi:copilot-fix:" + repo + ":" + strconv.Itoa(prNumber)
+}

--- a/internal/dispatch/copilot_fix_test.go
+++ b/internal/dispatch/copilot_fix_test.go
@@ -1,0 +1,264 @@
+package dispatch
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+// --- minimal Redis mock implementing redis.Cmdable ---
+
+// mockRedis is a minimal in-memory implementation of the redis.Cmdable interface
+// for the subset of commands used by CopilotFixLoop (Incr, Del).
+//
+// redis.Cmdable is a large interface; we implement it by embedding a
+// *redis.Client (nil) and overriding just the methods we use. Any call to an
+// unimplemented method will panic, which is fine for tests — it means we're
+// calling something unexpected.
+type mockRedis struct {
+	mu      sync.Mutex
+	counters map[string]int64
+}
+
+func newMockRedis() *mockRedis {
+	return &mockRedis{counters: make(map[string]int64)}
+}
+
+func (m *mockRedis) get(key string) int64 {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.counters[key]
+}
+
+// Incr increments the key and returns an *redis.IntCmd with the new value.
+func (m *mockRedis) Incr(ctx context.Context, key string) *redis.IntCmd {
+	m.mu.Lock()
+	m.counters[key]++
+	val := m.counters[key]
+	m.mu.Unlock()
+
+	cmd := redis.NewIntCmd(ctx)
+	cmd.SetVal(val)
+	return cmd
+}
+
+// Del deletes the given keys and returns an *redis.IntCmd.
+func (m *mockRedis) Del(ctx context.Context, keys ...string) *redis.IntCmd {
+	m.mu.Lock()
+	var deleted int64
+	for _, k := range keys {
+		if _, ok := m.counters[k]; ok {
+			delete(m.counters, k)
+			deleted++
+		}
+	}
+	m.mu.Unlock()
+
+	cmd := redis.NewIntCmd(ctx)
+	cmd.SetVal(deleted)
+	return cmd
+}
+
+// newCopilotFixLoopForTest constructs a CopilotFixLoop pointing at the given
+// test server URL so we can capture GitHub API calls.
+func newCopilotFixLoopForTest(ghToken string, rdb *mockRedis, baseURL string) *CopilotFixLoop {
+	return &CopilotFixLoop{
+		ghToken:     ghToken,
+		rdb:         rdb,
+		baseURL:     baseURL,
+		maxAttempts: defaultMaxAttempts,
+	}
+}
+
+// --- helpers ---
+
+// capturedComment records the JSON body sent to the GitHub API mock.
+type capturedComment struct {
+	Body string `json:"body"`
+}
+
+// newGHMock returns a test server that records PR comment POST requests.
+func newGHMock(t *testing.T) (*httptest.Server, *[]capturedComment) {
+	t.Helper()
+	var comments []capturedComment
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("unexpected method %s", r.Method)
+			http.Error(w, "bad method", http.StatusMethodNotAllowed)
+			return
+		}
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("read body: %v", err)
+			http.Error(w, "read error", http.StatusInternalServerError)
+			return
+		}
+		var c capturedComment
+		if err := json.Unmarshal(body, &c); err != nil {
+			t.Errorf("unmarshal body: %v", err)
+			http.Error(w, "bad json", http.StatusBadRequest)
+			return
+		}
+		comments = append(comments, c)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		w.Write([]byte(`{"id":1}`))
+	}))
+	t.Cleanup(srv.Close)
+	return srv, &comments
+}
+
+// --- tests ---
+
+// TestCopilotFix_ChangesRequested_PostsComment verifies that a changes_requested
+// review causes the @copilot trigger comment to be posted.
+func TestCopilotFix_ChangesRequested_PostsComment(t *testing.T) {
+	srv, comments := newGHMock(t)
+	rdb := newMockRedis()
+	fix := newCopilotFixLoopForTest("tok", rdb, srv.URL)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if err := fix.HandleReview(ctx, "owner/repo", 42, "changes_requested"); err != nil {
+		t.Fatalf("HandleReview: %v", err)
+	}
+
+	if len(*comments) != 1 {
+		t.Fatalf("expected 1 comment posted, got %d", len(*comments))
+	}
+	if (*comments)[0].Body != copilotFixComment {
+		t.Errorf("expected @copilot comment, got %q", (*comments)[0].Body)
+	}
+}
+
+// TestCopilotFix_ChangesRequested_IncrementsCounter verifies the Redis counter
+// is incremented on each changes_requested review.
+func TestCopilotFix_ChangesRequested_IncrementsCounter(t *testing.T) {
+	srv, _ := newGHMock(t)
+	rdb := newMockRedis()
+	fix := newCopilotFixLoopForTest("tok", rdb, srv.URL)
+
+	ctx := context.Background()
+	key := fix.attemptKey("owner/repo", 7)
+
+	_ = fix.HandleReview(ctx, "owner/repo", 7, "changes_requested")
+	if got := rdb.get(key); got != 1 {
+		t.Errorf("after 1st review: counter=%d, want 1", got)
+	}
+
+	_ = fix.HandleReview(ctx, "owner/repo", 7, "changes_requested")
+	if got := rdb.get(key); got != 2 {
+		t.Errorf("after 2nd review: counter=%d, want 2", got)
+	}
+}
+
+// TestCopilotFix_Escalation verifies that after maxAttempts the escalation
+// comment is posted instead of the @copilot trigger.
+func TestCopilotFix_Escalation(t *testing.T) {
+	srv, comments := newGHMock(t)
+	rdb := newMockRedis()
+	fix := newCopilotFixLoopForTest("tok", rdb, srv.URL)
+
+	ctx := context.Background()
+
+	// First attempt: @copilot comment
+	if err := fix.HandleReview(ctx, "owner/repo", 10, "changes_requested"); err != nil {
+		t.Fatalf("attempt 1: %v", err)
+	}
+	// Second attempt (== maxAttempts): escalation comment
+	if err := fix.HandleReview(ctx, "owner/repo", 10, "changes_requested"); err != nil {
+		t.Fatalf("attempt 2: %v", err)
+	}
+	// Third attempt (> maxAttempts): no comment (counter already above max)
+	if err := fix.HandleReview(ctx, "owner/repo", 10, "changes_requested"); err != nil {
+		t.Fatalf("attempt 3: %v", err)
+	}
+
+	if len(*comments) != 2 {
+		t.Fatalf("expected 2 comments total, got %d", len(*comments))
+	}
+	if (*comments)[0].Body != copilotFixComment {
+		t.Errorf("attempt 1: expected @copilot comment, got %q", (*comments)[0].Body)
+	}
+	if (*comments)[1].Body != copilotEscalComment {
+		t.Errorf("attempt 2: expected escalation comment, got %q", (*comments)[1].Body)
+	}
+}
+
+// TestCopilotFix_Approved_ResetsCounter verifies that an approved review
+// resets the Redis counter.
+func TestCopilotFix_Approved_ResetsCounter(t *testing.T) {
+	srv, _ := newGHMock(t)
+	rdb := newMockRedis()
+	fix := newCopilotFixLoopForTest("tok", rdb, srv.URL)
+
+	ctx := context.Background()
+	key := fix.attemptKey("owner/repo", 99)
+
+	// Simulate a previous failed attempt
+	_ = fix.HandleReview(ctx, "owner/repo", 99, "changes_requested")
+	if rdb.get(key) != 1 {
+		t.Fatal("counter should be 1 before reset")
+	}
+
+	// Approve should reset counter
+	if err := fix.HandleReview(ctx, "owner/repo", 99, "approved"); err != nil {
+		t.Fatalf("approved: %v", err)
+	}
+	if rdb.get(key) != 0 {
+		t.Errorf("counter should be 0 after approval, got %d", rdb.get(key))
+	}
+}
+
+// TestCopilotFix_Commented_DoesNothing verifies that a "commented" review
+// state (not changes_requested) takes no action.
+func TestCopilotFix_Commented_DoesNothing(t *testing.T) {
+	srv, comments := newGHMock(t)
+	rdb := newMockRedis()
+	fix := newCopilotFixLoopForTest("tok", rdb, srv.URL)
+
+	ctx := context.Background()
+	if err := fix.HandleReview(ctx, "owner/repo", 55, "commented"); err != nil {
+		t.Fatalf("HandleReview(commented): %v", err)
+	}
+
+	if len(*comments) != 0 {
+		t.Errorf("expected 0 comments for 'commented' state, got %d", len(*comments))
+	}
+	key := fix.attemptKey("owner/repo", 55)
+	if rdb.get(key) != 0 {
+		t.Errorf("expected counter=0 for 'commented' state, got %d", rdb.get(key))
+	}
+}
+
+// TestCopilotFix_ResetAttempts_ClearsKey verifies that ResetAttempts deletes
+// the Redis key directly.
+func TestCopilotFix_ResetAttempts_ClearsKey(t *testing.T) {
+	rdb := newMockRedis()
+	fix := &CopilotFixLoop{rdb: rdb, maxAttempts: defaultMaxAttempts}
+
+	ctx := context.Background()
+	key := fix.attemptKey("org/repo", 3)
+
+	// Manually seed the counter
+	rdb.Incr(ctx, key)
+	rdb.Incr(ctx, key)
+	if rdb.get(key) != 2 {
+		t.Fatal("pre-condition: counter should be 2")
+	}
+
+	if err := fix.ResetAttempts(ctx, "org/repo", 3); err != nil {
+		t.Fatalf("ResetAttempts: %v", err)
+	}
+	if rdb.get(key) != 0 {
+		t.Errorf("expected counter=0 after reset, got %d", rdb.get(key))
+	}
+}

--- a/internal/dispatch/webhook.go
+++ b/internal/dispatch/webhook.go
@@ -39,6 +39,7 @@ type WebhookServer struct {
 	plannerHandler     *PlannerHandler
 	cascadeHandler     *CascadeHandler
 	draftConverter     *DraftConverter
+	copilotFix         *CopilotFixLoop
 }
 
 // SetTriageHandler enables automatic issue triage via Claude API.
@@ -64,6 +65,12 @@ func (ws *WebhookServer) SetCascadeHandler(ch *CascadeHandler) {
 // SetDraftConverter enables automatic draft-to-ready conversion for Copilot PRs.
 func (ws *WebhookServer) SetDraftConverter(dc *DraftConverter) {
 	ws.draftConverter = dc
+}
+
+// SetCopilotFixLoop enables the Copilot fix loop — auto-posts @copilot comments
+// when PR reviews request changes.
+func (ws *WebhookServer) SetCopilotFixLoop(cf *CopilotFixLoop) {
+	ws.copilotFix = cf
 }
 
 // NewWebhookServer creates a webhook handler backed by the dispatcher.
@@ -250,6 +257,25 @@ func (ws *WebhookServer) handleWebhook(w http.ResponseWriter, r *http.Request) {
 			})
 			return
 		}
+	}
+
+	// Copilot fix loop: auto-post @copilot comment when a review requests changes.
+	if githubEvent == "pull_request_review" && action == "submitted" {
+		if ws.copilotFix != nil {
+			reviewState := getNestedString(payload, "review", "state")
+			prNumber := int(getNestedNumber(payload, "pull_request", "number"))
+			go ws.copilotFix.HandleReview(context.Background(), repo, prNumber, reviewState)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(map[string]interface{}{"ok": true, "action": "copilot_fix_dispatched"})
+		return
+	}
+
+	// Reset Copilot fix counter when a PR is closed (merged or abandoned).
+	if githubEvent == "pull_request" && action == "closed" && ws.copilotFix != nil {
+		prNumber := int(getNestedNumber(payload, "pull_request", "number"))
+		go ws.copilotFix.ResetAttempts(context.Background(), repo, prNumber)
 	}
 
 	// Convert GitHub event to our Event type


### PR DESCRIPTION
## Summary
When a PR review requests changes, Octi Pulpo auto-posts:
> @copilot apply changes based on the comments in this thread

No more manually typing that comment.

## Details
- Detects `pull_request_review` webhook with `state: changes_requested`
- Posts `@copilot` trigger comment via GitHub API
- Tracks attempts per PR in Redis (`octi:copilot-fix:{repo}:{pr}`)
- After 2 failed rounds: escalation comment for human review
- Resets counter on PR approval or close/merge

Closes #123

## Agent
- **Driver:** Claude Code CLI subagent
- **Model:** Claude Sonnet 4.6

🤖 Generated by /evolve