### PR TITLE
feat(mcp): emit tool invocation telemetry via mcptrace

### DIFF
--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -14,6 +14,7 @@ import (
 	"github.com/chitinhq/octi-pulpo/internal/budget"
 	"github.com/chitinhq/octi-pulpo/internal/coordination"
 	"github.com/chitinhq/octi-pulpo/internal/dispatch"
+	"github.com/chitinhq/octi-pulpo/internal/mcptrace"
 	"github.com/chitinhq/octi-pulpo/internal/memory"
 	"github.com/chitinhq/octi-pulpo/internal/org"
 	"github.com/chitinhq/octi-pulpo/internal/routing"
@@ -168,7 +169,7 @@ func (s *Server) handle(req Request) Response {
 	}
 }
 
-func (s *Server) handleToolCall(req Request) Response {
+func (s *Server) handleToolCall(req Request) (resp Response) {
 	var params struct {
 		Name      string          `json:"name"`
 		Arguments json.RawMessage `json:"arguments"`
@@ -182,6 +183,18 @@ func (s *Server) handleToolCall(req Request) Response {
 	if agentID == "" {
 		agentID = "unknown"
 	}
+
+	// Emit a telemetry event after the tool handler returns. Best-effort —
+	// never blocks the response path. Outcome is inferred from resp.Error.
+	start := time.Now()
+	defer func() {
+		outcome, reason := "allow", ""
+		if resp.Error != nil {
+			outcome = "deny"
+			reason = resp.Error.Message
+		}
+		mcptrace.Emit("octi", agentID, params.Name, outcome, reason, start)
+	}()
 
 	switch params.Name {
 	case "memory_store":

--- a/internal/mcptrace/emit.go
+++ b/internal/mcptrace/emit.go
@@ -1,0 +1,93 @@
+// Package mcptrace emits MCP tool invocation events to a JSONL file so
+// Sentinel can ingest and analyse which tools agents actually use.
+//
+// The event schema matches chitinhq/chitin's governance events.jsonl so the
+// existing Sentinel chitin_governance ingester picks them up with no change:
+// ts, sid, agent, tool, action, outcome, reason, source, latency_us.
+//
+// Destination:
+//   1. $MCPTRACE_FILE if set (absolute path)
+//   2. $CHITIN_WORKSPACE/.chitin/events.jsonl if CHITIN_WORKSPACE is set
+//   3. $HOME/.chitin/mcp_events.jsonl as a fallback
+//   4. no-op if none of the above resolve
+package mcptrace
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+)
+
+// Event is one MCP tool invocation.
+type Event struct {
+	Timestamp string `json:"ts"`
+	SessionID string `json:"sid,omitempty"`
+	Agent     string `json:"agent"`
+	Tool      string `json:"tool"`
+	Action    string `json:"action"`         // always "mcp_call" for MCP server events
+	Outcome   string `json:"outcome"`        // "allow" | "deny" (allow = success, deny = error)
+	Reason    string `json:"reason,omitempty"`
+	Source    string `json:"source"`         // the MCP server name, e.g. "octi" or "atlas"
+	LatencyUs int64  `json:"latency_us"`
+}
+
+var (
+	writeMu sync.Mutex
+)
+
+// Emit appends a single event to the configured JSONL file.
+// Never blocks the caller on errors — telemetry is best-effort.
+func Emit(source, agent, tool, outcome, reason string, start time.Time) {
+	path := destination()
+	if path == "" {
+		return
+	}
+
+	ev := Event{
+		Timestamp: time.Now().UTC().Format(time.RFC3339Nano),
+		SessionID: os.Getenv("CHITIN_SESSION_ID"),
+		Agent:     agent,
+		Tool:      "mcp__" + source + "__" + tool,
+		Action:    "mcp_call",
+		Outcome:   outcome,
+		Reason:    reason,
+		Source:    source,
+		LatencyUs: time.Since(start).Microseconds(),
+	}
+
+	data, err := json.Marshal(ev)
+	if err != nil {
+		return
+	}
+	data = append(data, '\n')
+
+	writeMu.Lock()
+	defer writeMu.Unlock()
+
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return
+	}
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		return
+	}
+	defer f.Close()
+	f.Write(data)
+}
+
+// destination resolves the JSONL path from environment, or returns ""
+// to disable emission when nothing is configured.
+func destination() string {
+	if p := os.Getenv("MCPTRACE_FILE"); p != "" {
+		return p
+	}
+	if ws := os.Getenv("CHITIN_WORKSPACE"); ws != "" {
+		return filepath.Join(ws, ".chitin", "events.jsonl")
+	}
+	if home, err := os.UserHomeDir(); err == nil && home != "" {
+		return filepath.Join(home, ".chitin", "mcp_events.jsonl")
+	}
+	return ""
+}

--- a/internal/mcptrace/emit.go
+++ b/internal/mcptrace/emit.go
@@ -6,7 +6,7 @@
 // ts, sid, agent, tool, action, outcome, reason, source, latency_us.
 //
 // Destination:
-//   1. $MCPTRACE_FILE if set (absolute path)
+//   1. $MCPTRACE_FILE if set (treated as a path; absolute recommended)
 //   2. $CHITIN_WORKSPACE/.chitin/events.jsonl if CHITIN_WORKSPACE is set
 //   3. $HOME/.chitin/mcp_events.jsonl as a fallback
 //   4. no-op if none of the above resolve
@@ -26,10 +26,10 @@ type Event struct {
 	SessionID string `json:"sid,omitempty"`
 	Agent     string `json:"agent"`
 	Tool      string `json:"tool"`
-	Action    string `json:"action"`         // always "mcp_call" for MCP server events
-	Outcome   string `json:"outcome"`        // "allow" | "deny" (allow = success, deny = error)
+	Action    string `json:"action"`  // always "mcp_call" for MCP server events
+	Outcome   string `json:"outcome"` // "allow" | "deny" (allow = success, deny = error)
 	Reason    string `json:"reason,omitempty"`
-	Source    string `json:"source"`         // the MCP server name, e.g. "octi" or "atlas"
+	Source    string `json:"source"` // the MCP server name, e.g. "octi" or "atlas"
 	LatencyUs int64  `json:"latency_us"`
 }
 
@@ -38,7 +38,10 @@ var (
 )
 
 // Emit appends a single event to the configured JSONL file.
-// Never blocks the caller on errors — telemetry is best-effort.
+//
+// Best-effort; emission is synchronous file I/O under a write mutex, expected
+// microseconds on local disk but could block under I/O contention. Errors are
+// swallowed — telemetry must never break the caller.
 func Emit(source, agent, tool, outcome, reason string, start time.Time) {
 	path := destination()
 	if path == "" {
@@ -66,15 +69,17 @@ func Emit(source, agent, tool, outcome, reason string, start time.Time) {
 	writeMu.Lock()
 	defer writeMu.Unlock()
 
-	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
 		return
 	}
-	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0600)
 	if err != nil {
 		return
 	}
 	defer f.Close()
-	f.Write(data)
+	if _, err := f.Write(data); err != nil {
+		return
+	}
 }
 
 // destination resolves the JSONL path from environment, or returns ""

--- a/internal/mcptrace/emit_test.go
+++ b/internal/mcptrace/emit_test.go
@@ -1,0 +1,103 @@
+package mcptrace
+
+import (
+	"bufio"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestEmit_WritesJSONLToMCPTRACE_FILE(t *testing.T) {
+	dir := t.TempDir()
+	dest := filepath.Join(dir, "sub", "events.jsonl")
+	t.Setenv("MCPTRACE_FILE", dest)
+
+	Emit("octi", "agent-1", "sprint_status", "allow", "", time.Now().Add(-5*time.Millisecond))
+	Emit("octi", "agent-1", "memory_store", "deny", "redis down", time.Now().Add(-2*time.Millisecond))
+
+	f, err := os.Open(dest)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	var events []Event
+	for scanner.Scan() {
+		var ev Event
+		if err := json.Unmarshal(scanner.Bytes(), &ev); err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		events = append(events, ev)
+	}
+	if len(events) != 2 {
+		t.Fatalf("want 2 events, got %d", len(events))
+	}
+	if events[0].Tool != "mcp__octi__sprint_status" {
+		t.Errorf("tool name: got %q", events[0].Tool)
+	}
+	if events[0].Action != "mcp_call" {
+		t.Errorf("action: got %q", events[0].Action)
+	}
+	if events[0].Outcome != "allow" || events[1].Outcome != "deny" {
+		t.Errorf("outcomes wrong: %s / %s", events[0].Outcome, events[1].Outcome)
+	}
+	if events[0].LatencyUs <= 0 || events[1].LatencyUs <= 0 {
+		t.Errorf("latencies not set: %d / %d", events[0].LatencyUs, events[1].LatencyUs)
+	}
+	if events[0].Source != "octi" {
+		t.Errorf("source: got %q", events[0].Source)
+	}
+}
+
+func TestEmit_PrefersMCPTRACE_FILEOverWorkspace(t *testing.T) {
+	dir := t.TempDir()
+	wsPath := filepath.Join(dir, "ws")
+	explicit := filepath.Join(dir, "explicit.jsonl")
+
+	t.Setenv("CHITIN_WORKSPACE", wsPath)
+	t.Setenv("MCPTRACE_FILE", explicit)
+
+	Emit("atlas", "a", "wiki_read", "allow", "", time.Now())
+
+	if _, err := os.Stat(explicit); err != nil {
+		t.Errorf("MCPTRACE_FILE not used: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(wsPath, ".chitin", "events.jsonl")); err == nil {
+		t.Error("workspace path should not be written when MCPTRACE_FILE is set")
+	}
+}
+
+func TestEmit_FallsBackToWorkspace(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("MCPTRACE_FILE", "")
+	t.Setenv("CHITIN_WORKSPACE", dir)
+
+	Emit("octi", "a", "ping", "allow", "", time.Now())
+
+	data, err := os.ReadFile(filepath.Join(dir, ".chitin", "events.jsonl"))
+	if err != nil {
+		t.Fatalf("workspace fallback not written: %v", err)
+	}
+	if !strings.Contains(string(data), `"tool":"mcp__octi__ping"`) {
+		t.Errorf("event not found: %s", data)
+	}
+}
+
+func TestEmit_NoConfigIsNoop(t *testing.T) {
+	t.Setenv("MCPTRACE_FILE", "")
+	t.Setenv("CHITIN_WORKSPACE", "")
+	t.Setenv("HOME", "")
+	// Must not panic.
+	Emit("octi", "a", "ping", "allow", "", time.Now())
+}
+
+func TestDestination(t *testing.T) {
+	t.Setenv("MCPTRACE_FILE", "/tmp/x.jsonl")
+	if got := destination(); got != "/tmp/x.jsonl" {
+		t.Errorf("MCPTRACE_FILE precedence: got %q", got)
+	}
+}

--- a/internal/mcptrace/emit_test.go
+++ b/internal/mcptrace/emit_test.go
@@ -87,11 +87,21 @@ func TestEmit_FallsBackToWorkspace(t *testing.T) {
 	}
 }
 
-func TestEmit_NoConfigIsNoop(t *testing.T) {
-	t.Setenv("MCPTRACE_FILE", "")
-	t.Setenv("CHITIN_WORKSPACE", "")
-	t.Setenv("HOME", "")
-	// Must not panic.
+func TestEmit_UnwritablePathIsNoop(t *testing.T) {
+	// Point MCPTRACE_FILE at a path that cannot be created (parent is a
+	// regular file, not a directory) and assert Emit returns without
+	// panicking. os.UserHomeDir may resolve a home even when HOME="", so
+	// we can't reliably test the "no destination at all" branch; instead
+	// we verify Emit swallows I/O errors silently.
+	dir := t.TempDir()
+	blocker := filepath.Join(dir, "not-a-dir")
+	if err := os.WriteFile(blocker, []byte("x"), 0600); err != nil {
+		t.Fatalf("seed blocker: %v", err)
+	}
+	dest := filepath.Join(blocker, "events.jsonl")
+	t.Setenv("MCPTRACE_FILE", dest)
+
+	// Must not panic, must return.
 	Emit("octi", "a", "ping", "allow", "", time.Now())
 }
 


### PR DESCRIPTION
## Summary
- Adds \`internal/mcptrace\` emitter, matches chitin events.jsonl schema so sentinel's existing ingester picks it up with zero sentinel-side changes
- Wraps \`handleToolCall\` with deferred \`mcptrace.Emit\`; outcome inferred from response error
- Tool field becomes \`mcp__octi__<name>\` so sentinel's new \`mcp_usage\` analyzer pass can prefix-partition

## Why P0
We haven't been capturing MCP telemetry at all — neither local sessions nor swarm. This is the first emitter that lights up the pipeline.

## Pairs with
- chitinhq/atlas#<TBD> — same pattern for atlas
- chitinhq/sentinel#<TBD> — mcp_usage analyzer pass