### PR TITLE
feat: auto-update PR branches + preflight gate (#120, #95)

### DIFF
--- a/internal/coordination/preflight_gate.go
+++ b/internal/coordination/preflight_gate.go
@@ -1,0 +1,78 @@
+package coordination
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/redis/go-redis/v9"
+)
+
+// requiredPhases are the Preflight phases that must be completed before a
+// task can transition from "assigned" to "in_progress".
+var requiredPhases = []string{"orient", "clarify", "approach", "confirm"}
+
+// PreflightGate blocks task state transitions unless the required Preflight
+// phases have been logged. This enforces design-before-you-build discipline
+// across the swarm.
+type PreflightGate struct {
+	rdb *redis.Client
+	ns  string
+}
+
+// NewPreflightGate creates a gate backed by Redis.
+func NewPreflightGate(rdb *redis.Client, namespace string) *PreflightGate {
+	return &PreflightGate{rdb: rdb, ns: namespace}
+}
+
+// BlockTransition checks whether a task state transition is allowed.
+// Only the "assigned" -> "in_progress" transition is gated; all other
+// transitions pass through unconditionally.
+//
+// The gate inspects the Redis set at key `octi:preflight:{taskID}:phases`
+// for completed phase entries. If any required phase is missing, the
+// transition is blocked and a reason string explains which phases are absent.
+func (pg *PreflightGate) BlockTransition(ctx context.Context, taskID, from, to string) (allowed bool, reason string) {
+	// Only gate the specific transition.
+	if from != "assigned" || to != "in_progress" {
+		return true, ""
+	}
+
+	key := pg.key(taskID)
+
+	members, err := pg.rdb.SMembers(ctx, key).Result()
+	if err != nil {
+		return false, fmt.Sprintf("preflight check failed: %v", err)
+	}
+
+	completed := make(map[string]bool, len(members))
+	for _, m := range members {
+		completed[m] = true
+	}
+
+	var missing []string
+	for _, phase := range requiredPhases {
+		if !completed[phase] {
+			missing = append(missing, phase)
+		}
+	}
+
+	if len(missing) > 0 {
+		return false, fmt.Sprintf("preflight phases incomplete: missing %s", strings.Join(missing, ", "))
+	}
+	return true, ""
+}
+
+// LogPhase records a completed Preflight phase for a task.
+func (pg *PreflightGate) LogPhase(ctx context.Context, taskID, phase string) error {
+	return pg.rdb.SAdd(ctx, pg.key(taskID), phase).Err()
+}
+
+// CompletedPhases returns the set of completed phases for a task.
+func (pg *PreflightGate) CompletedPhases(ctx context.Context, taskID string) ([]string, error) {
+	return pg.rdb.SMembers(ctx, pg.key(taskID)).Result()
+}
+
+func (pg *PreflightGate) key(taskID string) string {
+	return pg.ns + ":preflight:" + taskID + ":phases"
+}

