### PR TITLE
refactor: rebrand Cata → Clawta

### DIFF
--- a/.github/workflows/clawta-dispatch.yml
+++ b/.github/workflows/clawta-dispatch.yml
@@ -1,10 +1,10 @@
-name: Cata Agent Dispatch
+name: Clawta Agent Dispatch
 on:
   repository_dispatch:
     types: [octi-pulpo-dispatch]
 
 jobs:
-  cata-agent:
+  clawta-agent:
     runs-on: ubuntu-latest
     if: |
       github.event.client_payload.type == 'evolve' ||
@@ -25,7 +25,7 @@ jobs:
         with:
           go-version: "1.22"
 
-      - name: Download Cata binary
+      - name: Download Clawta binary
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -33,35 +33,35 @@ jobs:
           echo "Type:      ${TASK_TYPE}"
           echo "Priority:  ${TASK_PRIORITY}"
 
-          # Download the latest Cata release binary.
-          gh release download --repo AgentGuardHQ/cata \
-            --pattern "cata-linux-amd64" \
-            --output cata \
-            --clobber || echo "WARN: cata release not yet published — skipping binary download"
+          # Download the latest Clawta release binary.
+          gh release download --repo AgentGuardHQ/clawta \
+            --pattern "clawta-linux-amd64" \
+            --output clawta \
+            --clobber || echo "WARN: clawta release not yet published — skipping binary download"
 
-          chmod +x cata 2>/dev/null || true
+          chmod +x clawta 2>/dev/null || true
 
       - name: Configure git identity
         run: |
           git config --global user.email "octi-pulpo@agentguardhq.com"
           git config --global user.name "Octi Pulpo Bot"
 
-      - name: Run Cata agent
+      - name: Run Clawta agent
         env:
           DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          if [ ! -f ./cata ]; then
-            echo "ERROR: cata binary not available. Cannot dispatch task ${TASK_ID}."
+          if [ ! -f ./clawta ]; then
+            echo "ERROR: clawta binary not available. Cannot dispatch task ${TASK_ID}."
             exit 1
           fi
 
-          ./cata run \
+          ./clawta run \
             --provider deepseek \
             --model deepseek-chat \
             --max-turns 100 \
             "${TASK_PROMPT}" \
-            || echo "WARN: cata exited non-zero for task ${TASK_ID}"
+            || echo "WARN: clawta exited non-zero for task ${TASK_ID}"
 
       - name: Report outcome
         if: always()

