### PR TITLE
feat: OpenClaw adapter + memory recall endpoint

### DIFF
--- a/cmd/octi-pulpo/main.go
+++ b/cmd/octi-pulpo/main.go
@@ -139,11 +139,13 @@ func main() {
 	anthropicAdapter := dispatch.NewAnthropicAdapter("", "")
 	ghActionsAdapter := dispatch.NewGHActionsAdapter("")
 	copilotAdapter := dispatch.NewCopilotAdapter("")
+	openclawAdapter := dispatch.NewOpenClawAdapter("", "", "", "")
 
 	// Wire learner for auto-store of task outcomes in episodic memory.
 	taskLearner := learner.New(mem)
 	anthropicAdapter.SetLearner(taskLearner)
 	copilotAdapter.SetLearner(taskLearner)
+	openclawAdapter.SetLearner(taskLearner)
 
 	server.SetAnthropicAdapter(anthropicAdapter)
 	server.SetGHActionsAdapter(ghActionsAdapter)
@@ -225,11 +227,11 @@ func main() {
 			brain.SetSprintStore(sprintStore)
 			brain.SetProfileStore(profiles)
 			brain.SetStandupStore(standupStore)
-			// Wire task adapters: Clawta (local DeepSeek) → GH Actions (Copilot) fallback → Copilot SDK
+			// Wire task adapters: Clawta → GH Actions (Copilot) → Copilot SDK → OpenClaw (Matrix)
 			clawtaBinary := filepath.Join(home, "workspace", "clawta", "bench", "clawta-linux-amd64")
 			clawtaAdapter := dispatch.NewClawtaAdapter(clawtaBinary, "", "", "")
 			clawtaAdapter.SetLearner(taskLearner)
-			brain.SetAdapters(clawtaAdapter, ghActionsAdapter, copilotAdapter)
+			brain.SetAdapters(clawtaAdapter, ghActionsAdapter, copilotAdapter, openclawAdapter)
 			if ghToken := os.Getenv("GITHUB_TOKEN"); ghToken != "" {
 				brain.SetGitHubToken(ghToken)
 			}

--- a/internal/dispatch/openclaw_adapter.go
+++ b/internal/dispatch/openclaw_adapter.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"strings"
 	"time"
@@ -65,6 +66,9 @@ func (a *OpenClawAdapter) SetLearner(l *learner.Learner) { a.learner = l }
 
 // CanAccept returns true for general tasks when Matrix credentials are configured.
 func (a *OpenClawAdapter) CanAccept(task *Task) bool {
+	if task == nil {
+		return false
+	}
 	if a.accessToken == "" || a.roomID == "" || a.botUserID == "" {
 		return false
 	}
@@ -79,6 +83,9 @@ func (a *OpenClawAdapter) CanAccept(task *Task) bool {
 
 // Dispatch sends a task to the OpenClaw bot via Matrix and waits for a response.
 func (a *OpenClawAdapter) Dispatch(ctx context.Context, task *Task) (*AdapterResult, error) {
+	ctx, cancel := context.WithTimeout(ctx, a.timeout)
+	defer cancel()
+
 	result := &AdapterResult{
 		TaskID:  task.ID,
 		Adapter: a.Name(),
@@ -132,15 +139,18 @@ func (a *OpenClawAdapter) Dispatch(ctx context.Context, task *Task) (*AdapterRes
 
 // sendMessage sends a text message to the dispatch room.
 func (a *OpenClawAdapter) sendMessage(ctx context.Context, txnID, body string) error {
-	url := fmt.Sprintf("%s/_matrix/client/v3/rooms/%s/send/m.room.message/%s",
-		a.homeserver, a.roomID, txnID)
+	reqURL := fmt.Sprintf("%s/_matrix/client/v3/rooms/%s/send/m.room.message/%s",
+		a.homeserver, url.PathEscape(a.roomID), url.PathEscape(txnID))
 
-	payload, _ := json.Marshal(map[string]string{
+	payload, err := json.Marshal(map[string]string{
 		"msgtype": "m.text",
 		"body":    body,
 	})
+	if err != nil {
+		return fmt.Errorf("marshal message payload: %w", err)
+	}
 
-	req, err := http.NewRequestWithContext(ctx, "PUT", url, bytes.NewReader(payload))
+	req, err := http.NewRequestWithContext(ctx, "PUT", reqURL, bytes.NewReader(payload))
 	if err != nil {
 		return err
 	}
@@ -180,9 +190,16 @@ func (a *OpenClawAdapter) waitForResponse(ctx context.Context, afterTxnID string
 		case <-deadline:
 			return "", fmt.Errorf("timeout waiting for OpenClaw response after %s", a.timeout)
 		case <-ticker.C:
-			response, found, err := a.checkForBotMessage(ctx, fromToken)
+			response, found, nextToken, err := a.checkForBotMessage(ctx, fromToken)
 			if err != nil {
+				// Non-transient HTTP errors should stop polling immediately.
+				if isNonTransientError(err) {
+					return "", fmt.Errorf("non-transient error polling for response: %w", err)
+				}
 				continue // transient error, keep polling
+			}
+			if nextToken != "" {
+				fromToken = nextToken
 			}
 			if found {
 				return response, nil
@@ -191,12 +208,21 @@ func (a *OpenClawAdapter) waitForResponse(ctx context.Context, afterTxnID string
 	}
 }
 
+// isNonTransientError returns true for HTTP status codes that indicate the
+// request will never succeed (auth failures, not found, etc.).
+func isNonTransientError(err error) bool {
+	msg := err.Error()
+	return strings.Contains(msg, "(401)") ||
+		strings.Contains(msg, "(403)") ||
+		strings.Contains(msg, "(404)")
+}
+
 // getSyncToken gets a pagination token from the room's latest state.
 func (a *OpenClawAdapter) getSyncToken(ctx context.Context) (string, error) {
-	url := fmt.Sprintf("%s/_matrix/client/v3/rooms/%s/messages?dir=b&limit=1",
-		a.homeserver, a.roomID)
+	reqURL := fmt.Sprintf("%s/_matrix/client/v3/rooms/%s/messages?dir=b&limit=1",
+		a.homeserver, url.PathEscape(a.roomID))
 
-	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	req, err := http.NewRequestWithContext(ctx, "GET", reqURL, nil)
 	if err != nil {
 		return "", err
 	}
@@ -207,6 +233,11 @@ func (a *OpenClawAdapter) getSyncToken(ctx context.Context) (string, error) {
 		return "", err
 	}
 	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		body, _ := io.ReadAll(resp.Body)
+		return "", fmt.Errorf("matrix messages failed (%d): %s", resp.StatusCode, string(body))
+	}
 
 	var result struct {
 		Start string `json:"start"`
@@ -218,24 +249,30 @@ func (a *OpenClawAdapter) getSyncToken(ctx context.Context) (string, error) {
 }
 
 // checkForBotMessage checks for new messages from the bot in the room.
-func (a *OpenClawAdapter) checkForBotMessage(ctx context.Context, fromToken string) (string, bool, error) {
-	url := fmt.Sprintf("%s/_matrix/client/v3/rooms/%s/messages?dir=f&limit=10",
-		a.homeserver, a.roomID)
+// Returns (message, found, nextToken, error).
+func (a *OpenClawAdapter) checkForBotMessage(ctx context.Context, fromToken string) (string, bool, string, error) {
+	reqURL := fmt.Sprintf("%s/_matrix/client/v3/rooms/%s/messages?dir=f&limit=10",
+		a.homeserver, url.PathEscape(a.roomID))
 	if fromToken != "" {
-		url += "&from=" + fromToken
+		reqURL += "&from=" + url.QueryEscape(fromToken)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	req, err := http.NewRequestWithContext(ctx, "GET", reqURL, nil)
 	if err != nil {
-		return "", false, err
+		return "", false, "", err
 	}
 	req.Header.Set("Authorization", "Bearer "+a.accessToken)
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		return "", false, err
+		return "", false, "", err
 	}
 	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		body, _ := io.ReadAll(resp.Body)
+		return "", false, "", fmt.Errorf("matrix messages failed (%d): %s", resp.StatusCode, string(body))
+	}
 
 	var result struct {
 		Chunk []struct {
@@ -246,10 +283,13 @@ func (a *OpenClawAdapter) checkForBotMessage(ctx context.Context, fromToken stri
 				MsgType string `json:"msgtype"`
 			} `json:"content"`
 		} `json:"chunk"`
+		End string `json:"end"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-		return "", false, err
+		return "", false, "", err
 	}
+
+	nextToken := result.End
 
 	// Look for a message from the bot (not from us)
 	for _, event := range result.Chunk {
@@ -265,9 +305,9 @@ func (a *OpenClawAdapter) checkForBotMessage(ctx context.Context, fromToken stri
 			continue
 		}
 		if len(body) > 0 {
-			return body, true, nil
+			return body, true, nextToken, nil
 		}
 	}
 
-	return "", false, nil
+	return "", false, nextToken, nil
 }

--- a/internal/dispatch/openclaw_adapter.go
+++ b/internal/dispatch/openclaw_adapter.go
@@ -1,0 +1,273 @@
+package dispatch
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/chitinhq/octi-pulpo/internal/learner"
+)
+
+const (
+	openclawDefaultTimeout    = 5 * time.Minute
+	openclawPollInterval      = 5 * time.Second
+	openclawDefaultHomeserver = "http://localhost:8008"
+)
+
+// OpenClawAdapter dispatches tasks to an OpenClaw agent via Matrix messages.
+// Octi sends a task message to a Matrix room where the OpenClaw bot is joined,
+// waits for the bot's response, and returns the result.
+type OpenClawAdapter struct {
+	homeserver  string // Matrix homeserver URL
+	accessToken string // Octi's Matrix access token
+	roomID      string // Dispatch room ID
+	botUserID   string // OpenClaw bot's Matrix user ID
+	timeout     time.Duration
+	learner     *learner.Learner
+}
+
+// NewOpenClawAdapter creates an OpenClawAdapter from environment variables or explicit params.
+// Env vars: MATRIX_HOMESERVER, OCTI_MATRIX_TOKEN, OPENCLAW_ROOM_ID, OPENCLAW_BOT_USER_ID.
+func NewOpenClawAdapter(homeserver, token, roomID, botUserID string) *OpenClawAdapter {
+	if homeserver == "" {
+		homeserver = os.Getenv("MATRIX_HOMESERVER")
+	}
+	if homeserver == "" {
+		homeserver = openclawDefaultHomeserver
+	}
+	if token == "" {
+		token = os.Getenv("OCTI_MATRIX_TOKEN")
+	}
+	if roomID == "" {
+		roomID = os.Getenv("OPENCLAW_ROOM_ID")
+	}
+	if botUserID == "" {
+		botUserID = os.Getenv("OPENCLAW_BOT_USER_ID")
+	}
+	return &OpenClawAdapter{
+		homeserver:  homeserver,
+		accessToken: token,
+		roomID:      roomID,
+		botUserID:   botUserID,
+		timeout:     openclawDefaultTimeout,
+	}
+}
+
+func (a *OpenClawAdapter) Name() string { return "openclaw" }
+
+func (a *OpenClawAdapter) SetLearner(l *learner.Learner) { a.learner = l }
+
+// CanAccept returns true for general tasks when Matrix credentials are configured.
+func (a *OpenClawAdapter) CanAccept(task *Task) bool {
+	if a.accessToken == "" || a.roomID == "" || a.botUserID == "" {
+		return false
+	}
+	// OpenClaw can handle general tasks — it has tools, web access, etc.
+	switch task.Type {
+	case "research", "triage", "qa", "prompt_config", "tool_addition":
+		return true
+	default:
+		return false
+	}
+}
+
+// Dispatch sends a task to the OpenClaw bot via Matrix and waits for a response.
+func (a *OpenClawAdapter) Dispatch(ctx context.Context, task *Task) (*AdapterResult, error) {
+	result := &AdapterResult{
+		TaskID:  task.ID,
+		Adapter: a.Name(),
+	}
+
+	// Build the dispatch message
+	msg := fmt.Sprintf("[Octi Dispatch] Contract: %s\nType: %s | Priority: %s | Repo: %s\n\n%s",
+		task.ID, task.Type, task.Priority, task.Repo, task.Prompt)
+
+	if task.Context != "" {
+		msg += "\n\nContext:\n" + task.Context
+	}
+
+	// Send the message
+	txnID := fmt.Sprintf("octi-%s-%d", task.ID, time.Now().UnixMilli())
+	if err := a.sendMessage(ctx, txnID, msg); err != nil {
+		result.Status = "failed"
+		result.Error = fmt.Sprintf("send message: %v", err)
+		return result, err
+	}
+
+	// Poll for the bot's response
+	response, err := a.waitForResponse(ctx, txnID)
+	if err != nil {
+		result.Status = "failed"
+		result.Error = fmt.Sprintf("wait for response: %v", err)
+		return result, err
+	}
+
+	result.Status = "completed"
+	result.Output = response
+
+	// Store learning if learner is available
+	if a.learner != nil {
+		taskInfo := &learner.TaskInfo{
+			Type:     task.Type,
+			Repo:     task.Repo,
+			Prompt:   task.Prompt,
+			Priority: task.Priority,
+		}
+		outcomeInfo := &learner.OutcomeInfo{
+			Status:  result.Status,
+			Adapter: a.Name(),
+			Output:  response,
+		}
+		_ = a.learner.RecordOutcome(ctx, taskInfo, outcomeInfo)
+	}
+
+	return result, nil
+}
+
+// sendMessage sends a text message to the dispatch room.
+func (a *OpenClawAdapter) sendMessage(ctx context.Context, txnID, body string) error {
+	url := fmt.Sprintf("%s/_matrix/client/v3/rooms/%s/send/m.room.message/%s",
+		a.homeserver, a.roomID, txnID)
+
+	payload, _ := json.Marshal(map[string]string{
+		"msgtype": "m.text",
+		"body":    body,
+	})
+
+	req, err := http.NewRequestWithContext(ctx, "PUT", url, bytes.NewReader(payload))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bearer "+a.accessToken)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("matrix send failed (%d): %s", resp.StatusCode, string(body))
+	}
+	return nil
+}
+
+// waitForResponse polls the room for a response from the bot.
+func (a *OpenClawAdapter) waitForResponse(ctx context.Context, afterTxnID string) (string, error) {
+	deadline := time.After(a.timeout)
+	ticker := time.NewTicker(openclawPollInterval)
+	defer ticker.Stop()
+
+	// Get the "from" token for pagination (start from now)
+	fromToken, err := a.getSyncToken(ctx)
+	if err != nil {
+		// Fall back to polling from recent messages
+		fromToken = ""
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return "", ctx.Err()
+		case <-deadline:
+			return "", fmt.Errorf("timeout waiting for OpenClaw response after %s", a.timeout)
+		case <-ticker.C:
+			response, found, err := a.checkForBotMessage(ctx, fromToken)
+			if err != nil {
+				continue // transient error, keep polling
+			}
+			if found {
+				return response, nil
+			}
+		}
+	}
+}
+
+// getSyncToken gets a pagination token from the room's latest state.
+func (a *OpenClawAdapter) getSyncToken(ctx context.Context) (string, error) {
+	url := fmt.Sprintf("%s/_matrix/client/v3/rooms/%s/messages?dir=b&limit=1",
+		a.homeserver, a.roomID)
+
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Authorization", "Bearer "+a.accessToken)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	var result struct {
+		Start string `json:"start"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return "", err
+	}
+	return result.Start, nil
+}
+
+// checkForBotMessage checks for new messages from the bot in the room.
+func (a *OpenClawAdapter) checkForBotMessage(ctx context.Context, fromToken string) (string, bool, error) {
+	url := fmt.Sprintf("%s/_matrix/client/v3/rooms/%s/messages?dir=f&limit=10",
+		a.homeserver, a.roomID)
+	if fromToken != "" {
+		url += "&from=" + fromToken
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	if err != nil {
+		return "", false, err
+	}
+	req.Header.Set("Authorization", "Bearer "+a.accessToken)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", false, err
+	}
+	defer resp.Body.Close()
+
+	var result struct {
+		Chunk []struct {
+			Type    string `json:"type"`
+			Sender  string `json:"sender"`
+			Content struct {
+				Body    string `json:"body"`
+				MsgType string `json:"msgtype"`
+			} `json:"content"`
+		} `json:"chunk"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return "", false, err
+	}
+
+	// Look for a message from the bot (not from us)
+	for _, event := range result.Chunk {
+		if event.Type != "m.room.message" {
+			continue
+		}
+		if event.Sender != a.botUserID {
+			continue
+		}
+		body := event.Content.Body
+		// Skip pairing/error messages
+		if strings.Contains(body, "Pairing code") || strings.Contains(body, "access not configured") {
+			continue
+		}
+		if len(body) > 0 {
+			return body, true, nil
+		}
+	}
+
+	return "", false, nil
+}

--- a/internal/dispatch/openclaw_adapter_test.go
+++ b/internal/dispatch/openclaw_adapter_test.go
@@ -1,0 +1,326 @@
+package dispatch
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// ---- Name ----
+
+func TestOpenClawAdapterName(t *testing.T) {
+	a := NewOpenClawAdapter("", "", "", "")
+	if got := a.Name(); got != "openclaw" {
+		t.Errorf("Name(): want openclaw, got %s", got)
+	}
+}
+
+// ---- CanAccept ----
+
+func TestOpenClawCanAcceptNilTask(t *testing.T) {
+	a := NewOpenClawAdapter("http://localhost", "tok", "!room", "@bot:local")
+	if a.CanAccept(nil) {
+		t.Error("CanAccept(nil): want false, got true")
+	}
+}
+
+func TestOpenClawCanAcceptNoCredentials(t *testing.T) {
+	a := NewOpenClawAdapter("http://localhost", "", "", "")
+	task := &Task{Type: "research"}
+	if a.CanAccept(task) {
+		t.Error("CanAccept with no creds: want false, got true")
+	}
+}
+
+func TestOpenClawCanAcceptSupportedTypes(t *testing.T) {
+	a := NewOpenClawAdapter("http://localhost", "tok", "!room", "@bot:local")
+	for _, typ := range []string{"research", "triage", "qa", "prompt_config", "tool_addition"} {
+		task := &Task{Type: typ}
+		if !a.CanAccept(task) {
+			t.Errorf("CanAccept(%s): want true, got false", typ)
+		}
+	}
+}
+
+func TestOpenClawCanAcceptUnsupportedTypes(t *testing.T) {
+	a := NewOpenClawAdapter("http://localhost", "tok", "!room", "@bot:local")
+	for _, typ := range []string{"code-gen", "bugfix", "pr-review", ""} {
+		task := &Task{Type: typ}
+		if a.CanAccept(task) {
+			t.Errorf("CanAccept(%s): want false, got true", typ)
+		}
+	}
+}
+
+// ---- sendMessage ----
+
+func TestSendMessageSuccess(t *testing.T) {
+	var gotAuth string
+	var gotBody map[string]string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		json.NewDecoder(r.Body).Decode(&gotBody)
+		w.WriteHeader(200)
+		w.Write([]byte(`{"event_id":"$abc"}`))
+	}))
+	defer srv.Close()
+
+	a := NewOpenClawAdapter(srv.URL, "test-token", "!room:local", "@bot:local")
+	err := a.sendMessage(context.Background(), "txn-1", "hello")
+	if err != nil {
+		t.Fatalf("sendMessage: unexpected error: %v", err)
+	}
+	if gotAuth != "Bearer test-token" {
+		t.Errorf("auth header: want 'Bearer test-token', got %q", gotAuth)
+	}
+	if gotBody["body"] != "hello" {
+		t.Errorf("body: want 'hello', got %q", gotBody["body"])
+	}
+}
+
+func TestSendMessageHTTPError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(403)
+		w.Write([]byte(`{"errcode":"M_FORBIDDEN"}`))
+	}))
+	defer srv.Close()
+
+	a := NewOpenClawAdapter(srv.URL, "bad-token", "!room:local", "@bot:local")
+	err := a.sendMessage(context.Background(), "txn-1", "hello")
+	if err == nil {
+		t.Fatal("sendMessage: expected error on 403, got nil")
+	}
+}
+
+// ---- checkForBotMessage ----
+
+func TestCheckForBotMessageFound(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"chunk": []map[string]interface{}{
+				{
+					"type":   "m.room.message",
+					"sender": "@bot:local",
+					"content": map[string]string{
+						"body":    "task completed",
+						"msgtype": "m.text",
+					},
+				},
+			},
+			"end": "t2_token",
+		})
+	}))
+	defer srv.Close()
+
+	a := NewOpenClawAdapter(srv.URL, "tok", "!room:local", "@bot:local")
+	msg, found, nextToken, err := a.checkForBotMessage(context.Background(), "t1_token")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !found {
+		t.Fatal("expected found=true")
+	}
+	if msg != "task completed" {
+		t.Errorf("message: want 'task completed', got %q", msg)
+	}
+	if nextToken != "t2_token" {
+		t.Errorf("nextToken: want 't2_token', got %q", nextToken)
+	}
+}
+
+func TestCheckForBotMessageSkipsPairing(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"chunk": []map[string]interface{}{
+				{
+					"type":   "m.room.message",
+					"sender": "@bot:local",
+					"content": map[string]string{
+						"body":    "Pairing code: ABC123",
+						"msgtype": "m.text",
+					},
+				},
+			},
+			"end": "t2",
+		})
+	}))
+	defer srv.Close()
+
+	a := NewOpenClawAdapter(srv.URL, "tok", "!room:local", "@bot:local")
+	_, found, _, err := a.checkForBotMessage(context.Background(), "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if found {
+		t.Error("expected found=false for pairing message")
+	}
+}
+
+func TestCheckForBotMessageNonTransientError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(401)
+		w.Write([]byte(`{"errcode":"M_UNKNOWN_TOKEN"}`))
+	}))
+	defer srv.Close()
+
+	a := NewOpenClawAdapter(srv.URL, "bad-tok", "!room:local", "@bot:local")
+	_, _, _, err := a.checkForBotMessage(context.Background(), "")
+	if err == nil {
+		t.Fatal("expected error on 401, got nil")
+	}
+}
+
+func TestCheckForBotMessageAdvancesToken(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"chunk": []map[string]interface{}{},
+			"end":   "t3_advanced",
+		})
+	}))
+	defer srv.Close()
+
+	a := NewOpenClawAdapter(srv.URL, "tok", "!room:local", "@bot:local")
+	_, _, nextToken, err := a.checkForBotMessage(context.Background(), "t1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if nextToken != "t3_advanced" {
+		t.Errorf("nextToken: want 't3_advanced', got %q", nextToken)
+	}
+}
+
+// ---- getSyncToken ----
+
+func TestGetSyncTokenSuccess(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]string{"start": "s123"})
+	}))
+	defer srv.Close()
+
+	a := NewOpenClawAdapter(srv.URL, "tok", "!room:local", "@bot:local")
+	tok, err := a.getSyncToken(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if tok != "s123" {
+		t.Errorf("token: want 's123', got %q", tok)
+	}
+}
+
+func TestGetSyncTokenHTTPError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(500)
+		w.Write([]byte("internal error"))
+	}))
+	defer srv.Close()
+
+	a := NewOpenClawAdapter(srv.URL, "tok", "!room:local", "@bot:local")
+	_, err := a.getSyncToken(context.Background())
+	if err == nil {
+		t.Fatal("expected error on 500, got nil")
+	}
+}
+
+// ---- Dispatch (integration) ----
+
+func TestDispatchTimeout(t *testing.T) {
+	// Server that accepts send but never returns a bot message
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "PUT" {
+			w.WriteHeader(200)
+			w.Write([]byte(`{"event_id":"$1"}`))
+			return
+		}
+		// GET /messages — always return empty
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"chunk": []map[string]interface{}{},
+			"start": "s1",
+			"end":   "s2",
+		})
+	}))
+	defer srv.Close()
+
+	a := NewOpenClawAdapter(srv.URL, "tok", "!room:local", "@bot:local")
+	a.timeout = 500 * time.Millisecond
+
+	task := &Task{ID: "test-1", Type: "research", Prompt: "test prompt"}
+	_, err := a.Dispatch(context.Background(), task)
+	if err == nil {
+		t.Fatal("expected timeout error, got nil")
+	}
+}
+
+func TestDispatchSuccess(t *testing.T) {
+	callCount := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "PUT" {
+			w.WriteHeader(200)
+			w.Write([]byte(`{"event_id":"$1"}`))
+			return
+		}
+		callCount++
+		// First poll: empty. Second poll: bot response.
+		if callCount <= 2 {
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"chunk": []map[string]interface{}{},
+				"start": "s1",
+				"end":   "s2",
+			})
+		} else {
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"chunk": []map[string]interface{}{
+					{
+						"type":   "m.room.message",
+						"sender": "@bot:local",
+						"content": map[string]string{
+							"body":    "done: all good",
+							"msgtype": "m.text",
+						},
+					},
+				},
+				"end": "s3",
+			})
+		}
+	}))
+	defer srv.Close()
+
+	a := NewOpenClawAdapter(srv.URL, "tok", "!room:local", "@bot:local")
+	a.timeout = 5 * time.Second
+
+	task := &Task{ID: "test-2", Type: "research", Prompt: "test prompt"}
+	result, err := a.Dispatch(context.Background(), task)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Status != "completed" {
+		t.Errorf("status: want 'completed', got %q", result.Status)
+	}
+	if result.Output != "done: all good" {
+		t.Errorf("output: want 'done: all good', got %q", result.Output)
+	}
+}
+
+// ---- isNonTransientError ----
+
+func TestIsNonTransientError(t *testing.T) {
+	tests := []struct {
+		msg  string
+		want bool
+	}{
+		{"matrix messages failed (401): unauthorized", true},
+		{"matrix messages failed (403): forbidden", true},
+		{"matrix messages failed (404): not found", true},
+		{"matrix messages failed (500): internal error", false},
+		{"connection refused", false},
+	}
+	for _, tt := range tests {
+		got := isNonTransientError(fmt.Errorf(tt.msg))
+		if got != tt.want {
+			t.Errorf("isNonTransientError(%q): want %v, got %v", tt.msg, tt.want, got)
+		}
+	}
+}

--- a/internal/dispatch/webhook.go
+++ b/internal/dispatch/webhook.go
@@ -13,6 +13,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -113,7 +114,7 @@ func NewWebhookServer(dispatcher *Dispatcher, secretFile string) *WebhookServer 
 	ws.mux.HandleFunc("/sprint/sync", ws.handleSprintSync)
 	ws.mux.HandleFunc("/benchmark", ws.handleBenchmark)
 	ws.mux.HandleFunc("/slack/actions", ws.handleSlackActions)
-	ws.mux.HandleFunc("/api/memory", ws.handleMemoryStore)
+	ws.mux.HandleFunc("/api/memory", ws.handleMemory)
 	ws.mux.HandleFunc("/cascade/trigger", ws.handleCascadeTrigger)
 	return ws
 }
@@ -123,14 +124,56 @@ func (ws *WebhookServer) SetMemoryStore(m *memory.Store) {
 	ws.memoryStore = m
 }
 
+// handleMemory routes GET (recall) and POST (store) for the /api/memory endpoint.
+func (ws *WebhookServer) handleMemory(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		ws.handleMemoryRecall(w, r)
+	case http.MethodPost:
+		ws.handleMemoryStore(w, r)
+	default:
+		http.Error(w, "GET or POST only", http.StatusMethodNotAllowed)
+	}
+}
+
+// handleMemoryRecall returns recent memories matching a query or topic.
+// GET /api/memory?query=swarm-worker&limit=5
+func (ws *WebhookServer) handleMemoryRecall(w http.ResponseWriter, r *http.Request) {
+	if ws.memoryStore == nil {
+		http.Error(w, "memory store not configured", http.StatusServiceUnavailable)
+		return
+	}
+
+	query := r.URL.Query().Get("query")
+	if query == "" {
+		query = r.URL.Query().Get("topic")
+	}
+	if query == "" {
+		http.Error(w, "query or topic parameter required", http.StatusBadRequest)
+		return
+	}
+
+	limit := 10
+	if l := r.URL.Query().Get("limit"); l != "" {
+		if n, err := strconv.Atoi(l); err == nil && n > 0 && n <= 100 {
+			limit = n
+		}
+	}
+
+	entries, err := ws.memoryStore.Recall(r.Context(), query, limit)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(entries)
+}
+
 // handleMemoryStore receives memory entries from Chitin CLI hooks
 // via the Octi Bridge. This is how human CLI sessions feed the swarm's
 // episodic memory.
 func (ws *WebhookServer) handleMemoryStore(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodPost {
-		http.Error(w, "POST only", http.StatusMethodNotAllowed)
-		return
-	}
 	if ws.memoryStore == nil {
 		http.Error(w, "memory store not configured", http.StatusServiceUnavailable)
 		return


### PR DESCRIPTION
## Summary
- OpenClaw Matrix adapter for dispatching tasks via Matrix messages
- **GET /api/memory recall endpoint** — enables remote agents (swarm worker) to recall episodic memories via REST
- Dispatch fixes: swallowed errors, progress TTL, structured completion reports

## Test plan
- [x] `go build ./...` passes
- [x] Memory store+recall roundtrip verified locally and through Cloudflare tunnel
- [ ] Verify swarm worker can recall memories on next hourly run

🤖 Generated with [Claude Code](https://claude.com/claude-code)