--- a/internal/coordination/preflight_gate_test.go
+++ b/internal/coordination/preflight_gate_test.go
@@ -1,0 +1,149 @@
+package coordination
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/redis/go-redis/v9"
+)
+
+// preflightTestSetup creates a PreflightGate backed by real Redis.
+// Tests are skipped gracefully if Redis is not available.
+func preflightTestSetup(t *testing.T) (*PreflightGate, context.Context) {
+	t.Helper()
+
+	redisURL := "redis://localhost:6379"
+	opts, err := redis.ParseURL(redisURL)
+	if err != nil {
+		t.Skipf("skipping: cannot parse redis URL: %v", err)
+	}
+	rdb := redis.NewClient(opts)
+
+	ctx := context.Background()
+	if err := rdb.Ping(ctx).Err(); err != nil {
+		t.Skipf("skipping: redis not available: %v", err)
+	}
+
+	ns := "preflight-test-" + strings.ReplaceAll(t.Name(), "/", "-")
+
+	t.Cleanup(func() {
+		keys, _ := rdb.Keys(ctx, ns+":*").Result()
+		if len(keys) > 0 {
+			rdb.Del(ctx, keys...)
+		}
+		rdb.Close()
+	})
+
+	return NewPreflightGate(rdb, ns), ctx
+}
+
+func TestBlockTransition_BlocksWithNoPhases(t *testing.T) {
+	pg, ctx := preflightTestSetup(t)
+
+	allowed, reason := pg.BlockTransition(ctx, "task-1", "assigned", "in_progress")
+	if allowed {
+		t.Error("expected transition to be blocked with no phases logged")
+	}
+	for _, phase := range requiredPhases {
+		if !strings.Contains(reason, phase) {
+			t.Errorf("reason %q should mention missing phase %q", reason, phase)
+		}
+	}
+}
+
+func TestBlockTransition_AllowsAfterAllPhases(t *testing.T) {
+	pg, ctx := preflightTestSetup(t)
+
+	for _, phase := range requiredPhases {
+		if err := pg.LogPhase(ctx, "task-2", phase); err != nil {
+			t.Fatalf("LogPhase(%q): %v", phase, err)
+		}
+	}
+
+	allowed, reason := pg.BlockTransition(ctx, "task-2", "assigned", "in_progress")
+	if !allowed {
+		t.Errorf("expected transition to be allowed, got blocked: %s", reason)
+	}
+}
+
+func TestBlockTransition_BlocksWithPartialPhases(t *testing.T) {
+	pg, ctx := preflightTestSetup(t)
+
+	// Log only orient and clarify — missing approach, confirm
+	if err := pg.LogPhase(ctx, "task-3", "orient"); err != nil {
+		t.Fatalf("LogPhase: %v", err)
+	}
+	if err := pg.LogPhase(ctx, "task-3", "clarify"); err != nil {
+		t.Fatalf("LogPhase: %v", err)
+	}
+
+	allowed, reason := pg.BlockTransition(ctx, "task-3", "assigned", "in_progress")
+	if allowed {
+		t.Error("expected transition to be blocked with only 2 of 4 phases")
+	}
+	if !strings.Contains(reason, "approach") {
+		t.Errorf("reason %q should mention missing 'approach'", reason)
+	}
+	if !strings.Contains(reason, "confirm") {
+		t.Errorf("reason %q should mention missing 'confirm'", reason)
+	}
+	// Should NOT mention completed phases as missing
+	if strings.Contains(reason, "orient") {
+		t.Errorf("reason %q should NOT mention completed 'orient' as missing", reason)
+	}
+}
+
+func TestBlockTransition_PassesThroughOtherTransitions(t *testing.T) {
+	pg, ctx := preflightTestSetup(t)
+
+	cases := []struct {
+		from string
+		to   string
+	}{
+		{"in_progress", "completed"},
+		{"pending", "assigned"},
+		{"assigned", "blocked"},
+		{"in_progress", "blocked"},
+		{"blocked", "assigned"},
+	}
+
+	for _, c := range cases {
+		allowed, _ := pg.BlockTransition(ctx, "task-any", c.from, c.to)
+		if !allowed {
+			t.Errorf("transition %s -> %s should pass through, but was blocked", c.from, c.to)
+		}
+	}
+}
+
+func TestLogPhase_Idempotent(t *testing.T) {
+	pg, ctx := preflightTestSetup(t)
+
+	// Log the same phase twice — should not error or duplicate
+	if err := pg.LogPhase(ctx, "task-4", "orient"); err != nil {
+		t.Fatalf("first LogPhase: %v", err)
+	}
+	if err := pg.LogPhase(ctx, "task-4", "orient"); err != nil {
+		t.Fatalf("second LogPhase: %v", err)
+	}
+
+	phases, err := pg.CompletedPhases(ctx, "task-4")
+	if err != nil {
+		t.Fatalf("CompletedPhases: %v", err)
+	}
+	if len(phases) != 1 {
+		t.Errorf("expected 1 phase after idempotent add, got %d", len(phases))
+	}
+}
+
+func TestCompletedPhases_EmptyForNewTask(t *testing.T) {
+	pg, ctx := preflightTestSetup(t)
+
+	phases, err := pg.CompletedPhases(ctx, "task-nonexistent")
+	if err != nil {
+		t.Fatalf("CompletedPhases: %v", err)
+	}
+	if len(phases) != 0 {
+		t.Errorf("expected 0 phases for new task, got %d", len(phases))
+	}
+}

