### PR TITLE
refactor: update all repo names to canonical Chitin names

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -207,13 +207,13 @@
       all through standard MCP tools.
     </p>
     <div class="btn-row">
-      <a href="https://github.com/AgentGuardHQ/octi-pulpo" class="btn btn-primary">GitHub</a>
-      <a href="https://github.com/AgentGuardHQ/octi-pulpo#quick-start" class="btn btn-secondary">Get Started</a>
+      <a href="https://github.com/chitinhq/octi" class="btn btn-primary">GitHub</a>
+      <a href="https://github.com/chitinhq/octi#quick-start" class="btn btn-secondary">Get Started</a>
     </div>
   </section>
 
   <section class="install">
-    <pre>go install github.com/AgentGuardHQ/octi-pulpo/cmd/octi-pulpo@latest</pre>
+    <pre>go install github.com/chitinhq/octi/cmd/octi-pulpo@latest</pre>
   </section>
 
   <section class="arms">
@@ -282,17 +282,17 @@ Policy · Telemetry · Invariants</pre>
     <h2>Governed Swarm Platform</h2>
     <p class="subtitle">Three layers. One platform.</p>
     <div class="eco-row">
-      <a href="https://github.com/AgentGuardHQ/shellforge" class="eco-card">
+      <a href="https://github.com/chitinhq/shellforge" class="eco-card">
         <div class="eco-icon">🔥</div>
         <h3>ShellForge</h3>
         <p>Orchestration — forge and run agent swarms</p>
       </a>
-      <a href="https://github.com/AgentGuardHQ/octi-pulpo" class="eco-card active">
+      <a href="https://github.com/chitinhq/octi" class="eco-card active">
         <div class="eco-icon">🐙</div>
         <h3>Octi Pulpo</h3>
         <p>Coordination — make agents work together</p>
       </a>
-      <a href="https://github.com/AgentGuardHQ/agentguard" class="eco-card">
+      <a href="https://github.com/chitinhq/kernel" class="eco-card">
         <div class="eco-icon">🛡️</div>
         <h3>AgentGuard</h3>
         <p>Governance — policy, telemetry, invariants</p>
@@ -301,7 +301,7 @@ Policy · Telemetry · Invariants</pre>
   </section>
 
   <footer>
-    <p>Apache 2.0 &middot; Built by <a href="https://github.com/AgentGuardHQ">AgentGuardHQ</a></p>
+    <p>Apache 2.0 &middot; Built by <a href="https://github.com/chitinhq">chitinhq</a></p>
   </footer>
 
 </body>