--- a/cmd/octi-pulpo/main.go
+++ b/cmd/octi-pulpo/main.go
@@ -217,11 +217,11 @@ func main() {
 			brain.SetSprintStore(sprintStore)
 			brain.SetProfileStore(profiles)
 			brain.SetStandupStore(standupStore)
-			// Wire task adapters: Cata (local DeepSeek) → GH Actions (Copilot) fallback
-			cataBinary := filepath.Join(home, "agentguard-workspace", "cata", "bench", "cata-linux-amd64")
-			cataAdapter := dispatch.NewCataAdapter(cataBinary, "", "", "")
-			cataAdapter.SetLearner(taskLearner)
-			brain.SetAdapters(cataAdapter, ghActionsAdapter)
+			// Wire task adapters: Clawta (local DeepSeek) → GH Actions (Copilot) fallback
+			clawtaBinary := filepath.Join(home, "agentguard-workspace", "clawta", "bench", "clawta-linux-amd64")
+			clawtaAdapter := dispatch.NewClawtaAdapter(clawtaBinary, "", "", "")
+			clawtaAdapter.SetLearner(taskLearner)
+			brain.SetAdapters(clawtaAdapter, ghActionsAdapter)
 			if ghToken := os.Getenv("GITHUB_TOKEN"); ghToken != "" {
 				brain.SetGitHubToken(ghToken)
 			}

--- a/internal/dispatch/brain.go
+++ b/internal/dispatch/brain.go
@@ -68,7 +68,7 @@ type Brain struct {
 	stuckAgentAlerted    map[string]time.Time
 	inactiveSquadAlerted map[string]time.Time
 
-	// Adapters for task-based dispatch (Cata + GH Actions).
+	// Adapters for task-based dispatch (Clawta + GH Actions).
 	adapters []Adapter
 
 	// ghToken is used for label state machine operations on GitHub issues.
@@ -89,7 +89,7 @@ func NewBrain(dispatcher *Dispatcher, chains ChainConfig) *Brain {
 	}
 }
 
-// SetAdapters registers task adapters (Cata, GH Actions) for direct dispatch.
+// SetAdapters registers task adapters (Clawta, GH Actions) for direct dispatch.
 func (b *Brain) SetAdapters(adapters ...Adapter) { b.adapters = adapters }
 
 // SetGitHubToken sets the token used for label state machine operations.
@@ -448,7 +448,7 @@ func (b *Brain) checkInactiveSquads(ctx context.Context) {
 // maybeNotifyConstraintChange fires edge-triggered Slack alerts when driver
 // availability transitions between healthy and all-exhausted states.
 // Suppressed when API adapters are available — CLI driver state is noise
-// when dispatch flows through Cata/GH Actions.
+// when dispatch flows through Clawta/GH Actions.
 func (b *Brain) maybeNotifyConstraintChange(ctx context.Context, constraint Constraint) {
 	if b.notifier == nil || !b.notifier.Enabled() {
 		return
@@ -475,7 +475,7 @@ func (b *Brain) maybeNotifyConstraintChange(ctx context.Context, constraint Cons
 // Checked in priority order — first match wins.
 func (b *Brain) identifyConstraint(ctx context.Context) Constraint {
 	// 1. All CLI drivers exhausted — but only block if no API adapters exist.
-	// API adapters (Cata, GH Actions) dispatch independently of CLI driver health.
+	// API adapters (Clawta, GH Actions) dispatch independently of CLI driver health.
 	decision := b.dispatcher.router.Recommend("brain-constraint-check", b.dispatcher.router.DynamicBudget())
 	if decision.Skip && len(b.adapters) == 0 {
 		return Constraint{
@@ -708,7 +708,7 @@ func (b *Brain) executeLeverageAction(ctx context.Context, action LeverageAction
 		return
 	}
 
-	// Adapter-based dispatch: create a Task and route to Cata or GH Actions.
+	// Adapter-based dispatch: create a Task and route to Clawta or GH Actions.
 	// Dedup: skip if we dispatched this issue recently (10 min cooldown).
 	dispatchKey := fmt.Sprintf("%s#%d", action.Repo, action.IssueNum)
 	if last, ok := b.stuckAgentAlerted[dispatchKey]; ok && time.Since(last) < 10*time.Minute {
@@ -744,7 +744,7 @@ func (b *Brain) executeLeverageAction(ctx context.Context, action LeverageAction
 				}
 
 				// Fire adapter dispatch in a goroutine so the brain tick
-				// is not blocked by long-running adapters (e.g. Cata ~10 min).
+				// is not blocked by long-running adapters (e.g. Clawta ~10 min).
 				go func(a Adapter, t *Task, repo string, issueNum int) {
 					result, err := a.Dispatch(context.Background(), t)
 					if err != nil {
@@ -840,7 +840,7 @@ func (b *Brain) srForSquad(squad string) string {
 		"octi-pulpo": "octi-pulpo-sr",
 		"studio":     "studio-sr",
 		"analytics":  "analytics-sr",
-		"cata":       "cata-sr",
+		"clawta":     "clawta-sr",
 		"sentinel":   "sentinel-sr",
 		"llmint":     "llmint-sr",
 		"ops":        "kernel-sr",

--- a/internal/dispatch/clawta_adapter.go
+++ b/internal/dispatch/clawta_adapter.go
@@ -13,40 +13,40 @@ import (
 )
 
 const (
-	defaultCataModel    = "deepseek-chat"
-	cataTimeout         = 10 * time.Minute
-	defaultCataBinary   = "cata"
-	defaultCataProvider = "deepseek"
+	defaultClawtaModel    = "deepseek-chat"
+	clawtaTimeout         = 10 * time.Minute
+	defaultClawtaBinary   = "clawta"
+	defaultClawtaProvider = "deepseek"
 )
 
-// CataAdapter dispatches tasks to the Cata governed CLI agent.
-// Cata runs in an isolated git worktree, implements the task,
+// ClawtaAdapter dispatches tasks to the Clawta governed CLI agent.
+// Clawta runs in an isolated git worktree, implements the task,
 // commits, pushes a branch, and opens a PR.
-type CataAdapter struct {
-	binary    string // path to cata binary
+type ClawtaAdapter struct {
+	binary    string // path to clawta binary
 	model     string
 	provider  string
 	workspace string // root workspace path
 	learner   *learner.Learner
 }
 
-// NewCataAdapter creates a CataAdapter. Zero-value strings fall back to
-// defaults: binary="cata", model="deepseek-chat", provider="deepseek",
+// NewClawtaAdapter creates a ClawtaAdapter. Zero-value strings fall back to
+// defaults: binary="clawta", model="deepseek-chat", provider="deepseek",
 // workspace="$HOME/agentguard-workspace".
-func NewCataAdapter(binary, model, provider, workspace string) *CataAdapter {
+func NewClawtaAdapter(binary, model, provider, workspace string) *ClawtaAdapter {
 	if binary == "" {
-		binary = defaultCataBinary
+		binary = defaultClawtaBinary
 	}
 	if model == "" {
-		model = defaultCataModel
+		model = defaultClawtaModel
 	}
 	if provider == "" {
-		provider = defaultCataProvider
+		provider = defaultClawtaProvider
 	}
 	if workspace == "" {
 		workspace = filepath.Join(os.Getenv("HOME"), "agentguard-workspace")
 	}
-	return &CataAdapter{
+	return &ClawtaAdapter{
 		binary:    binary,
 		model:     model,
 		provider:  provider,
@@ -55,14 +55,14 @@ func NewCataAdapter(binary, model, provider, workspace string) *CataAdapter {
 }
 
 // Name returns the adapter identifier.
-func (a *CataAdapter) Name() string { return "cata" }
+func (a *ClawtaAdapter) Name() string { return "clawta" }
 
 // SetLearner enables automatic episodic memory storage for task outcomes.
-func (a *CataAdapter) SetLearner(l *learner.Learner) { a.learner = l }
+func (a *ClawtaAdapter) SetLearner(l *learner.Learner) { a.learner = l }
 
 // CanAccept returns true for code-gen, bugfix, config, and evolve task types
 // when DEEPSEEK_API_KEY is available in the environment.
-func (a *CataAdapter) CanAccept(task *Task) bool {
+func (a *ClawtaAdapter) CanAccept(task *Task) bool {
 	if os.Getenv("DEEPSEEK_API_KEY") == "" {
 		return false
 	}
@@ -74,11 +74,11 @@ func (a *CataAdapter) CanAccept(task *Task) bool {
 	}
 }
 
-// Dispatch runs Cata in an isolated git worktree to implement the task.
+// Dispatch runs Clawta in an isolated git worktree to implement the task.
 // On success the branch is pushed and a PR is opened. The worktree is removed
 // on return regardless of outcome.
-func (a *CataAdapter) Dispatch(ctx context.Context, task *Task) (*AdapterResult, error) {
-	ctx, cancel := context.WithTimeout(ctx, cataTimeout)
+func (a *ClawtaAdapter) Dispatch(ctx context.Context, task *Task) (*AdapterResult, error) {
+	ctx, cancel := context.WithTimeout(ctx, clawtaTimeout)
 	defer cancel()
 
 	result := &AdapterResult{
@@ -95,7 +95,7 @@ func (a *CataAdapter) Dispatch(ctx context.Context, task *Task) (*AdapterResult,
 
 	// Create a git worktree for isolation so changes don't pollute the
 	// main working tree.
-	branchName := fmt.Sprintf("cata/%s", sanitizeBranch(task.ID))
+	branchName := fmt.Sprintf("clawta/%s", sanitizeBranch(task.ID))
 	worktreePath := filepath.Join(a.workspace, ".worktrees", branchName)
 
 	defaultBranch := detectDefaultBranch(repoPath)
@@ -119,7 +119,7 @@ func (a *CataAdapter) Dispatch(ctx context.Context, task *Task) (*AdapterResult,
 		}
 	}
 
-	// Tell Cata to commit but NOT to push or open PRs — the adapter
+	// Tell Clawta to commit but NOT to push or open PRs — the adapter
 	// handles git plumbing after the agent finishes.
 	prompt += "\n\nAfter implementing, stage and commit your changes with a descriptive message. Do NOT push or open PRs."
 
@@ -128,7 +128,7 @@ func (a *CataAdapter) Dispatch(ctx context.Context, task *Task) (*AdapterResult,
 		"--provider", a.provider,
 		"--model", a.model,
 		"--max-turns", "100",
-		"--timeout", fmt.Sprintf("%d", int(cataTimeout.Milliseconds())),
+		"--timeout", fmt.Sprintf("%d", int(clawtaTimeout.Milliseconds())),
 		prompt,
 	}
 
@@ -146,12 +146,12 @@ func (a *CataAdapter) Dispatch(ctx context.Context, task *Task) (*AdapterResult,
 
 	if err != nil {
 		result.Status = "failed"
-		result.Error = fmt.Sprintf("cata exited: %v", err)
+		result.Error = fmt.Sprintf("clawta exited: %v", err)
 	} else {
 		result.Status = "completed"
 	}
 
-	// Adapter-side git plumbing: push branch and open PR if Cata produced commits.
+	// Adapter-side git plumbing: push branch and open PR if Clawta produced commits.
 	if result.Status == "completed" {
 		if hasNewCommits(worktreePath, "origin/"+defaultBranch) {
 			pushCmd := exec.CommandContext(ctx, "git", "push", "-u", "origin", branchName)
@@ -160,7 +160,7 @@ func (a *CataAdapter) Dispatch(ctx context.Context, task *Task) (*AdapterResult,
 				result.Error = fmt.Sprintf("push failed: %s: %s", pushErr, string(pushOut))
 			} else {
 				prTitle := truncate(task.Prompt, 60)
-				prBody := fmt.Sprintf("Auto-generated by Cata via Octi Pulpo dispatch\n\nTask: %s\nAdapter: %s\nType: %s", task.ID, a.Name(), task.Type)
+				prBody := fmt.Sprintf("Auto-generated by Clawta via Octi Pulpo dispatch\n\nTask: %s\nAdapter: %s\nType: %s", task.ID, a.Name(), task.Type)
 				prCmd := exec.CommandContext(ctx, "gh", "pr", "create",
 					"--repo", task.Repo,
 					"--head", branchName,

--- a/internal/dispatch/clawta_adapter_test.go
+++ b/internal/dispatch/clawta_adapter_test.go
@@ -10,54 +10,54 @@ import (
 
 // ---- Name ----
 
-func TestCataAdapterName(t *testing.T) {
-	a := NewCataAdapter("", "", "", "")
-	if got := a.Name(); got != "cata" {
-		t.Errorf("Name(): want cata, got %s", got)
+func TestClawtaAdapterName(t *testing.T) {
+	a := NewClawtaAdapter("", "", "", "")
+	if got := a.Name(); got != "clawta" {
+		t.Errorf("Name(): want clawta, got %s", got)
 	}
 }
 
 // ---- CanAccept ----
 
-func TestCataAdapterCanAcceptCodeGen(t *testing.T) {
+func TestClawtaAdapterCanAcceptCodeGen(t *testing.T) {
 	t.Setenv("DEEPSEEK_API_KEY", "test-key")
-	a := NewCataAdapter("", "", "", "")
+	a := NewClawtaAdapter("", "", "", "")
 	task := &Task{Type: "code-gen"}
 	if !a.CanAccept(task) {
 		t.Error("CanAccept(code-gen) with key: want true, got false")
 	}
 }
 
-func TestCataAdapterCanAcceptBugfix(t *testing.T) {
+func TestClawtaAdapterCanAcceptBugfix(t *testing.T) {
 	t.Setenv("DEEPSEEK_API_KEY", "test-key")
-	a := NewCataAdapter("", "", "", "")
+	a := NewClawtaAdapter("", "", "", "")
 	task := &Task{Type: "bugfix"}
 	if !a.CanAccept(task) {
 		t.Error("CanAccept(bugfix) with key: want true, got false")
 	}
 }
 
-func TestCataAdapterCanAcceptConfig(t *testing.T) {
+func TestClawtaAdapterCanAcceptConfig(t *testing.T) {
 	t.Setenv("DEEPSEEK_API_KEY", "test-key")
-	a := NewCataAdapter("", "", "", "")
+	a := NewClawtaAdapter("", "", "", "")
 	task := &Task{Type: "config"}
 	if !a.CanAccept(task) {
 		t.Error("CanAccept(config) with key: want true, got false")
 	}
 }
 
-func TestCataAdapterCanAcceptEvolve(t *testing.T) {
+func TestClawtaAdapterCanAcceptEvolve(t *testing.T) {
 	t.Setenv("DEEPSEEK_API_KEY", "test-key")
-	a := NewCataAdapter("", "", "", "")
+	a := NewClawtaAdapter("", "", "", "")
 	task := &Task{Type: "evolve"}
 	if !a.CanAccept(task) {
 		t.Error("CanAccept(evolve) with key: want true, got false")
 	}
 }
 
-func TestCataAdapterCanAcceptEvolveSubTypes(t *testing.T) {
+func TestClawtaAdapterCanAcceptEvolveSubTypes(t *testing.T) {
 	t.Setenv("DEEPSEEK_API_KEY", "test-key")
-	a := NewCataAdapter("", "", "", "")
+	a := NewClawtaAdapter("", "", "", "")
 	for _, typ := range []string{"prompt_config", "tool_addition", "config_change"} {
 		task := &Task{Type: typ}
 		if !a.CanAccept(task) {
@@ -66,27 +66,27 @@ func TestCataAdapterCanAcceptEvolveSubTypes(t *testing.T) {
 	}
 }
 
-func TestCataAdapterRejectsPRReview(t *testing.T) {
+func TestClawtaAdapterRejectsPRReview(t *testing.T) {
 	t.Setenv("DEEPSEEK_API_KEY", "test-key")
-	a := NewCataAdapter("", "", "", "")
+	a := NewClawtaAdapter("", "", "", "")
 	task := &Task{Type: "pr-review"}
 	if a.CanAccept(task) {
 		t.Error("CanAccept(pr-review): want false, got true")
 	}
 }
 
-func TestCataAdapterRejectsTriage(t *testing.T) {
+func TestClawtaAdapterRejectsTriage(t *testing.T) {
 	t.Setenv("DEEPSEEK_API_KEY", "test-key")
-	a := NewCataAdapter("", "", "", "")
+	a := NewClawtaAdapter("", "", "", "")
 	task := &Task{Type: "triage"}
 	if a.CanAccept(task) {
 		t.Error("CanAccept(triage): want false, got true")
 	}
 }
 
-func TestCataAdapterRejectsWithoutKey(t *testing.T) {
+func TestClawtaAdapterRejectsWithoutKey(t *testing.T) {
 	t.Setenv("DEEPSEEK_API_KEY", "")
-	a := NewCataAdapter("", "", "", "")
+	a := NewClawtaAdapter("", "", "", "")
 	task := &Task{Type: "code-gen"}
 	if a.CanAccept(task) {
 		t.Error("CanAccept(code-gen) without key: want false, got true")
@@ -95,23 +95,23 @@ func TestCataAdapterRejectsWithoutKey(t *testing.T) {
 
 // ---- Defaults ----
 
-func TestCataAdapterDefaults(t *testing.T) {
-	a := NewCataAdapter("", "", "", "")
-	if a.binary != defaultCataBinary {
-		t.Errorf("default binary: want %s, got %s", defaultCataBinary, a.binary)
+func TestClawtaAdapterDefaults(t *testing.T) {
+	a := NewClawtaAdapter("", "", "", "")
+	if a.binary != defaultClawtaBinary {
+		t.Errorf("default binary: want %s, got %s", defaultClawtaBinary, a.binary)
 	}
-	if a.model != defaultCataModel {
-		t.Errorf("default model: want %s, got %s", defaultCataModel, a.model)
+	if a.model != defaultClawtaModel {
+		t.Errorf("default model: want %s, got %s", defaultClawtaModel, a.model)
 	}
-	if a.provider != defaultCataProvider {
-		t.Errorf("default provider: want %s, got %s", defaultCataProvider, a.provider)
+	if a.provider != defaultClawtaProvider {
+		t.Errorf("default provider: want %s, got %s", defaultClawtaProvider, a.provider)
 	}
 }
 
-func TestCataAdapterCustomValues(t *testing.T) {
-	a := NewCataAdapter("/usr/local/bin/cata", "deepseek-v3", "anthropic", "/tmp/ws")
-	if a.binary != "/usr/local/bin/cata" {
-		t.Errorf("binary: want /usr/local/bin/cata, got %s", a.binary)
+func TestClawtaAdapterCustomValues(t *testing.T) {
+	a := NewClawtaAdapter("/usr/local/bin/clawta", "deepseek-v3", "anthropic", "/tmp/ws")
+	if a.binary != "/usr/local/bin/clawta" {
+		t.Errorf("binary: want /usr/local/bin/clawta, got %s", a.binary)
 	}
 	if a.model != "deepseek-v3" {
 		t.Errorf("model: want deepseek-v3, got %s", a.model)
@@ -150,7 +150,7 @@ func TestSanitizeBranch(t *testing.T) {
 
 // TestDetectDefaultBranchMaster verifies that detectDefaultBranch returns
 // "master" when origin/main does not exist. Uses a real temp git repo with
-// a "master" remote branch to avoid actually calling the cata binary.
+// a "master" remote branch to avoid actually calling the clawta binary.
 func TestDetectDefaultBranchMaster(t *testing.T) {
 	// Build a bare "remote" repo with only a master branch.
 	remoteDir := t.TempDir()
@@ -207,16 +207,16 @@ func TestDetectDefaultBranchMain(t *testing.T) {
 
 // ---- Dispatch (mocked subprocess) ----
 
-// TestCataAdapterDispatchMissingBinary verifies that when the binary does not
+// TestClawtaAdapterDispatchMissingBinary verifies that when the binary does not
 // exist the result status is "failed" and no panic occurs.
 // The worktree creation will also fail (no real git repo), which is the first
 // failure surface — the adapter must handle it gracefully.
-func TestCataAdapterDispatchFailsGracefully(t *testing.T) {
+func TestClawtaAdapterDispatchFailsGracefully(t *testing.T) {
 	t.Setenv("DEEPSEEK_API_KEY", "test-key")
 
 	// Use a tmp dir that is NOT a git repo so worktree add fails immediately.
 	ws := t.TempDir()
-	a := NewCataAdapter("cata-does-not-exist", "", "", ws)
+	a := NewClawtaAdapter("clawta-does-not-exist", "", "", ws)
 
 	task := &Task{
 		ID:     "test-task-001",
@@ -236,8 +236,8 @@ func TestCataAdapterDispatchFailsGracefully(t *testing.T) {
 	if result.Status != "failed" {
 		t.Errorf("Status: want failed, got %s", result.Status)
 	}
-	if result.Adapter != "cata" {
-		t.Errorf("Adapter: want cata, got %s", result.Adapter)
+	if result.Adapter != "clawta" {
+		t.Errorf("Adapter: want clawta, got %s", result.Adapter)
 	}
 	if result.TaskID != "test-task-001" {
 		t.Errorf("TaskID: want test-task-001, got %s", result.TaskID)

--- a/internal/sprint/store.go
+++ b/internal/sprint/store.go
@@ -120,7 +120,7 @@ var DefaultRepos = []string{
 	"AgentGuardHQ/agentguard",
 	"AgentGuardHQ/octi-pulpo",
 	"AgentGuardHQ/shellforge",
-	"AgentGuardHQ/cata",
+	"AgentGuardHQ/clawta",
 	"AgentGuardHQ/sentinel",
 	"AgentGuardHQ/llmint",
 	"AgentGuardHQ/agentguard-analytics",


### PR DESCRIPTION
Full rebrand of Cata to Clawta across adapter code, squad mappings, DefaultRepos, and dispatch workflows.