--- a/internal/dispatch/branch_updater.go
+++ b/internal/dispatch/branch_updater.go
@@ -1,0 +1,177 @@
+package dispatch
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+)
+
+// BranchUpdateResult summarises a single PR branch update attempt.
+type BranchUpdateResult struct {
+	PRNumber int    `json:"pr_number"`
+	Updated  bool   `json:"updated"`
+	Skipped  bool   `json:"skipped"`
+	Reason   string `json:"reason"`
+}
+
+// BranchUpdater auto-updates open PR branches that fall behind the default
+// branch after a push. This keeps CI green and reduces merge conflicts.
+type BranchUpdater struct {
+	ghToken    string       // GitHub PAT — reads GITHUB_TOKEN from env if empty
+	baseURL    string       // GitHub API base URL (overridable for tests)
+	httpClient *http.Client // HTTP client (overridable for tests)
+}
+
+// NewBranchUpdater creates a BranchUpdater. Reads GITHUB_TOKEN from env if ghToken is empty.
+func NewBranchUpdater(ghToken string) *BranchUpdater {
+	if ghToken == "" {
+		ghToken = os.Getenv("GITHUB_TOKEN")
+	}
+	return &BranchUpdater{
+		ghToken:    ghToken,
+		baseURL:    "https://api.github.com",
+		httpClient: http.DefaultClient,
+	}
+}
+
+// prListItem is the subset of the GitHub PR response we need.
+type prListItem struct {
+	Number int    `json:"number"`
+	State  string `json:"state"`
+	Base   struct {
+		Ref string `json:"ref"`
+	} `json:"base"`
+	Head struct {
+		Ref string `json:"ref"`
+		SHA string `json:"sha"`
+	} `json:"head"`
+}
+
+// compareResponse is the subset of the GitHub compare API we need.
+type compareResponse struct {
+	BehindBy int `json:"behind_by"`
+}
+
+// HandlePush lists open PRs targeting the default branch and updates any
+// that are behind. It is designed to be called from the webhook handler
+// when a push to the default branch is detected.
+func (bu *BranchUpdater) HandlePush(ctx context.Context, repo, defaultBranch string) ([]BranchUpdateResult, error) {
+	if bu.ghToken == "" {
+		return nil, fmt.Errorf("branch updater: no GitHub token configured")
+	}
+
+	prs, err := bu.listOpenPRs(ctx, repo, defaultBranch)
+	if err != nil {
+		return nil, fmt.Errorf("list open PRs: %w", err)
+	}
+
+	var results []BranchUpdateResult
+	for _, pr := range prs {
+		result := bu.updateIfBehind(ctx, repo, defaultBranch, pr)
+		results = append(results, result)
+	}
+	return results, nil
+}
+
+// listOpenPRs fetches open PRs targeting the given base branch.
+func (bu *BranchUpdater) listOpenPRs(ctx context.Context, repo, base string) ([]prListItem, error) {
+	url := fmt.Sprintf("%s/repos/%s/pulls?state=open&base=%s&per_page=100", bu.baseURL, repo, base)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+bu.ghToken)
+	req.Header.Set("Accept", "application/vnd.github+json")
+
+	resp, err := bu.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("list PRs: status %d: %s", resp.StatusCode, body)
+	}
+
+	var prs []prListItem
+	if err := json.NewDecoder(resp.Body).Decode(&prs); err != nil {
+		return nil, fmt.Errorf("decode PRs: %w", err)
+	}
+	return prs, nil
+}
+
+// updateIfBehind checks whether a PR branch is behind the base and calls
+// the GitHub update-branch API if so.
+func (bu *BranchUpdater) updateIfBehind(ctx context.Context, repo, defaultBranch string, pr prListItem) BranchUpdateResult {
+	behind, err := bu.isBehind(ctx, repo, defaultBranch, pr.Head.SHA)
+	if err != nil {
+		return BranchUpdateResult{PRNumber: pr.Number, Skipped: true, Reason: fmt.Sprintf("compare failed: %v", err)}
+	}
+	if !behind {
+		return BranchUpdateResult{PRNumber: pr.Number, Skipped: true, Reason: "already up to date"}
+	}
+
+	if err := bu.updateBranch(ctx, repo, pr.Number); err != nil {
+		return BranchUpdateResult{PRNumber: pr.Number, Skipped: true, Reason: fmt.Sprintf("update failed: %v", err)}
+	}
+	return BranchUpdateResult{PRNumber: pr.Number, Updated: true, Reason: "updated"}
+}
+
+// isBehind returns true if headSHA is behind the default branch.
+func (bu *BranchUpdater) isBehind(ctx context.Context, repo, base, headSHA string) (bool, error) {
+	url := fmt.Sprintf("%s/repos/%s/compare/%s...%s", bu.baseURL, repo, base, headSHA)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return false, err
+	}
+	req.Header.Set("Authorization", "Bearer "+bu.ghToken)
+	req.Header.Set("Accept", "application/vnd.github+json")
+
+	resp, err := bu.httpClient.Do(req)
+	if err != nil {
+		return false, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return false, fmt.Errorf("compare: status %d: %s", resp.StatusCode, body)
+	}
+
+	var cmp compareResponse
+	if err := json.NewDecoder(resp.Body).Decode(&cmp); err != nil {
+		return false, fmt.Errorf("decode compare: %w", err)
+	}
+	return cmp.BehindBy > 0, nil
+}
+
+// updateBranch calls the GitHub "update a pull request branch" API.
+func (bu *BranchUpdater) updateBranch(ctx context.Context, repo string, prNumber int) error {
+	url := fmt.Sprintf("%s/repos/%s/pulls/%d/update-branch", bu.baseURL, repo, prNumber)
+	body, _ := json.Marshal(map[string]string{"update_method": "merge"})
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, url, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bearer "+bu.ghToken)
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := bu.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusAccepted && resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("update branch: status %d: %s", resp.StatusCode, respBody)
+	}
+	return nil
+}