--- a/internal/admission/admission.go
+++ b/internal/admission/admission.go
@@ -35,7 +35,7 @@ type TaskSpec struct {
 	Title string `json:"title"`
 	// Squad is the owning squad (e.g. "kernel", "octi-pulpo").
 	Squad string `json:"squad"`
-	// Repo is the target repository (e.g. "chitinhq/agentguard").
+	// Repo is the target repository (e.g. "chitinhq/kernel").
 	Repo string `json:"repo"`
 	// FilePaths lists files this task will touch (used for blast-radius scoring).
 	FilePaths []string `json:"file_paths,omitempty"`

--- a/internal/admission/admission_test.go
+++ b/internal/admission/admission_test.go
@@ -45,7 +45,7 @@ func TestScore_Accept(t *testing.T) {
 	score := g.Score(ctx, admission.TaskSpec{
 		Title:        "Fix nil pointer in handler",
 		Squad:        "kernel",
-		Repo:         "chitinhq/agentguard",
+		Repo:         "chitinhq/kernel",
 		FilePaths:    []string{"internal/handler/handler.go"},
 		Priority:     1,
 		IsReversible: true,
@@ -65,7 +65,7 @@ func TestScore_LowClarity_Preflight(t *testing.T) {
 	score := g.Score(ctx, admission.TaskSpec{
 		Title:       "Do the thing",
 		Squad:       "kernel",
-		Repo:        "chitinhq/agentguard",
+		Repo:        "chitinhq/kernel",
 		SpecClarity: 0.3,
 		Priority:    2,
 	})
@@ -84,7 +84,7 @@ func TestScore_LargeBlast_Defer(t *testing.T) {
 	score := g.Score(ctx, admission.TaskSpec{
 		Title:        "Partial refactor",
 		Squad:        "kernel",
-		Repo:         "chitinhq/agentguard",
+		Repo:         "chitinhq/kernel",
 		FilePaths:    files,
 		Priority:     2,
 		IsReversible: true,
@@ -106,7 +106,7 @@ func TestScore_HugeBlast_Reject(t *testing.T) {
 	score := g.Score(ctx, admission.TaskSpec{
 		Title:        "Big bang refactor",
 		Squad:        "kernel",
-		Repo:         "chitinhq/agentguard",
+		Repo:         "chitinhq/kernel",
 		FilePaths:    files,
 		Priority:     3,
 		IsReversible: false,
@@ -129,7 +129,7 @@ func TestScore_AllPenalties_Reject(t *testing.T) {
 	score := g.Score(ctx, admission.TaskSpec{
 		Title:           "Everything everywhere all at once",
 		Squad:           "kernel",
-		Repo:            "chitinhq/agentguard",
+		Repo:            "chitinhq/kernel",
 		FilePaths:       files,
 		Priority:        3,
 		IsReversible:    false,

--- a/internal/dispatch/adapter.go
+++ b/internal/dispatch/adapter.go
@@ -13,7 +13,7 @@ type Adapter interface {
 type Task struct {
 	ID       string   `json:"id"`
 	Type     string   `json:"type"`     // "code-gen", "bugfix", "pr-review", "qa", "triage"
-	Repo     string   `json:"repo"`     // "chitinhq/octi-pulpo"
+	Repo     string   `json:"repo"`     // "chitinhq/octi"
 	Prompt   string   `json:"prompt"`
 	Toolset  []string `json:"toolset"`  // allowed tools for this task type
 	Priority string   `json:"priority"` // "critical", "high", "normal", "background"

--- a/internal/dispatch/adapter_test.go
+++ b/internal/dispatch/adapter_test.go
@@ -16,7 +16,7 @@ func TestTaskFields(t *testing.T) {
 	task := Task{
 		ID:       "t1",
 		Type:     "code-gen",
-		Repo:     "chitinhq/octi-pulpo",
+		Repo:     "chitinhq/octi",
 		Prompt:   "write a hello world",
 		Toolset:  []string{"read_file", "write_file"},
 		Priority: "normal",
@@ -30,7 +30,7 @@ func TestTaskFields(t *testing.T) {
 	if task.Type != "code-gen" {
 		t.Errorf("Type: got %q", task.Type)
 	}
-	if task.Repo != "chitinhq/octi-pulpo" {
+	if task.Repo != "chitinhq/octi" {
 		t.Errorf("Repo: got %q", task.Repo)
 	}
 	if len(task.Toolset) != 2 {
@@ -127,7 +127,7 @@ func TestGHActionsAdapterName(t *testing.T) {
 
 func TestGHActionsAdapterCanAccept(t *testing.T) {
 	g := NewGHActionsAdapter("mytoken")
-	task := &Task{ID: "t1", Repo: "chitinhq/octi-pulpo"}
+	task := &Task{ID: "t1", Repo: "chitinhq/octi"}
 	if !g.CanAccept(task) {
 		t.Error("expected CanAccept true with token + repo")
 	}
@@ -144,7 +144,7 @@ func TestGHActionsAdapterCanAccept_NoRepo(t *testing.T) {
 func TestGHActionsAdapterCanAccept_NoToken(t *testing.T) {
 	os.Unsetenv("GITHUB_TOKEN")
 	g := NewGHActionsAdapter("")
-	task := &Task{ID: "t1", Repo: "chitinhq/octi-pulpo"}
+	task := &Task{ID: "t1", Repo: "chitinhq/octi"}
 	if g.CanAccept(task) {
 		t.Error("expected CanAccept false when token is empty")
 	}
@@ -177,7 +177,7 @@ func TestGHActionsAdapterDispatch(t *testing.T) {
 	task := &Task{
 		ID:       "task-99",
 		Type:     "pr-review",
-		Repo:     "chitinhq/octi-pulpo",
+		Repo:     "chitinhq/octi",
 		Prompt:   "review this PR",
 		Toolset:  []string{"read_file"},
 		Priority: "high",

--- a/internal/dispatch/branch_updater_test.go
+++ b/internal/dispatch/branch_updater_test.go
@@ -78,7 +78,7 @@ func TestHandlePush_UpdatesBehindPRs(t *testing.T) {
 
 	bu := newTestBranchUpdater(srv.URL, "test-token")
 
-	results, err := bu.HandlePush(context.Background(), "chitinhq/octi-pulpo", "main")
+	results, err := bu.HandlePush(context.Background(), "chitinhq/octi", "main")
 	if err != nil {
 		t.Fatalf("HandlePush: %v", err)
 	}
@@ -118,7 +118,7 @@ func TestHandlePush_NoPRs(t *testing.T) {
 
 	bu := newTestBranchUpdater(srv.URL, "test-token")
 
-	results, err := bu.HandlePush(context.Background(), "chitinhq/octi-pulpo", "main")
+	results, err := bu.HandlePush(context.Background(), "chitinhq/octi", "main")
 	if err != nil {
 		t.Fatalf("HandlePush: %v", err)
 	}
@@ -131,7 +131,7 @@ func TestHandlePush_NoTokenReturnsError(t *testing.T) {
 	bu := NewBranchUpdater("")
 	bu.ghToken = ""
 
-	_, err := bu.HandlePush(context.Background(), "chitinhq/octi-pulpo", "main")
+	_, err := bu.HandlePush(context.Background(), "chitinhq/octi", "main")
 	if err == nil {
 		t.Fatal("expected error for missing token, got nil")
 	}
@@ -146,7 +146,7 @@ func TestHandlePush_APIErrorOnListPRs(t *testing.T) {
 
 	bu := newTestBranchUpdater(srv.URL, "test-token")
 
-	_, err := bu.HandlePush(context.Background(), "chitinhq/octi-pulpo", "main")
+	_, err := bu.HandlePush(context.Background(), "chitinhq/octi", "main")
 	if err == nil {
 		t.Fatal("expected error on API failure, got nil")
 	}
@@ -181,7 +181,7 @@ func TestHandlePush_CompareErrorSkipsPR(t *testing.T) {
 
 	bu := newTestBranchUpdater(srv.URL, "test-token")
 
-	results, err := bu.HandlePush(context.Background(), "chitinhq/octi-pulpo", "main")
+	results, err := bu.HandlePush(context.Background(), "chitinhq/octi", "main")
 	if err != nil {
 		t.Fatalf("HandlePush: %v", err)
 	}
@@ -230,7 +230,7 @@ func TestHandlePush_UpdateBranchErrorSkipsPR(t *testing.T) {
 
 	bu := newTestBranchUpdater(srv.URL, "test-token")
 
-	results, err := bu.HandlePush(context.Background(), "chitinhq/octi-pulpo", "main")
+	results, err := bu.HandlePush(context.Background(), "chitinhq/octi", "main")
 	if err != nil {
 		t.Fatalf("HandlePush: %v", err)
 	}

--- a/internal/dispatch/cascade_handler.go
+++ b/internal/dispatch/cascade_handler.go
@@ -46,11 +46,11 @@ type CascadeHandler struct {
 
 // DefaultCascadeRepos is the list of repos the cascade handler manages.
 var DefaultCascadeRepos = []string{
-	"chitinhq/agentguard-cloud",
-	"chitinhq/agentguard",
-	"chitinhq/octi-pulpo",
+	"chitinhq/cloud",
+	"chitinhq/kernel",
+	"chitinhq/octi",
 	"chitinhq/shellforge",
-	"chitinhq/agentguard-analytics",
+	"chitinhq/analytics",
 }
 
 // NewCascadeHandler creates a cascade handler. Reads tokens from env if empty.
@@ -164,7 +164,7 @@ func (ch *CascadeHandler) fetchRoadmap(ctx context.Context) (string, error) {
 
 	if resp.StatusCode == http.StatusNotFound {
 		// Fallback: try strategy/roadmap.md
-		return ch.fetchFile(ctx, "chitinhq/agentguard-workspace", "strategy/roadmap.md")
+		return ch.fetchFile(ctx, "chitinhq/workspace", "strategy/roadmap.md")
 	}
 
 	if resp.StatusCode != http.StatusOK {

--- a/internal/dispatch/clawta_adapter_test.go
+++ b/internal/dispatch/clawta_adapter_test.go
@@ -221,7 +221,7 @@ func TestClawtaAdapterDispatchFailsGracefully(t *testing.T) {
 	task := &Task{
 		ID:     "test-task-001",
 		Type:   "code-gen",
-		Repo:   "chitinhq/octi-pulpo",
+		Repo:   "chitinhq/octi",
 		Prompt: "Add a hello world function",
 	}
 

--- a/internal/dispatch/copilot_adapter_test.go
+++ b/internal/dispatch/copilot_adapter_test.go
@@ -92,7 +92,7 @@ func TestCopilotAdapterDispatch(t *testing.T) {
 	task := &Task{
 		ID:       "task-123",
 		Type:     "code-gen",
-		Repo:     "chitinhq/octi-pulpo",
+		Repo:     "chitinhq/octi",
 		Prompt:   "Write a function to calculate factorial",
 		Toolset:  []string{"read_file", "write_file"},
 		Priority: "normal",

--- a/internal/dispatch/dispatcher_test.go
+++ b/internal/dispatch/dispatcher_test.go
@@ -269,7 +269,7 @@ func TestEventRouter_MatchesPROpened(t *testing.T) {
 	event := Event{
 		Type:   EventPROpened,
 		Source: "github",
-		Repo:   "chitinhq/agentguard",
+		Repo:   "chitinhq/kernel",
 	}
 
 	matches := er.Match(event)
@@ -295,7 +295,7 @@ func TestEventRouter_MatchesCICompleted(t *testing.T) {
 	event := Event{
 		Type:   EventCICompleted,
 		Source: "github",
-		Repo:   "chitinhq/agentguard-cloud",
+		Repo:   "chitinhq/cloud",
 	}
 
 	matches := er.Match(event)
@@ -429,7 +429,7 @@ func TestDispatchEvent_PROpenedRoutes(t *testing.T) {
 	event := Event{
 		Type:   EventPROpened,
 		Source: "github",
-		Repo:   "chitinhq/agentguard",
+		Repo:   "chitinhq/kernel",
 	}
 
 	results, err := d.DispatchEvent(ctx, event)

--- a/internal/dispatch/draft_converter_test.go
+++ b/internal/dispatch/draft_converter_test.go
@@ -163,7 +163,7 @@ func TestConvertToReady(t *testing.T) {
 
 	dc := newTestDraftConverter(srv.URL, "test-token")
 
-	result, err := dc.ConvertToReady(context.Background(), "chitinhq/octi-pulpo", 42)
+	result, err := dc.ConvertToReady(context.Background(), "chitinhq/octi", 42)
 	if err != nil {
 		t.Fatalf("ConvertToReady returned error: %v", err)
 	}
@@ -183,8 +183,8 @@ func TestConvertToReady(t *testing.T) {
 	if method != http.MethodPatch {
 		t.Errorf("method = %s, want PATCH", method)
 	}
-	if path != "/repos/chitinhq/octi-pulpo/pulls/42" {
-		t.Errorf("path = %s, want /repos/chitinhq/octi-pulpo/pulls/42", path)
+	if path != "/repos/chitinhq/octi/pulls/42" {
+		t.Errorf("path = %s, want /repos/chitinhq/octi/pulls/42", path)
 	}
 	draftVal, ok := body["draft"].(bool)
 	if !ok || draftVal != false {
@@ -202,7 +202,7 @@ func TestConvertToReadyAPIError(t *testing.T) {
 
 	dc := newTestDraftConverter(srv.URL, "test-token")
 
-	_, err := dc.ConvertToReady(context.Background(), "chitinhq/octi-pulpo", 99)
+	_, err := dc.ConvertToReady(context.Background(), "chitinhq/octi", 99)
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -214,7 +214,7 @@ func TestConvertToReadyNoToken(t *testing.T) {
 	// Unset any env-provided token to ensure the empty path is exercised.
 	dc.ghToken = ""
 
-	_, err := dc.ConvertToReady(context.Background(), "chitinhq/octi-pulpo", 1)
+	_, err := dc.ConvertToReady(context.Background(), "chitinhq/octi", 1)
 	if err == nil {
 		t.Fatal("expected error for missing token, got nil")
 	}
@@ -222,7 +222,7 @@ func TestConvertToReadyNoToken(t *testing.T) {
 
 // TestSkipResult verifies the skip helper builds the right struct.
 func TestSkipResult(t *testing.T) {
-	r := SkipResult("chitinhq/octi-pulpo", 7, "not a copilot PR")
+	r := SkipResult("chitinhq/octi", 7, "not a copilot PR")
 	if !r.Skipped {
 		t.Error("expected Skipped=true")
 	}

--- a/internal/dispatch/events.go
+++ b/internal/dispatch/events.go
@@ -28,7 +28,7 @@ const (
 type Event struct {
 	Type     EventType         `json:"type"`
 	Source   string            `json:"source"`   // "github", "cron", "slack", "manual"
-	Repo     string            `json:"repo"`     // "chitinhq/agentguard"
+	Repo     string            `json:"repo"`     // "chitinhq/kernel"
 	Payload  map[string]string `json:"payload"`  // event-specific data
 	Priority int               `json:"priority"` // 0=critical, 1=high, 2=normal, 3=background
 }
@@ -89,42 +89,42 @@ func DefaultRules() []EventRule {
 		// PR review agents (triggered by PR events)
 		{
 			EventType: EventPROpened,
-			RepoMatch: "chitinhq/agentguard",
+			RepoMatch: "chitinhq/kernel",
 			AgentName: "workspace-pr-review-agent",
 			Priority:  1,
 			Cooldown:  5 * time.Minute,
 		},
 		{
 			EventType: EventPRUpdated,
-			RepoMatch: "chitinhq/agentguard",
+			RepoMatch: "chitinhq/kernel",
 			AgentName: "workspace-pr-review-agent",
 			Priority:  1,
 			Cooldown:  5 * time.Minute,
 		},
 		{
 			EventType: EventPROpened,
-			RepoMatch: "chitinhq/agentguard-cloud",
+			RepoMatch: "chitinhq/cloud",
 			AgentName: "code-review-agent-cloud",
 			Priority:  1,
 			Cooldown:  5 * time.Minute,
 		},
 		{
 			EventType: EventPRUpdated,
-			RepoMatch: "chitinhq/agentguard-cloud",
+			RepoMatch: "chitinhq/cloud",
 			AgentName: "code-review-agent-cloud",
 			Priority:  1,
 			Cooldown:  5 * time.Minute,
 		},
 		{
 			EventType: EventPROpened,
-			RepoMatch: "chitinhq/agentguard-analytics",
+			RepoMatch: "chitinhq/analytics",
 			AgentName: "analytics-pr-review-agent",
 			Priority:  1,
 			Cooldown:  5 * time.Minute,
 		},
 		{
 			EventType: EventPROpened,
-			RepoMatch: "chitinhq/agentguard-workspace",
+			RepoMatch: "chitinhq/workspace",
 			AgentName: "workspace-pr-review-agent",
 			Priority:  1,
 			Cooldown:  5 * time.Minute,
@@ -133,28 +133,28 @@ func DefaultRules() []EventRule {
 		// PR merger agents (triggered by CI completion)
 		{
 			EventType: EventCICompleted,
-			RepoMatch: "chitinhq/agentguard",
+			RepoMatch: "chitinhq/kernel",
 			AgentName: "pr-merger-agent",
 			Priority:  2,
 			Cooldown:  10 * time.Minute, // prevents stampede (was 214 runs/day)
 		},
 		{
 			EventType: EventCICompleted,
-			RepoMatch: "chitinhq/agentguard-cloud",
+			RepoMatch: "chitinhq/cloud",
 			AgentName: "pr-merger-agent-cloud",
 			Priority:  2,
 			Cooldown:  10 * time.Minute,
 		},
 		{
 			EventType: EventCICompleted,
-			RepoMatch: "chitinhq/agentguard-analytics",
+			RepoMatch: "chitinhq/analytics",
 			AgentName: "analytics-pr-review-agent",
 			Priority:  2,
 			Cooldown:  10 * time.Minute,
 		},
 		{
 			EventType: EventCICompleted,
-			RepoMatch: "chitinhq/agentguard-workspace",
+			RepoMatch: "chitinhq/workspace",
 			AgentName: "pr-merger-agent",
 			Priority:  2,
 			Cooldown:  10 * time.Minute,

--- a/internal/dispatch/slack_actions_test.go
+++ b/internal/dispatch/slack_actions_test.go
@@ -83,7 +83,7 @@ func TestNotifier_PostPRReadyAlert(t *testing.T) {
 	ctx := context.Background()
 	n := NewNotifier(srv.URL)
 
-	if err := n.PostPRReadyAlert(ctx, "chitinhq/octi-pulpo", 42, "feat: my change"); err != nil {
+	if err := n.PostPRReadyAlert(ctx, "chitinhq/octi", 42, "feat: my change"); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -252,7 +252,7 @@ func TestWebhookServer_SlackActions_NoSignatureCheck_WhenSecretEmpty(t *testing.
 	ws := NewWebhookServer(d, "")
 	// No signing secret set — should accept any request (useful for local dev)
 
-	body := makeSlackPayload("skip_pr", "chitinhq/octi-pulpo/42", "jared")
+	body := makeSlackPayload("skip_pr", "chitinhq/octi/42", "jared")
 	req := httptest.NewRequest(http.MethodPost, "/slack/actions", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	rr := httptest.NewRecorder()

--- a/internal/dispatch/slack_intake_test.go
+++ b/internal/dispatch/slack_intake_test.go
@@ -1,6 +1,9 @@
 package dispatch
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestClassifyMessage(t *testing.T) {
 	tests := []struct {
@@ -25,28 +28,28 @@ func TestClassifyMessage(t *testing.T) {
 func TestFormatBudgetAlert(t *testing.T) {
 	alert := FormatBudgetAlert("claude-code", 15, 2)
 
-	if !contains(alert, "claude-code") {
+	if !strings.Contains(alert, "claude-code") {
 		t.Error("expected driver name in alert")
 	}
-	if !contains(alert, "15%") {
+	if !strings.Contains(alert, "15%") {
 		t.Error("expected percentage in alert")
 	}
-	if !contains(alert, "2 architect") {
+	if !strings.Contains(alert, "2 architect") {
 		t.Error("expected queued task count in alert")
 	}
 }
 
 func TestFormatEscalation(t *testing.T) {
-	blocks := FormatEscalation("chitinhq/agentguard", 42, "High blast radius: modifies auth middleware", 55)
+	blocks := FormatEscalation("chitinhq/kernel", 42, "High blast radius: modifies auth middleware", 55)
 
 	if len(blocks) == 0 {
 		t.Fatal("expected non-empty blocks")
 	}
 	raw := blocksToString(blocks)
-	if !contains(raw, "#42") {
+	if !strings.Contains(raw, "#42") {
 		t.Error("expected PR number in escalation")
 	}
-	if !contains(raw, "auth middleware") {
+	if !strings.Contains(raw, "auth middleware") {
 		t.Error("expected reason in escalation")
 	}
 }

--- a/internal/dispatch/slack_test.go
+++ b/internal/dispatch/slack_test.go
@@ -173,9 +173,9 @@ func TestNotifier_PostSprintDigest_Basic(t *testing.T) {
 		{Name: "codex", CircuitState: "OPEN", Failures: 73},
 	}
 	items := []sprint.SprintItem{
-		{IssueNum: 1, Repo: "chitinhq/octi-pulpo", Title: "feat A", Status: "done", Priority: 0},
-		{IssueNum: 2, Repo: "chitinhq/octi-pulpo", Title: "feat B", Status: "open", Priority: 1},
-		{IssueNum: 3, Repo: "chitinhq/octi-pulpo", Title: "feat C", Status: "pr_open", PRNumber: 42, Priority: 1},
+		{IssueNum: 1, Repo: "chitinhq/octi", Title: "feat A", Status: "done", Priority: 0},
+		{IssueNum: 2, Repo: "chitinhq/octi", Title: "feat B", Status: "open", Priority: 1},
+		{IssueNum: 3, Repo: "chitinhq/octi", Title: "feat C", Status: "pr_open", PRNumber: 42, Priority: 1},
 	}
 
 	if err := n.PostSprintDigest(ctx, drivers, 90, 10, items); err != nil {
@@ -223,8 +223,8 @@ func TestNotifier_PostSprintDigest_ShowsBlockers(t *testing.T) {
 
 	// Item 20 depends on item 10, which is still open → blocker
 	items := []sprint.SprintItem{
-		{IssueNum: 10, Repo: "chitinhq/octi-pulpo", Title: "dep item", Status: "open", Priority: 1},
-		{IssueNum: 20, Repo: "chitinhq/octi-pulpo", Title: "blocked item", Status: "open", Priority: 2, DependsOn: []int{10}},
+		{IssueNum: 10, Repo: "chitinhq/octi", Title: "dep item", Status: "open", Priority: 1},
+		{IssueNum: 20, Repo: "chitinhq/octi", Title: "blocked item", Status: "open", Priority: 2, DependsOn: []int{10}},
 	}
 
 	if err := n.PostSprintDigest(ctx, nil, 0, 0, items); err != nil {
@@ -261,8 +261,8 @@ func TestNotifier_PostSprintDigest_NoBlockersWhenDepDone(t *testing.T) {
 
 	// Item 20 depends on item 10, which is done → not a blocker
 	items := []sprint.SprintItem{
-		{IssueNum: 10, Repo: "chitinhq/octi-pulpo", Title: "dep item", Status: "done", Priority: 0},
-		{IssueNum: 20, Repo: "chitinhq/octi-pulpo", Title: "unblocked item", Status: "open", Priority: 1, DependsOn: []int{10}},
+		{IssueNum: 10, Repo: "chitinhq/octi", Title: "dep item", Status: "done", Priority: 0},
+		{IssueNum: 20, Repo: "chitinhq/octi", Title: "unblocked item", Status: "open", Priority: 1, DependsOn: []int{10}},
 	}
 
 	if err := n.PostSprintDigest(ctx, nil, 0, 0, items); err != nil {

--- a/internal/dispatch/webhook.go
+++ b/internal/dispatch/webhook.go
@@ -423,7 +423,7 @@ func (ws *WebhookServer) handleWebhook(w http.ResponseWriter, r *http.Request) {
 	// Strategy cascade: when roadmap.md or strategy/ changes are pushed to
 	// agentguard-workspace, diff roadmap against managed issues and sync.
 	if event.Type == EventPush && ws.cascadeHandler != nil {
-		if repo == "chitinhq/agentguard-workspace" && event.Payload["touches_roadmap"] == "true" {
+		if repo == "chitinhq/workspace" && event.Payload["touches_roadmap"] == "true" {
 			go func() {
 				result, err := ws.cascadeHandler.HandlePush(context.Background())
 				if err != nil {

--- a/internal/learner/learner_test.go
+++ b/internal/learner/learner_test.go
@@ -9,7 +9,7 @@ func TestRepoShortName(t *testing.T) {
 	cases := []struct {
 		input, want string
 	}{
-		{"chitinhq/octi-pulpo", "octi-pulpo"},
+		{"chitinhq/octi", "octi"},
 		{"chitinhq/shellforge", "shellforge"},
 		{"single", "single"},
 		{"", ""},
@@ -26,7 +26,7 @@ func TestRecordOutcome_BuildsContent(t *testing.T) {
 	// but we can verify the content formatting logic.
 	task := &TaskInfo{
 		Type:     "bugfix",
-		Repo:     "chitinhq/octi-pulpo",
+		Repo:     "chitinhq/octi",
 		Prompt:   "fix the null pointer in auth handler",
 		Priority: "high",
 	}

--- a/internal/learner/procedure_test.go
+++ b/internal/learner/procedure_test.go
@@ -4,7 +4,7 @@ import "testing"
 
 func TestParseEpisode(t *testing.T) {
 	content := `Task: fix the null pointer in auth handler
-Type: bugfix | Repo: chitinhq/octi-pulpo | Priority: high
+Type: bugfix | Repo: chitinhq/octi | Priority: high
 Outcome: completed | Adapter: anthropic-cascade:claude-haiku-4-5-20251001
 Tokens: 2500 in / 800 out | Cost: $0.0100
 Summary: Fixed by adding nil check in middleware/auth.go line 47`
@@ -14,8 +14,8 @@ Summary: Fixed by adding nil check in middleware/auth.go line 47`
 	if ep.taskType != "bugfix" {
 		t.Errorf("expected bugfix, got %s", ep.taskType)
 	}
-	if ep.repo != "chitinhq/octi-pulpo" {
-		t.Errorf("expected chitinhq/octi-pulpo, got %s", ep.repo)
+	if ep.repo != "chitinhq/octi" {
+		t.Errorf("expected chitinhq/octi, got %s", ep.repo)
 	}
 	if ep.status != "completed" {
 		t.Errorf("expected completed, got %s", ep.status)
@@ -42,9 +42,9 @@ Error: shellforge exited: exit status 1`
 
 func TestBuildProcedure(t *testing.T) {
 	episodes := []episodeData{
-		{taskType: "bugfix", repo: "chitinhq/octi-pulpo", status: "completed", prompt: "fix auth bug"},
-		{taskType: "bugfix", repo: "chitinhq/octi-pulpo", status: "completed", prompt: "fix session bug"},
-		{taskType: "bugfix", repo: "chitinhq/octi-pulpo", status: "failed", prompt: "fix crash"},
+		{taskType: "bugfix", repo: "chitinhq/octi", status: "completed", prompt: "fix auth bug"},
+		{taskType: "bugfix", repo: "chitinhq/octi", status: "completed", prompt: "fix session bug"},
+		{taskType: "bugfix", repo: "chitinhq/octi", status: "failed", prompt: "fix crash"},
 	}
 
 	proc := buildProcedure("bugfix:chitinhq/octi-pulpo", episodes)

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -1115,7 +1115,7 @@ func toolDefs() []ToolDef {
 				"properties": map[string]interface{}{
 					"eventType": map[string]interface{}{"type": "string", "enum": []string{"pr.opened", "pr.updated", "ci.completed", "timer", "budget.change", "manual", "slack.action"}, "description": "Event type"},
 					"source":    map[string]string{"type": "string", "description": "Event source (github, cron, slack, manual)"},
-					"repo":      map[string]string{"type": "string", "description": "Repository full name (e.g. chitinhq/agentguard)"},
+					"repo":      map[string]string{"type": "string", "description": "Repository full name (e.g. chitinhq/kernel)"},
 					"payload":   map[string]interface{}{"type": "object", "description": "Event-specific key-value data"},
 					"priority":  map[string]interface{}{"type": "number", "description": "Priority (0=critical, 1=high, 2=normal, 3=background)"},
 				},
@@ -1355,7 +1355,7 @@ func toolDefs() []ToolDef {
 				"properties": map[string]interface{}{
 					"title":            map[string]string{"type": "string", "description": "Short task title"},
 					"squad":            map[string]string{"type": "string", "description": "Owning squad (e.g. 'kernel')"},
-					"repo":             map[string]string{"type": "string", "description": "Target repo (e.g. 'chitinhq/agentguard')"},
+					"repo":             map[string]string{"type": "string", "description": "Target repo (e.g. 'chitinhq/kernel')"},
 					"file_paths":       map[string]interface{}{"type": "array", "items": map[string]string{"type": "string"}, "description": "Files the task will touch (used for blast-radius scoring)"},
 					"priority":         map[string]interface{}{"type": "integer", "description": "0=CRITICAL, 1=HIGH, 2=NORMAL, 3=BACKGROUND"},
 					"is_reversible":    map[string]interface{}{"type": "boolean", "description": "Whether the changes can be easily undone"},

--- a/internal/optimize/dedup_test.go
+++ b/internal/optimize/dedup_test.go
@@ -5,15 +5,15 @@ import (
 )
 
 func TestTaskHash_Deterministic(t *testing.T) {
-	h1 := TaskHash("code-gen", "fix the bug", "chitinhq/octi-pulpo")
-	h2 := TaskHash("code-gen", "fix the bug", "chitinhq/octi-pulpo")
+	h1 := TaskHash("code-gen", "fix the bug", "chitinhq/octi")
+	h2 := TaskHash("code-gen", "fix the bug", "chitinhq/octi")
 	if h1 != h2 {
 		t.Errorf("same inputs should produce same hash: %s vs %s", h1, h2)
 	}
 }
 
 func TestTaskHash_DifferentInputs(t *testing.T) {
-	h1 := TaskHash("code-gen", "fix the bug", "chitinhq/octi-pulpo")
+	h1 := TaskHash("code-gen", "fix the bug", "chitinhq/octi")
 	h2 := TaskHash("code-gen", "fix the bug", "chitinhq/shellforge")
 	if h1 == h2 {
 		t.Error("different repos should produce different hashes")

--- a/internal/sprint/store.go
+++ b/internal/sprint/store.go
@@ -117,16 +117,16 @@ type Store struct {
 
 // DefaultRepos is the standard set of repos to sync.
 var DefaultRepos = []string{
-	"chitinhq/agentguard",
-	"chitinhq/octi-pulpo",
+	"chitinhq/kernel",
+	"chitinhq/octi",
 	"chitinhq/shellforge",
 	"chitinhq/clawta",
 	"chitinhq/sentinel",
 	"chitinhq/llmint",
-	"chitinhq/agentguard-analytics",
-	"chitinhq/agentguard-cloud",
-	"chitinhq/agentguard-workspace",
-	"chitinhq/agentguard-extensions",
+	"chitinhq/analytics",
+	"chitinhq/cloud",
+	"chitinhq/workspace",
+	"chitinhq/extensions",
 	"chitinhq/preflight",
 	"chitinhq/homebrew-tap",
 }
@@ -840,19 +840,19 @@ func inferSquadFromRepo(repo string) string {
 	}
 	name := parts[1]
 	switch {
-	case name == "agentguard":
+	case name == "kernel":
 		return "kernel"
-	case name == "agentguard-cloud":
+	case name == "cloud":
 		return "cloud"
-	case name == "agentguard-analytics":
+	case name == "analytics":
 		return "analytics"
-	case name == "agentguard-extensions" || name == "preflight" || name == "homebrew-tap":
+	case name == "extensions" || name == "preflight" || name == "homebrew-tap":
 		return "kernel"
-	case name == "agentguard-workspace":
+	case name == "workspace":
 		return "ops"
 	case name == "shellforge":
 		return "shellforge"
-	case name == "octi-pulpo":
+	case name == "octi":
 		return "octi-pulpo"
 	case strings.HasPrefix(name, "studio"):
 		return "studio"

--- a/internal/sprint/store_test.go
+++ b/internal/sprint/store_test.go
@@ -52,17 +52,17 @@ func TestStore_UpdateStatus(t *testing.T) {
 	item := SprintItem{
 		Squad:    "kernel",
 		IssueNum: 42,
-		Repo:     "chitinhq/agentguard",
+		Repo:     "chitinhq/kernel",
 		Title:    "Fix bug",
 		Priority: 0,
 		Status:   "open",
 	}
 	data, _ := json.Marshal(item)
-	s.rdb.Set(ctx, s.itemKey("chitinhq/agentguard", 42), data, 0)
-	s.rdb.SAdd(ctx, s.key("sprint-repos"), "chitinhq/agentguard")
+	s.rdb.Set(ctx, s.itemKey("chitinhq/kernel", 42), data, 0)
+	s.rdb.SAdd(ctx, s.key("sprint-repos"), "chitinhq/kernel")
 
 	// Update status
-	err := s.UpdateStatus(ctx, "chitinhq/agentguard", 42, "in_progress")
+	err := s.UpdateStatus(ctx, "chitinhq/kernel", 42, "in_progress")
 	if err != nil {
 		t.Fatalf("update status: %v", err)
 	}
@@ -80,7 +80,7 @@ func TestStore_UpdateStatus(t *testing.T) {
 func TestStore_NextDispatchable(t *testing.T) {
 	s, ctx := testStore(t)
 
-	repo := "chitinhq/agentguard"
+	repo := "chitinhq/kernel"
 	s.rdb.SAdd(ctx, s.key("sprint-repos"), repo)
 
 	// Seed items: one open with no deps, one open with unmet dep, one done
@@ -118,8 +118,8 @@ func TestStore_NextDispatchable(t *testing.T) {
 func TestStore_GetBySquad(t *testing.T) {
 	s, ctx := testStore(t)
 
-	repo1 := "chitinhq/agentguard"
-	repo2 := "chitinhq/octi-pulpo"
+	repo1 := "chitinhq/kernel"
+	repo2 := "chitinhq/octi"
 	s.rdb.SAdd(ctx, s.key("sprint-repos"), repo1, repo2)
 
 	items := []SprintItem{
@@ -176,7 +176,7 @@ func TestParseIssueRefs(t *testing.T) {
 func TestStore_NextDispatchable_SkipsPROpen(t *testing.T) {
 	s, ctx := testStore(t)
 
-	repo := "chitinhq/octi-pulpo"
+	repo := "chitinhq/octi"
 	s.rdb.SAdd(ctx, s.key("sprint-repos"), repo)
 
 	items := []SprintItem{
@@ -205,7 +205,7 @@ func TestStore_NextDispatchable_SkipsPROpen(t *testing.T) {
 func TestStore_NextMergeable(t *testing.T) {
 	s, ctx := testStore(t)
 
-	repo := "chitinhq/octi-pulpo"
+	repo := "chitinhq/octi"
 	s.rdb.SAdd(ctx, s.key("sprint-repos"), repo)
 
 	items := []SprintItem{
@@ -243,7 +243,7 @@ func TestStore_NextMergeable(t *testing.T) {
 func TestStore_NextMergeable_Empty(t *testing.T) {
 	s, ctx := testStore(t)
 
-	repo := "chitinhq/octi-pulpo"
+	repo := "chitinhq/octi"
 	s.rdb.SAdd(ctx, s.key("sprint-repos"), repo)
 
 	items := []SprintItem{
@@ -266,7 +266,7 @@ func TestStore_NextMergeable_Empty(t *testing.T) {
 func TestStore_SyncPRs_PreservesNonOpen(t *testing.T) {
 	s, ctx := testStore(t)
 
-	repo := "chitinhq/octi-pulpo"
+	repo := "chitinhq/octi"
 	s.rdb.SAdd(ctx, s.key("sprint-repos"), repo)
 
 	// Seed items: one claimed, one done — SyncPRs must not override either
@@ -314,7 +314,7 @@ func TestStore_SyncPRs_PreservesNonOpen(t *testing.T) {
 
 func TestMarkClosedItems_MarksOpenAndPROpen(t *testing.T) {
 	s, ctx := testStore(t)
-	repo := "chitinhq/octi-pulpo"
+	repo := "chitinhq/octi"
 	s.rdb.SAdd(ctx, s.key("sprint-repos"), repo)
 
 	items := []SprintItem{
@@ -352,7 +352,7 @@ func TestMarkClosedItems_MarksOpenAndPROpen(t *testing.T) {
 
 func TestMarkClosedItems_SkipsUntracked(t *testing.T) {
 	s, ctx := testStore(t)
-	repo := "chitinhq/octi-pulpo"
+	repo := "chitinhq/octi"
 
 	// Sprint store has no items for this repo
 	marked := s.markClosedItems(ctx, repo, []int{1, 2, 3})
@@ -363,7 +363,7 @@ func TestMarkClosedItems_SkipsUntracked(t *testing.T) {
 
 func TestMarkClosedItems_EmptyList(t *testing.T) {
 	s, ctx := testStore(t)
-	marked := s.markClosedItems(ctx, "chitinhq/octi-pulpo", []int{})
+	marked := s.markClosedItems(ctx, "chitinhq/octi", []int{})
 	if marked != 0 {
 		t.Fatalf("expected 0 for empty list, got %d", marked)
 	}
@@ -372,7 +372,7 @@ func TestMarkClosedItems_EmptyList(t *testing.T) {
 func TestStore_Reprioritize(t *testing.T) {
 	s, ctx := testStore(t)
 
-	repo := "chitinhq/octi-pulpo"
+	repo := "chitinhq/octi"
 	s.rdb.SAdd(ctx, s.key("sprint-repos"), repo)
 
 	item := SprintItem{
@@ -398,7 +398,7 @@ func TestStore_Reprioritize(t *testing.T) {
 func TestStore_Reprioritize_NotFound(t *testing.T) {
 	s, ctx := testStore(t)
 
-	err := s.Reprioritize(ctx, "chitinhq/octi-pulpo", 9999, 0)
+	err := s.Reprioritize(ctx, "chitinhq/octi", 9999, 0)
 	if err == nil {
 		t.Fatal("expected error for missing item, got nil")
 	}
@@ -407,7 +407,7 @@ func TestStore_Reprioritize_NotFound(t *testing.T) {
 func TestStore_Complete_NoDepedents(t *testing.T) {
 	s, ctx := testStore(t)
 
-	repo := "chitinhq/octi-pulpo"
+	repo := "chitinhq/octi"
 	s.rdb.SAdd(ctx, s.key("sprint-repos"), repo)
 
 	item := SprintItem{
@@ -434,7 +434,7 @@ func TestStore_Complete_NoDepedents(t *testing.T) {
 func TestStore_Complete_UnblocksDependent(t *testing.T) {
 	s, ctx := testStore(t)
 
-	repo := "chitinhq/octi-pulpo"
+	repo := "chitinhq/octi"
 	s.rdb.SAdd(ctx, s.key("sprint-repos"), repo)
 
 	// Item 10: the blocker; item 20: depends on 10; item 30: depends on 10 AND 40 (not done)
@@ -467,7 +467,7 @@ func TestStore_Create_Basic(t *testing.T) {
 	s, ctx := testStore(t)
 
 	item := SprintItem{
-		Repo:     "chitinhq/octi-pulpo",
+		Repo:     "chitinhq/octi",
 		IssueNum: 99,
 		Title:    "Manual sprint item",
 		Priority: 1,
@@ -508,7 +508,7 @@ func TestStore_Create_WithDependencies(t *testing.T) {
 	s, ctx := testStore(t)
 
 	item := SprintItem{
-		Repo:      "chitinhq/agentguard",
+		Repo:      "chitinhq/kernel",
 		IssueNum:  50,
 		Title:     "Feature with deps",
 		Priority:  0,
@@ -539,7 +539,7 @@ func TestStore_Create_WithDependencies(t *testing.T) {
 func TestStore_Create_ReplacesExisting(t *testing.T) {
 	s, ctx := testStore(t)
 
-	repo := "chitinhq/octi-pulpo"
+	repo := "chitinhq/octi"
 	original := SprintItem{
 		Repo: repo, IssueNum: 10, Title: "Old title", Priority: 2, Status: "open",
 	}
@@ -574,8 +574,8 @@ func TestStore_Create_ValidationErrors(t *testing.T) {
 		item SprintItem
 	}{
 		{"missing repo", SprintItem{IssueNum: 1, Title: "t"}},
-		{"missing issue_num", SprintItem{Repo: "chitinhq/octi-pulpo", Title: "t"}},
-		{"missing title", SprintItem{Repo: "chitinhq/octi-pulpo", IssueNum: 1}},
+		{"missing issue_num", SprintItem{Repo: "chitinhq/octi", Title: "t"}},
+		{"missing title", SprintItem{Repo: "chitinhq/octi", IssueNum: 1}},
 	}
 
 	for _, tc := range cases {
@@ -618,11 +618,11 @@ func TestInferSquadFromRepo(t *testing.T) {
 		repo  string
 		squad string
 	}{
-		{"chitinhq/agentguard", "kernel"},
-		{"chitinhq/agentguard-cloud", "cloud"},
-		{"chitinhq/octi-pulpo", "octi-pulpo"},
+		{"chitinhq/kernel", "kernel"},
+		{"chitinhq/cloud", "cloud"},
+		{"chitinhq/octi", "octi-pulpo"},
 		{"chitinhq/shellforge", "shellforge"},
-		{"chitinhq/agentguard-analytics", "analytics"},
+		{"chitinhq/analytics", "analytics"},
 	}
 
 	for _, tc := range tests {
@@ -639,7 +639,7 @@ func TestInferSquadFromRepo(t *testing.T) {
 func TestTombstoneFromOpenSet_MarksStaleItems(t *testing.T) {
 	s, ctx := testStore(t)
 
-	repo := "chitinhq/octi-pulpo"
+	repo := "chitinhq/octi"
 	s.rdb.SAdd(ctx, s.key("sprint-repos"), repo)
 
 	items := []SprintItem{
@@ -687,7 +687,7 @@ func TestTombstoneFromOpenSet_MarksStaleItems(t *testing.T) {
 func TestTombstoneFromOpenSet_SkipsInProgressAndClaimed(t *testing.T) {
 	s, ctx := testStore(t)
 
-	repo := "chitinhq/octi-pulpo"
+	repo := "chitinhq/octi"
 	s.rdb.SAdd(ctx, s.key("sprint-repos"), repo)
 
 	items := []SprintItem{
@@ -720,5 +720,5 @@ func TestTombstoneFromOpenSet_SkipsInProgressAndClaimed(t *testing.T) {
 func TestTombstoneFromOpenSet_EmptyStore(t *testing.T) {
 	s, ctx := testStore(t)
 	// No panic, no error when store has no items.
-	s.tombstoneFromOpenSet(ctx, "chitinhq/octi-pulpo", map[int]bool{1: true, 2: true})
+	s.tombstoneFromOpenSet(ctx, "chitinhq/octi", map[int]bool{1: true, 2: true})
 }


### PR DESCRIPTION
## Summary
- Sprint store DefaultRepos: old names → kernel, octi, cloud, analytics, workspace, extensions
- Event routing rules: webhook payloads now use canonical names
- Cascade handler: updated repo list
- inferSquadFromRepo: updated switch cases for new short names
- docs/index.html: AgentGuardHQ → chitinhq URLs
- All 22 files, 361 tests pass

Without this fix, webhook-based event routing is broken — GitHub sends `chitinhq/kernel` but rules match `chitinhq/agentguard`.

## Test plan
- [x] All 361 tests pass
- [ ] Sprint store syncs with new repo names
- [ ] Webhook routing matches for renamed repos

🤖 Generated with [Claude Code](https://claude.com/claude-code)