### PR TITLE
fix: update clawta-dispatch.yml email from agentguardhq to chitinhq

### DIFF
--- a/.github/workflows/clawta-dispatch.yml
+++ b/.github/workflows/clawta-dispatch.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Configure git identity
         run: |
-          git config --global user.email "octi-pulpo@agentguardhq.com"
+          git config --global user.email "octi-pulpo@chitinhq.com"
           git config --global user.name "Octi Pulpo Bot"
 
       - name: Run Clawta agent


### PR DESCRIPTION
## Summary
- Update bot email: `octi-pulpo@agentguardhq.com` → `octi-pulpo@chitinhq.com`

Part of the org rebrand from AgentGuardHQ to chitinhq.

## Test plan
- [ ] Verify workflow git identity uses correct email

🤖 Generated with [Claude Code](https://claude.com/claude-code)