--- a/internal/dispatch/branch_updater_test.go
+++ b/internal/dispatch/branch_updater_test.go
@@ -1,0 +1,249 @@
+package dispatch
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// newTestBranchUpdater creates a BranchUpdater that talks to the given test server URL.
+func newTestBranchUpdater(serverURL, token string) *BranchUpdater {
+	bu := NewBranchUpdater(token)
+	bu.baseURL = serverURL
+	bu.httpClient = &http.Client{}
+	return bu
+}
+
+func TestHandlePush_UpdatesBehindPRs(t *testing.T) {
+	var mu sync.Mutex
+	var updateCalls []int
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		// GET /repos/:owner/:repo/pulls?state=open&base=main...
+		if r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/pulls") && r.URL.Query().Get("state") == "open" {
+			json.NewEncoder(w).Encode([]prListItem{
+				{Number: 10, State: "open", Base: struct {
+					Ref string `json:"ref"`
+				}{Ref: "main"}, Head: struct {
+					Ref string `json:"ref"`
+					SHA string `json:"sha"`
+				}{Ref: "feat-a", SHA: "aaa111"}},
+				{Number: 20, State: "open", Base: struct {
+					Ref string `json:"ref"`
+				}{Ref: "main"}, Head: struct {
+					Ref string `json:"ref"`
+					SHA string `json:"sha"`
+				}{Ref: "feat-b", SHA: "bbb222"}},
+			})
+			return
+		}
+
+		// GET /repos/:owner/:repo/compare/main...{sha}
+		if r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/compare/") {
+			behind := 0
+			if strings.HasSuffix(r.URL.Path, "aaa111") {
+				behind = 3 // PR #10 is behind
+			}
+			json.NewEncoder(w).Encode(compareResponse{BehindBy: behind})
+			return
+		}
+
+		// PUT /repos/:owner/:repo/pulls/:number/update-branch
+		if r.Method == http.MethodPut && strings.Contains(r.URL.Path, "/update-branch") {
+			mu.Lock()
+			// Extract PR number from path: .../pulls/10/update-branch
+			parts := strings.Split(r.URL.Path, "/")
+			for i, p := range parts {
+				if p == "pulls" && i+1 < len(parts) {
+					var n int
+					_ = json.Unmarshal([]byte(parts[i+1]), &n) //nolint:errcheck
+					updateCalls = append(updateCalls, n)
+				}
+			}
+			mu.Unlock()
+			w.WriteHeader(http.StatusAccepted)
+			json.NewEncoder(w).Encode(map[string]string{"message": "Updating pull request branch."})
+			return
+		}
+
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	bu := newTestBranchUpdater(srv.URL, "test-token")
+
+	results, err := bu.HandlePush(context.Background(), "AgentGuardHQ/octi-pulpo", "main")
+	if err != nil {
+		t.Fatalf("HandlePush: %v", err)
+	}
+
+	if len(results) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(results))
+	}
+
+	// PR #10 should be updated (behind by 3)
+	if !results[0].Updated {
+		t.Errorf("PR #10: expected Updated=true, got Updated=%v Reason=%s", results[0].Updated, results[0].Reason)
+	}
+	// PR #20 should be skipped (up to date)
+	if !results[1].Skipped {
+		t.Errorf("PR #20: expected Skipped=true, got Skipped=%v", results[1].Skipped)
+	}
+	if results[1].Reason != "already up to date" {
+		t.Errorf("PR #20: reason = %q, want %q", results[1].Reason, "already up to date")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(updateCalls) != 1 {
+		t.Fatalf("expected 1 update-branch call, got %d", len(updateCalls))
+	}
+	if updateCalls[0] != 10 {
+		t.Errorf("update-branch called for PR #%d, want #10", updateCalls[0])
+	}
+}
+
+func TestHandlePush_NoPRs(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode([]prListItem{})
+	}))
+	defer srv.Close()
+
+	bu := newTestBranchUpdater(srv.URL, "test-token")
+
+	results, err := bu.HandlePush(context.Background(), "AgentGuardHQ/octi-pulpo", "main")
+	if err != nil {
+		t.Fatalf("HandlePush: %v", err)
+	}
+	if len(results) != 0 {
+		t.Errorf("expected 0 results, got %d", len(results))
+	}
+}
+
+func TestHandlePush_NoTokenReturnsError(t *testing.T) {
+	bu := NewBranchUpdater("")
+	bu.ghToken = ""
+
+	_, err := bu.HandlePush(context.Background(), "AgentGuardHQ/octi-pulpo", "main")
+	if err == nil {
+		t.Fatal("expected error for missing token, got nil")
+	}
+}
+
+func TestHandlePush_APIErrorOnListPRs(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte(`{"message":"internal error"}`))
+	}))
+	defer srv.Close()
+
+	bu := newTestBranchUpdater(srv.URL, "test-token")
+
+	_, err := bu.HandlePush(context.Background(), "AgentGuardHQ/octi-pulpo", "main")
+	if err == nil {
+		t.Fatal("expected error on API failure, got nil")
+	}
+}
+
+func TestHandlePush_CompareErrorSkipsPR(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		if r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/pulls") && r.URL.Query().Get("state") == "open" {
+			json.NewEncoder(w).Encode([]prListItem{
+				{Number: 5, State: "open", Base: struct {
+					Ref string `json:"ref"`
+				}{Ref: "main"}, Head: struct {
+					Ref string `json:"ref"`
+					SHA string `json:"sha"`
+				}{Ref: "feat-c", SHA: "ccc333"}},
+			})
+			return
+		}
+
+		// Compare endpoint returns 500
+		if strings.Contains(r.URL.Path, "/compare/") {
+			w.WriteHeader(http.StatusInternalServerError)
+			w.Write([]byte(`{"message":"compare failed"}`))
+			return
+		}
+
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	bu := newTestBranchUpdater(srv.URL, "test-token")
+
+	results, err := bu.HandlePush(context.Background(), "AgentGuardHQ/octi-pulpo", "main")
+	if err != nil {
+		t.Fatalf("HandlePush: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if !results[0].Skipped {
+		t.Error("expected Skipped=true when compare fails")
+	}
+	if !strings.Contains(results[0].Reason, "compare failed") {
+		t.Errorf("reason = %q, want it to mention compare failure", results[0].Reason)
+	}
+}
+
+func TestHandlePush_UpdateBranchErrorSkipsPR(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		if r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/pulls") && r.URL.Query().Get("state") == "open" {
+			json.NewEncoder(w).Encode([]prListItem{
+				{Number: 7, State: "open", Base: struct {
+					Ref string `json:"ref"`
+				}{Ref: "main"}, Head: struct {
+					Ref string `json:"ref"`
+					SHA string `json:"sha"`
+				}{Ref: "feat-d", SHA: "ddd444"}},
+			})
+			return
+		}
+
+		if strings.Contains(r.URL.Path, "/compare/") {
+			json.NewEncoder(w).Encode(compareResponse{BehindBy: 2})
+			return
+		}
+
+		// Update branch returns 422
+		if r.Method == http.MethodPut && strings.Contains(r.URL.Path, "/update-branch") {
+			w.WriteHeader(http.StatusUnprocessableEntity)
+			w.Write([]byte(`{"message":"merge conflict"}`))
+			return
+		}
+
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	bu := newTestBranchUpdater(srv.URL, "test-token")
+
+	results, err := bu.HandlePush(context.Background(), "AgentGuardHQ/octi-pulpo", "main")
+	if err != nil {
+		t.Fatalf("HandlePush: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if results[0].Updated {
+		t.Error("should not be Updated when update-branch returns 422")
+	}
+	if !results[0].Skipped {
+		t.Error("expected Skipped=true when update-branch fails")
+	}
+	if !strings.Contains(results[0].Reason, "update failed") {
+		t.Errorf("reason = %q, want it to mention update failure", results[0].Reason)
+	}
+}

