### PR TITLE
feat(flow): emit lifecycle events around dispatch + triage

### DIFF
--- a/internal/dispatch/anthropic_adapter.go
+++ b/internal/dispatch/anthropic_adapter.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/chitinhq/octi-pulpo/internal/flow"
 	"github.com/chitinhq/octi-pulpo/internal/learner"
 )
 
@@ -55,7 +56,11 @@ func (a *AnthropicAdapter) CanAccept(_ *Task) bool {
 // Dispatch runs `shellforge agent --provider anthropic "<prompt>"` as a
 // subprocess and returns the captured output. A 5-minute timeout is applied
 // via the derived context.
-func (a *AnthropicAdapter) Dispatch(ctx context.Context, task *Task) (*AdapterResult, error) {
+func (a *AnthropicAdapter) Dispatch(ctx context.Context, task *Task) (retResult *AdapterResult, retErr error) {
+	defer flow.Span("swarm.dispatch.anthropic", map[string]interface{}{
+		"task_id": task.ID, "type": task.Type, "repo": task.Repo, "priority": task.Priority,
+	})(&retErr)
+
 	ctx, cancel := context.WithTimeout(ctx, anthropicTimeout)
 	defer cancel()
 

--- a/internal/dispatch/copilot_adapter.go
+++ b/internal/dispatch/copilot_adapter.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/chitinhq/octi-pulpo/internal/flow"
 	"github.com/chitinhq/octi-pulpo/internal/learner"
 )
 
@@ -75,7 +76,11 @@ type copilotCompletionResponse struct {
 }
 
 // Dispatch sends a completion request to Copilot SDK and returns the result.
-func (c *CopilotAdapter) Dispatch(ctx context.Context, task *Task) (*AdapterResult, error) {
+func (c *CopilotAdapter) Dispatch(ctx context.Context, task *Task) (retResult *AdapterResult, retErr error) {
+	defer flow.Span("swarm.dispatch.copilot", map[string]interface{}{
+		"task_id": task.ID, "type": task.Type, "repo": task.Repo, "priority": task.Priority,
+	})(&retErr)
+
 	ctx, cancel := context.WithTimeout(ctx, copilotTimeout)
 	defer cancel()
 

--- a/internal/dispatch/dispatcher.go
+++ b/internal/dispatch/dispatcher.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/chitinhq/octi-pulpo/internal/budget"
 	"github.com/chitinhq/octi-pulpo/internal/coordination"
+	"github.com/chitinhq/octi-pulpo/internal/flow"
 	"github.com/chitinhq/octi-pulpo/internal/presence"
 	"github.com/chitinhq/octi-pulpo/internal/routing"
 	"github.com/redis/go-redis/v9"
@@ -79,7 +80,11 @@ func (d *Dispatcher) Dispatch(ctx context.Context, event Event, agentName string
 // DispatchBudget is like Dispatch but accepts an explicit budget level ("low", "medium", "high").
 // Use this when you need to override the automatic dynamic budget — e.g. for API-tier burst
 // capacity via a manual MCP trigger, or in tests that need deterministic routing.
-func (d *Dispatcher) DispatchBudget(ctx context.Context, event Event, agentName string, priority int, budget string) (DispatchResult, error) {
+func (d *Dispatcher) DispatchBudget(ctx context.Context, event Event, agentName string, priority int, budget string) (retResult DispatchResult, retErr error) {
+	defer flow.Span("swarm.dispatch", map[string]interface{}{
+		"agent": agentName, "event_type": event.Type, "priority": priority, "budget": budget,
+	})(&retErr)
+
 	now := time.Now().UTC()
 	result := DispatchResult{
 		Agent:     agentName,

--- a/internal/dispatch/ghactions_adapter.go
+++ b/internal/dispatch/ghactions_adapter.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+
+	"github.com/chitinhq/octi-pulpo/internal/flow"
 )
 
 const defaultGHBaseURL = "https://api.github.com"
@@ -55,7 +57,11 @@ type ghClientPayload struct {
 
 // Dispatch POSTs a repository_dispatch event to GitHub. On 204 the task is
 // considered queued — the actual workflow result is asynchronous.
-func (g *GHActionsAdapter) Dispatch(ctx context.Context, task *Task) (*AdapterResult, error) {
+func (g *GHActionsAdapter) Dispatch(ctx context.Context, task *Task) (retResult *AdapterResult, retErr error) {
+	defer flow.Span("swarm.dispatch.ghactions", map[string]interface{}{
+		"task_id": task.ID, "type": task.Type, "repo": task.Repo, "priority": task.Priority,
+	})(&retErr)
+
 	payload := ghDispatchPayload{
 		EventType: "octi-pulpo-dispatch",
 		ClientPayload: ghClientPayload{

--- a/internal/dispatch/triage.go
+++ b/internal/dispatch/triage.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/chitinhq/octi-pulpo/internal/budget"
+	"github.com/chitinhq/octi-pulpo/internal/flow"
 )
 
 // TriageResult is the outcome of classifying an issue.
@@ -80,7 +81,11 @@ func NewTriageHandler(ghToken, apiKey, model string) *TriageHandler {
 }
 
 // HandleIssue triages a newly opened issue: classify → label → comment.
-func (t *TriageHandler) HandleIssue(ctx context.Context, repo string, issueNumber int, title, body string, labels []string) (*TriageResult, error) {
+func (t *TriageHandler) HandleIssue(ctx context.Context, repo string, issueNumber int, title, body string, labels []string) (retResult *TriageResult, retErr error) {
+	defer flow.Span("swarm.triage", map[string]interface{}{
+		"repo": repo, "issue": issueNumber,
+	})(&retErr)
+
 	// Skip if already triaged
 	for _, l := range labels {
 		if strings.HasPrefix(l, "tier:") {

--- a/internal/flow/flow.go
+++ b/internal/flow/flow.go
@@ -1,0 +1,152 @@
+// Package flow emits flow-lifecycle events to a JSONL file so Sentinel can
+// observe swarm health across the octi dispatch path.
+//
+// The wire format mirrors sentinel/internal/flow and is compatible with the
+// chitin governance events.jsonl ingester: ts, sid, agent, tool, action,
+// outcome, source, latency_us, fields.
+//
+// Destination resolution (same as internal/mcptrace):
+//  1. $MCPTRACE_FILE if set
+//  2. $CHITIN_WORKSPACE/.chitin/events.jsonl if CHITIN_WORKSPACE is set
+//  3. $HOME/.chitin/flow_events.jsonl as a fallback
+//  4. no-op if none of the above resolve
+package flow
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+)
+
+// Status values for flow events.
+const (
+	StatusStarted   = "started"
+	StatusCompleted = "completed"
+	StatusFailed    = "failed"
+)
+
+// Event is one flow-lifecycle record.
+type Event struct {
+	Timestamp string                 `json:"ts"`
+	SessionID string                 `json:"sid,omitempty"`
+	Agent     string                 `json:"agent"`
+	Tool      string                 `json:"tool"`       // "flow.<name>"
+	Action    string                 `json:"action"`     // "flow_started" | "flow_completed" | "flow_failed"
+	Outcome   string                 `json:"outcome"`    // "allow" on start/complete, "deny" on fail
+	Source    string                 `json:"source"`     // always "flow"
+	LatencyUs int64                  `json:"latency_us"` // 0 for start/fail, duration for complete
+	Fields    map[string]interface{} `json:"fields,omitempty"`
+}
+
+var writeMu sync.Mutex
+
+// Emit appends a single flow event. Best-effort; errors are swallowed so
+// telemetry never breaks the caller.
+func Emit(name, status string, fields map[string]interface{}) {
+	EmitLatency(name, status, fields, 0)
+}
+
+// EmitLatency is Emit with an explicit latency in microseconds (for Complete/Fail).
+func EmitLatency(name, status string, fields map[string]interface{}, latencyUs int64) {
+	path := destination()
+	if path == "" {
+		return
+	}
+
+	outcome := "allow"
+	if status == StatusFailed {
+		outcome = "deny"
+	}
+
+	ev := Event{
+		Timestamp: time.Now().UTC().Format(time.RFC3339Nano),
+		SessionID: os.Getenv("CHITIN_SESSION_ID"),
+		Agent:     agentName(),
+		Tool:      "flow." + name,
+		Action:    "flow_" + status,
+		Outcome:   outcome,
+		Source:    "flow",
+		LatencyUs: latencyUs,
+		Fields:    fields,
+	}
+
+	data, err := json.Marshal(ev)
+	if err != nil {
+		return
+	}
+	data = append(data, '\n')
+
+	writeMu.Lock()
+	defer writeMu.Unlock()
+
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		return
+	}
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0600)
+	if err != nil {
+		return
+	}
+	defer f.Close()
+	_, _ = f.Write(data)
+}
+
+// Start emits a flow_started event.
+func Start(name string, fields map[string]interface{}) {
+	Emit(name, StatusStarted, fields)
+}
+
+// Complete emits a flow_completed event with measured latency from start.
+func Complete(name string, start time.Time, fields map[string]interface{}) {
+	EmitLatency(name, StatusCompleted, fields, time.Since(start).Microseconds())
+}
+
+// Fail emits a flow_failed event. Latency is measured from start; err is
+// attached in fields["error"] if non-nil.
+func Fail(name string, start time.Time, err error, fields map[string]interface{}) {
+	if err != nil {
+		if fields == nil {
+			fields = map[string]interface{}{}
+		}
+		fields["error"] = err.Error()
+	}
+	EmitLatency(name, StatusFailed, fields, time.Since(start).Microseconds())
+}
+
+// Span is a helper that emits Start immediately and returns a function to
+// call on scope exit. The returned function picks Complete or Fail based on
+// the pointer to error it's given.
+//
+//	defer flow.Span("swarm.dispatch", nil)(&err)
+func Span(name string, fields map[string]interface{}) func(*error) {
+	start := time.Now()
+	Start(name, fields)
+	return func(errp *error) {
+		if errp != nil && *errp != nil {
+			Fail(name, start, *errp, fields)
+			return
+		}
+		Complete(name, start, fields)
+	}
+}
+
+func agentName() string {
+	if a := os.Getenv("CHITIN_AGENT_NAME"); a != "" {
+		return a
+	}
+	return "octi-pulpo"
+}
+
+func destination() string {
+	if p := os.Getenv("MCPTRACE_FILE"); p != "" {
+		return p
+	}
+	if ws := os.Getenv("CHITIN_WORKSPACE"); ws != "" {
+		return filepath.Join(ws, ".chitin", "events.jsonl")
+	}
+	if home, err := os.UserHomeDir(); err == nil && home != "" {
+		return filepath.Join(home, ".chitin", "flow_events.jsonl")
+	}
+	return ""
+}

--- a/internal/flow/flow_test.go
+++ b/internal/flow/flow_test.go
@@ -1,0 +1,117 @@
+package flow
+
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestSpan_HappyPath(t *testing.T) {
+	dir := t.TempDir()
+	dest := filepath.Join(dir, "events.jsonl")
+	t.Setenv("MCPTRACE_FILE", dest)
+	t.Setenv("CHITIN_AGENT_NAME", "test-agent")
+	t.Setenv("CHITIN_SESSION_ID", "sess-xyz")
+
+	func() {
+		var err error
+		defer Span("swarm.dispatch.anthropic", map[string]interface{}{"task_id": "T1"})(&err)
+		time.Sleep(time.Millisecond)
+	}()
+
+	f, err := os.Open(dest)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer f.Close()
+
+	var events []Event
+	s := bufio.NewScanner(f)
+	for s.Scan() {
+		var ev Event
+		if err := json.Unmarshal(s.Bytes(), &ev); err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		events = append(events, ev)
+	}
+	if len(events) != 2 {
+		t.Fatalf("want 2 events (started + completed), got %d", len(events))
+	}
+	if events[0].Action != "flow_started" || events[1].Action != "flow_completed" {
+		t.Errorf("action sequence: %s / %s", events[0].Action, events[1].Action)
+	}
+	if events[0].Tool != "flow.swarm.dispatch.anthropic" {
+		t.Errorf("tool: got %q", events[0].Tool)
+	}
+	if events[0].Source != "flow" {
+		t.Errorf("source: got %q", events[0].Source)
+	}
+	if events[0].Agent != "test-agent" {
+		t.Errorf("agent: got %q", events[0].Agent)
+	}
+	if events[0].SessionID != "sess-xyz" {
+		t.Errorf("sid: got %q", events[0].SessionID)
+	}
+	if events[0].Outcome != "allow" || events[1].Outcome != "allow" {
+		t.Errorf("outcomes: %s / %s", events[0].Outcome, events[1].Outcome)
+	}
+	if events[1].LatencyUs <= 0 {
+		t.Errorf("completed latency not set: %d", events[1].LatencyUs)
+	}
+	if events[0].Fields["task_id"] != "T1" {
+		t.Errorf("fields missing: %+v", events[0].Fields)
+	}
+}
+
+func TestSpan_FailurePath(t *testing.T) {
+	dir := t.TempDir()
+	dest := filepath.Join(dir, "events.jsonl")
+	t.Setenv("MCPTRACE_FILE", dest)
+
+	boom := errors.New("boom")
+	func() {
+		var err error
+		defer Span("swarm.triage", nil)(&err)
+		err = boom
+	}()
+
+	data, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	var last Event
+	s := bufio.NewScanner(bufio.NewReader(openFile(t, dest)))
+	for s.Scan() {
+		_ = json.Unmarshal(s.Bytes(), &last)
+	}
+	if last.Action != "flow_failed" {
+		t.Errorf("expected flow_failed as last action, got %s (data=%s)", last.Action, data)
+	}
+	if last.Outcome != "deny" {
+		t.Errorf("failed outcome: %s", last.Outcome)
+	}
+	if last.Fields == nil || last.Fields["error"] != "boom" {
+		t.Errorf("error field missing: %+v", last.Fields)
+	}
+}
+
+func TestAgentName_Default(t *testing.T) {
+	t.Setenv("CHITIN_AGENT_NAME", "")
+	if a := agentName(); a != "octi-pulpo" {
+		t.Errorf("default agent: got %q", a)
+	}
+}
+
+func openFile(t *testing.T, path string) *os.File {
+	t.Helper()
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { f.Close() })
+	return f
+}


### PR DESCRIPTION
## Summary
- Adds `internal/flow` package (mirrors `internal/mcptrace`) that writes flow-lifecycle events to the same events.jsonl stream Sentinel already ingests.
- Wraps the three adapter `Dispatch` methods (Anthropic, GHActions, Copilot), the parent `Dispatcher.DispatchBudget`, and `TriageHandler.HandleIssue` with `flow_started` / `flow_completed` / `flow_failed` events via a small `Span` helper.
- Gives Sentinel visibility into swarm health across the octi dispatch path.

## Flow names emitted
- `flow.swarm.dispatch` (parent)
- `flow.swarm.dispatch.anthropic`
- `flow.swarm.dispatch.ghactions`
- `flow.swarm.dispatch.copilot`
- `flow.swarm.triage`

## Wire format
`{ts, sid, agent, tool: "flow.<name>", action: "flow_<status>", outcome, source: "flow", latency_us, fields}`

Destination resolution: `MCPTRACE_FILE` > `\$CHITIN_WORKSPACE/.chitin/events.jsonl` > `\$HOME/.chitin/flow_events.jsonl`. Agent from `CHITIN_AGENT_NAME`, default `octi-pulpo`.

Refs chitinhq/sentinel#36

## Test plan
- [x] `go build ./...`
- [x] `go test ./...` (all packages pass)
- [x] New `internal/flow/flow_test.go` covers happy path, failure path, agent default

Generated with Claude Code