### PR TITLE
fix: remove CLI driver health from Sprint Digest

### DIFF
--- a/internal/dispatch/brain.go
+++ b/internal/dispatch/brain.go
@@ -291,7 +291,7 @@ func (b *Brain) maybePostDashboard(ctx context.Context) {
 		return
 	}
 
-	drivers := b.dispatcher.router.AllHealth()
+	// NOTE: CLI driver health is deprecated (see #153). Pass nil to omit from digest.
 	rdb := b.dispatcher.RedisClient()
 	ns := b.dispatcher.Namespace()
 
@@ -306,7 +306,7 @@ func (b *Brain) maybePostDashboard(ctx context.Context) {
 			b.log.Printf("sprint digest: get all: %v", err)
 			// fall through to budget-only dashboard
 		} else {
-			if err := b.notifier.PostSprintDigest(ctx, drivers, ok, fail, items); err != nil {
+			if err := b.notifier.PostSprintDigest(ctx, nil, ok, fail, items); err != nil {
 				b.log.Printf("slack sprint digest: %v", err)
 				return
 			}
@@ -315,7 +315,7 @@ func (b *Brain) maybePostDashboard(ctx context.Context) {
 		}
 	}
 
-	if err := b.notifier.PostBudgetDashboard(ctx, drivers, ok, fail); err != nil {
+	if err := b.notifier.PostBudgetDashboard(ctx, nil, ok, fail); err != nil {
 		b.log.Printf("slack dashboard: %v", err)
 		return
 	}


### PR DESCRIPTION
## Summary
- Pass `nil` instead of driver health data to `PostSprintDigest` and `PostBudgetDashboard`
- Stops Slack from showing stale CLI driver failure counts (codex 262, copilot 193, etc.)
- Full routing layer cleanup tracked in #153

## Test plan
- [ ] Build passes
- [ ] Next Sprint Digest on Slack omits the "Drivers:" line

🤖 Generated with [Claude Code](https://claude.com/claude-code)