--- a/internal/dispatch/webhook.go
+++ b/internal/dispatch/webhook.go
@@ -40,6 +40,7 @@ type WebhookServer struct {
 	cascadeHandler     *CascadeHandler
 	draftConverter     *DraftConverter
 	copilotFix         *CopilotFixLoop
+	branchUpdater      *BranchUpdater
 }
 
 // SetTriageHandler enables automatic issue triage via Claude API.
@@ -71,6 +72,12 @@ func (ws *WebhookServer) SetDraftConverter(dc *DraftConverter) {
 // when PR reviews request changes.
 func (ws *WebhookServer) SetCopilotFixLoop(cf *CopilotFixLoop) {
 	ws.copilotFix = cf
+}
+
+// SetBranchUpdater enables automatic PR branch updates when the default
+// branch receives new commits.
+func (ws *WebhookServer) SetBranchUpdater(bu *BranchUpdater) {
+	ws.branchUpdater = bu
 }
 
 // NewWebhookServer creates a webhook handler backed by the dispatcher.
@@ -409,6 +416,29 @@ func (ws *WebhookServer) handleWebhook(w http.ResponseWriter, r *http.Request) {
 				"action": "cascade_dispatched",
 			})
 			return
+		}
+	}
+
+	// Auto-update PR branches when the default branch receives new commits.
+	if githubEvent == "push" && ws.branchUpdater != nil {
+		ref := getString(payload, "ref")
+		defaultBranch := getNestedString(payload, "repository", "default_branch")
+		if defaultBranch != "" && ref == "refs/heads/"+defaultBranch {
+			go func() {
+				updateResults, err := ws.branchUpdater.HandlePush(context.Background(), repo, defaultBranch)
+				if err != nil {
+					fmt.Fprintf(os.Stderr, "[octi-pulpo] branch-updater error: %v\n", err)
+				} else {
+					updated := 0
+					for _, r := range updateResults {
+						if r.Updated {
+							updated++
+						}
+					}
+					fmt.Fprintf(os.Stderr, "[octi-pulpo] branch-updater: %d/%d PRs updated in %s\n",
+						updated, len(updateResults), repo)
+				}
+			}()
 		}
 	}
 


### PR DESCRIPTION
## Summary
- **Branch Updater (#120)**: On push to main/master, lists all open PRs and updates any that are behind via the GitHub update-branch API. Wired into `webhook.go` for push events to the default branch.
- **Preflight Gate (#95)**: Blocks task state transitions from "assigned" to "in_progress" unless all four Preflight phases (orient, clarify, approach, confirm) are logged in Redis. All other transitions pass through unconditionally.

## Files changed
- `internal/dispatch/branch_updater.go` — `BranchUpdater` struct with `HandlePush`, GitHub API integration
- `internal/dispatch/branch_updater_test.go` — 6 test cases with httptest mocks
- `internal/dispatch/webhook.go` — Wire `BranchUpdater` into push event handling
- `internal/coordination/preflight_gate.go` — `PreflightGate` struct with `BlockTransition`, `LogPhase`
- `internal/coordination/preflight_gate_test.go` — 6 test cases with Redis integration

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes (all 18 packages)
- [ ] Verify branch updater fires on push webhook to default branch
- [ ] Verify preflight gate blocks transitions with missing phases
- [ ] Verify preflight gate allows transitions after all 4 phases logged

Closes #120, Closes #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)