### PR TITLE
fix: enable brain dispatch for sprint items

### DIFF
--- a/internal/dispatch/brain.go
+++ b/internal/dispatch/brain.go
@@ -153,7 +153,7 @@ func (b *Brain) Tick(ctx context.Context) {
 	if b.sprintStore != nil {
 		constraint := b.identifyConstraint(ctx)
 		b.maybeNotifyConstraintChange(ctx, constraint)
-		if constraint.Type != "none" && constraint.Type != "all_drivers_down" {
+		if constraint.Type != "all_drivers_down" {
 			action := b.highestLeverageAction(ctx, constraint)
 			if action != nil {
 				b.executeLeverageAction(ctx, *action)
@@ -450,8 +450,7 @@ func (b *Brain) maybeNotifyConstraintChange(ctx context.Context, constraint Cons
 // identifyConstraint reads system state and returns the single most important constraint.
 // Checked in priority order — first match wins.
 func (b *Brain) identifyConstraint(ctx context.Context) Constraint {
-	// 1. All drivers exhausted (within current budget policy; "high"/API tier is never
-	// assumed available automatically — use DynamicBudget to stay within economics)
+	// 1. All drivers exhausted (within current budget policy)
 	decision := b.dispatcher.router.Recommend("brain-constraint-check", b.dispatcher.router.DynamicBudget())
 	if decision.Skip {
 		return Constraint{


### PR DESCRIPTION
## Summary
- Remove `!= "none"` gate from Tick dispatch — `"none"` with sprint items means "dispatch next sprint item", not "do nothing"
- `highestLeverageAction` already handles `case "none"` via `leverageForNextSprint` but it was never reached

Closes #140

## Test plan
- [x] All 590 tests pass
- [x] Build succeeds
- [ ] After merge: rebuild binary, restart service, verify brain logs show dispatch activity

🤖 Generated with [Claude Code](https://claude.com/claude-code)