### PR TITLE
fix: expand DefaultRepos to all 11 active repos

### DIFF
--- a/internal/dispatch/brain.go
+++ b/internal/dispatch/brain.go
@@ -843,6 +843,7 @@ func (b *Brain) srForSquad(squad string) string {
 		"cata":       "cata-sr",
 		"sentinel":   "sentinel-sr",
 		"llmint":     "llmint-sr",
+		"ops":        "kernel-sr",
 	}
 	return mapping[squad]
 }

--- a/internal/sprint/store.go
+++ b/internal/sprint/store.go
@@ -125,6 +125,9 @@ var DefaultRepos = []string{
 	"AgentGuardHQ/llmint",
 	"AgentGuardHQ/agentguard-analytics",
 	"AgentGuardHQ/agentguard-cloud",
+	"AgentGuardHQ/agentguard-workspace",
+	"AgentGuardHQ/agentguard-extensions",
+	"AgentGuardHQ/preflight",
 }
 
 // NewStore creates a sprint store backed by Redis.
@@ -842,6 +845,10 @@ func inferSquadFromRepo(repo string) string {
 		return "cloud"
 	case name == "agentguard-analytics":
 		return "analytics"
+	case name == "agentguard-extensions" || name == "preflight" || name == "homebrew-tap":
+		return "kernel"
+	case name == "agentguard-workspace":
+		return "ops"
 	case name == "shellforge":
 		return "shellforge"
 	case name == "octi-pulpo":


### PR DESCRIPTION
## Summary
- Adds 3 missing repos: agentguard-workspace (22 sprint issues), agentguard-extensions (3), preflight (2)
- Maps extensions/preflight/homebrew-tap → kernel squad, workspace → ops squad
- ops squad routes to kernel-sr agent
- homebrew-tap excluded (0 sprint issues) but mapped if added later

## Context
Brain was only syncing 8 of 11 active repos, missing 27 sprint issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)