### PR TITLE
Instrument dispatch.sh with flow events for 12 phases

### DIFF
--- a/scripts/swarm/dispatch.sh
+++ b/scripts/swarm/dispatch.sh
@@ -26,6 +26,64 @@ mkdir -p "$LOG_DIR"
 log() { echo "[$(date -u +%H:%M:%S)] $*"; }
 die() { log "ABORT: $*" >&2; exit 1; }
 
+# ── Flow emit helpers ────────────────────────────────────────────────
+# Thin wrappers around `chitin flow emit`. Errors never abort dispatch:
+# if chitin isn't installed or the subcommand fails, we log nothing
+# and continue. Fields are passed via the FIELDS env var as a
+# space-separated list of key=value pairs to avoid quoting pain.
+_flow_field_args() {
+  local args=()
+  if [[ -n "${FIELDS:-}" ]]; then
+    for kv in $FIELDS; do
+      args+=(--field "$kv")
+    done
+  fi
+  printf '%s\n' "${args[@]}"
+}
+flow_start() {
+  local name="$1"
+  local field_args=()
+  while IFS= read -r line; do [[ -n "$line" ]] && field_args+=("$line"); done < <(_flow_field_args)
+  chitin flow emit "$name" started "${field_args[@]}" >/dev/null 2>&1 || true
+}
+flow_complete() {
+  local name="$1"
+  local field_args=()
+  while IFS= read -r line; do [[ -n "$line" ]] && field_args+=("$line"); done < <(_flow_field_args)
+  chitin flow emit "$name" completed "${field_args[@]}" >/dev/null 2>&1 || true
+}
+flow_fail() {
+  local name="$1"
+  local reason="$2"
+  local field_args=()
+  while IFS= read -r line; do [[ -n "$line" ]] && field_args+=("$line"); done < <(_flow_field_args)
+  chitin flow emit "$name" failed --reason "$reason" "${field_args[@]}" >/dev/null 2>&1 || true
+}
+
+# Generate a dispatch_id for this run (used as a correlation key across
+# all 12 phase events). Falls back to epoch+pid if uuidgen is missing.
+DISPATCH_ID="${DISPATCH_ID:-$(uuidgen 2>/dev/null || echo "dispatch-$(date +%s)-$$")}"
+export DISPATCH_ID
+
+# Ensure the parent span always closes, even on die/failure paths.
+# Guarded so it's safe to call before the span is opened (no-op in that
+# case because _flow_dispatch_opened stays 0).
+_flow_dispatch_opened=0
+_flow_dispatch_closed=0
+close_flow_dispatch() {
+  local rc=$?
+  if [[ "$_flow_dispatch_opened" -eq 1 && "$_flow_dispatch_closed" -eq 0 ]]; then
+    _flow_dispatch_closed=1
+    if [[ "$rc" -eq 0 ]]; then
+      FIELDS="dispatch_id=$DISPATCH_ID repo=$REPO issue=$ISSUE_NUM platform=$PLATFORM queue=$QUEUE" \
+        flow_complete swarm.dispatch
+    else
+      FIELDS="dispatch_id=$DISPATCH_ID repo=$REPO issue=$ISSUE_NUM platform=$PLATFORM queue=$QUEUE exit_code=$rc" \
+        flow_fail swarm.dispatch "dispatch exited rc=$rc"
+    fi
+  fi
+}
+
 # ── Phase 0: Open Chitin session ─────────────────────────────────────
 # The session wraps the entire dispatch so every downstream event
 # (pre-check, gate, telemetry) threads the same session id. If chitin
@@ -56,6 +114,9 @@ export CHITIN_SESSION_ID
 # final exit code.
 cleanup_chitin_session() {
   local rc=$?
+  # Close the parent flow span first so its timing doesn't include
+  # the chitin session teardown.
+  close_flow_dispatch
   if [[ -n "${CHITIN_SESSION_ID:-}" && -n "${CHITIN_BIN:-}" ]]; then
     local reason="dispatch_done"
     [[ "$rc" -ne 0 ]] && reason="dispatch_failed_rc${rc}"
@@ -64,23 +125,44 @@ cleanup_chitin_session() {
 }
 trap cleanup_chitin_session EXIT
 
+# Open the parent span that brackets the whole dispatch. Placed after
+# the trap so close_flow_dispatch always runs to close it.
+FIELDS="dispatch_id=$DISPATCH_ID repo=$REPO issue=$ISSUE_NUM platform=$PLATFORM queue=$QUEUE model=$MODEL" \
+  flow_start swarm.dispatch
+_flow_dispatch_opened=1
+
 # ── Phase 1: Deterministic pre-checks (no tokens) ────────────────────
 log "Phase 1: Pre-dispatch checks"
+FIELDS="dispatch_id=$DISPATCH_ID" flow_start swarm.dispatch.phase.pre_checks
 
-"$SCRIPT_DIR/check-budget.sh" "$PLATFORM" || die "budget check failed"
-"$SCRIPT_DIR/pre-dispatch.sh" "$PLATFORM" "$REPO" "$ISSUE_NUM" "$QUEUE" || die "pre-dispatch check failed"
+if ! "$SCRIPT_DIR/check-budget.sh" "$PLATFORM"; then
+  FIELDS="dispatch_id=$DISPATCH_ID" flow_fail swarm.dispatch.phase.pre_checks "budget check failed"
+  die "budget check failed"
+fi
+if ! "$SCRIPT_DIR/pre-dispatch.sh" "$PLATFORM" "$REPO" "$ISSUE_NUM" "$QUEUE"; then
+  FIELDS="dispatch_id=$DISPATCH_ID" flow_fail swarm.dispatch.phase.pre_checks "pre-dispatch check failed"
+  die "pre-dispatch check failed"
+fi
+FIELDS="dispatch_id=$DISPATCH_ID" flow_complete swarm.dispatch.phase.pre_checks
 
 # ── Phase 2: Build prompt from template (no tokens) ──────────────────
 log "Phase 2: Building prompt from template"
+FIELDS="dispatch_id=$DISPATCH_ID" flow_start swarm.dispatch.phase.prompt_building
 
-PROMPT=$("$SCRIPT_DIR/build-prompt.sh" "$REPO" "$ISSUE_NUM" "$QUEUE") || die "prompt build failed"
+if ! PROMPT=$("$SCRIPT_DIR/build-prompt.sh" "$REPO" "$ISSUE_NUM" "$QUEUE"); then
+  FIELDS="dispatch_id=$DISPATCH_ID" flow_fail swarm.dispatch.phase.prompt_building "prompt build failed"
+  die "prompt build failed"
+fi
 PROMPT_LEN=${#PROMPT}
 log "Prompt assembled: $PROMPT_LEN chars"
+FIELDS="dispatch_id=$DISPATCH_ID prompt_len=$PROMPT_LEN" flow_complete swarm.dispatch.phase.prompt_building
 
 # ── Phase 3: Claim issue ─────────────────────────────────────────────
 log "Phase 3: Claiming issue #$ISSUE_NUM"
+FIELDS="dispatch_id=$DISPATCH_ID" flow_start swarm.dispatch.phase.claim
 
 gh api "repos/chitinhq/$REPO/issues/$ISSUE_NUM/labels" --input - <<< "{\"labels\":[\"agent:claimed\"]}" >/dev/null 2>&1 || true
+FIELDS="dispatch_id=$DISPATCH_ID" flow_complete swarm.dispatch.phase.claim
 
 # ── Phase 4: Create worktree ─────────────────────────────────────────
 BRANCH="swarm/${QUEUE}-${ISSUE_NUM}"
@@ -88,15 +170,26 @@ WORKTREE_DIR="$REPO_DIR/.worktrees/$BRANCH"
 
 if [[ "$QUEUE" != "intake" && "$QUEUE" != "groom" ]]; then
   log "Phase 4: Creating worktree $BRANCH"
-  git -C "$REPO_DIR" worktree add -b "$BRANCH" "$WORKTREE_DIR" 2>/dev/null || die "worktree creation failed"
+  FIELDS="dispatch_id=$DISPATCH_ID branch=$BRANCH" flow_start swarm.dispatch.phase.worktree
+  if ! git -C "$REPO_DIR" worktree add -b "$BRANCH" "$WORKTREE_DIR" 2>/dev/null; then
+    FIELDS="dispatch_id=$DISPATCH_ID branch=$BRANCH" flow_fail swarm.dispatch.phase.worktree "worktree creation failed"
+    die "worktree creation failed"
+  fi
   WORK_DIR="$WORKTREE_DIR"
+  FIELDS="dispatch_id=$DISPATCH_ID branch=$BRANCH" flow_complete swarm.dispatch.phase.worktree
 else
-  # Intake and groom don't need worktrees — they read, not write
+  # Intake and groom don't need worktrees — they read, not write.
+  # Emit a started/completed pair anyway so the phase is observable and
+  # dashboards see a 0ms span rather than a gap.
+  FIELDS="dispatch_id=$DISPATCH_ID skipped=true queue=$QUEUE" flow_start swarm.dispatch.phase.worktree
   WORK_DIR="$REPO_DIR"
+  FIELDS="dispatch_id=$DISPATCH_ID skipped=true queue=$QUEUE" flow_complete swarm.dispatch.phase.worktree
 fi
 
 # ── Phase 5: Dispatch agent (tokens spent here) ──────────────────────
 log "Phase 5: Dispatching $PLATFORM ($MODEL) for $QUEUE"
+FIELDS="dispatch_id=$DISPATCH_ID platform=$PLATFORM model=$MODEL queue=$QUEUE" \
+  flow_start swarm.dispatch.phase.agent_execution
 DISPATCH_START=$(date +%s%N)
 
 # Max turns by queue (deterministic, not LLM-decided)
@@ -148,14 +241,37 @@ DISPATCH_END=$(date +%s%N)
 DURATION_MS=$(( (DISPATCH_END - DISPATCH_START) / 1000000 ))
 log "Agent finished with exit code $EXIT_CODE (${DURATION_MS}ms)"
 
+if [[ "$EXIT_CODE" -eq 0 ]]; then
+  FIELDS="dispatch_id=$DISPATCH_ID duration_ms=$DURATION_MS exit_code=$EXIT_CODE" \
+    flow_complete swarm.dispatch.phase.agent_execution
+else
+  FIELDS="dispatch_id=$DISPATCH_ID duration_ms=$DURATION_MS exit_code=$EXIT_CODE" \
+    flow_fail swarm.dispatch.phase.agent_execution "agent exited rc=$EXIT_CODE"
+fi
+
 # ── Phase 6: Deterministic post-validation (no tokens) ───────────────
 log "Phase 6: Post-dispatch validation"
+FIELDS="dispatch_id=$DISPATCH_ID" flow_start swarm.dispatch.phase.post_validation
 
 POST_RESULT=0
 "$SCRIPT_DIR/post-dispatch.sh" "$PLATFORM" "$REPO" "$ISSUE_NUM" "$QUEUE" "${WORKTREE_DIR:-$REPO_DIR}" "$EXIT_CODE" || POST_RESULT=$?
 
+# tests_passed / lint_passed aren't yet plumbed out of post-dispatch.sh
+# as separate signals — it returns a single exit code. Emit what we
+# have and mark both as derived from POST_RESULT so dashboards can
+# still group. Splitting them properly is a follow-up on post-dispatch.sh.
+if [[ "$POST_RESULT" -eq 0 ]]; then
+  FIELDS="dispatch_id=$DISPATCH_ID tests_passed=true lint_passed=true post_result=$POST_RESULT" \
+    flow_complete swarm.dispatch.phase.post_validation
+else
+  FIELDS="dispatch_id=$DISPATCH_ID tests_passed=false lint_passed=false post_result=$POST_RESULT" \
+    flow_fail swarm.dispatch.phase.post_validation "post-validation failed rc=$POST_RESULT"
+fi
+
 # ── Phase 7: Advance labels or escalate ──────────────────────────────
 log "Phase 7: Label advancement"
+FIELDS="dispatch_id=$DISPATCH_ID from_label=agent:claimed" \
+  flow_start swarm.dispatch.phase.label_advance
 
 # Remove agent:claimed
 gh api "repos/chitinhq/$REPO/issues/$ISSUE_NUM/labels/agent:claimed" -X DELETE >/dev/null 2>&1 || true
@@ -172,23 +288,47 @@ if [[ "$EXIT_CODE" -eq 0 && "$POST_RESULT" -eq 0 ]]; then
     log "Advanced: $QUEUE → $NEXT_LABEL"
   fi
   RESULT="success"
+  FIELDS="dispatch_id=$DISPATCH_ID from_label=agent:claimed to_label=${NEXT_LABEL:-none}" \
+    flow_complete swarm.dispatch.phase.label_advance
 else
   log "Dispatch failed — escalation needed"
   RESULT="failed"
+  FIELDS="dispatch_id=$DISPATCH_ID from_label=agent:claimed to_label=agent:blocked" \
+    flow_fail swarm.dispatch.phase.label_advance "dispatch failed; escalation"
 fi
 
 # ── Phase 8: Log dispatch event ──────────────────────────────────────
+FIELDS="dispatch_id=$DISPATCH_ID result=$RESULT" flow_start swarm.dispatch.phase.telemetry_emit
 "$SCRIPT_DIR/log-dispatch.sh" "$PLATFORM" "$REPO" "$ISSUE_NUM" "$QUEUE" "$MODEL" "$RESULT"
+FIELDS="dispatch_id=$DISPATCH_ID result=$RESULT" flow_complete swarm.dispatch.phase.telemetry_emit
 
 # ── Phase 9: Emit telemetry for sentinel ──────────────────────────────
+# Note: per spec, sentinel_eval is the phase name for the sentinel step
+# (Phase 10 below). The emit-telemetry.sh call is folded under
+# telemetry_emit (Phase 8) conceptually — we leave the log line here
+# but don't double-emit a flow event.
 log "Phase 9: Emitting telemetry"
 "$SCRIPT_DIR/emit-telemetry.sh" "$PLATFORM" "$REPO" "$ISSUE_NUM" "$QUEUE" "$MODEL" "$RESULT" "$EXIT_CODE" "$DURATION_MS" || true
 
 # ── Phase 10: Sentinel evaluation ────────────────────────────────────
 log "Phase 10: Sentinel eval"
+FIELDS="dispatch_id=$DISPATCH_ID" flow_start swarm.dispatch.phase.sentinel_eval
 "$SCRIPT_DIR/sentinel-eval.sh" 2>&1 | tail -10 || true
+FIELDS="dispatch_id=$DISPATCH_ID" flow_complete swarm.dispatch.phase.sentinel_eval
+
+# ── Phase 10b: PR creation ───────────────────────────────────────────
+# dispatch.sh doesn't currently run `gh pr create` itself — that's done
+# by the build agent during Phase 5, or by downstream handlers. We emit
+# a zero-duration span so the phase appears in dashboards; pr_number
+# is unknown at this layer. Splitting PR creation out of the agent is
+# tracked as a follow-up.
+FIELDS="dispatch_id=$DISPATCH_ID note=pr_creation_inside_agent" \
+  flow_start swarm.dispatch.phase.pr_creation
+FIELDS="dispatch_id=$DISPATCH_ID note=pr_creation_inside_agent" \
+  flow_complete swarm.dispatch.phase.pr_creation
 
 # ── Phase 11: Cleanup worktree ───────────────────────────────────────
+FIELDS="dispatch_id=$DISPATCH_ID" flow_start swarm.dispatch.phase.cleanup
 if [[ -d "${WORKTREE_DIR:-}" ]]; then
   if [[ "$RESULT" == "success" && "$QUEUE" == "build" ]]; then
     log "Worktree kept for PR: $WORKTREE_DIR"
@@ -197,8 +337,10 @@ if [[ -d "${WORKTREE_DIR:-}" ]]; then
     log "Worktree cleaned up"
   fi
 fi
+FIELDS="dispatch_id=$DISPATCH_ID" flow_complete swarm.dispatch.phase.cleanup
 
 # ── Phase 12: Ensure main checkout is on default branch ─────────────
+FIELDS="dispatch_id=$DISPATCH_ID" flow_start swarm.dispatch.phase.ensure_main
 DEFAULT_BRANCH=$(git -C "$REPO_DIR" symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|refs/remotes/origin/||' || true)
 if [[ -z "$DEFAULT_BRANCH" ]]; then
   if git -C "$REPO_DIR" rev-parse --verify origin/main &>/dev/null; then
@@ -211,6 +353,8 @@ CURRENT=$(git -C "$REPO_DIR" rev-parse --abbrev-ref HEAD 2>/dev/null || true)
 if [[ "$CURRENT" != "$DEFAULT_BRANCH" ]]; then
   git -C "$REPO_DIR" checkout "$DEFAULT_BRANCH" 2>/dev/null || log "WARN: failed to return to $DEFAULT_BRANCH"
 fi
+FIELDS="dispatch_id=$DISPATCH_ID default_branch=$DEFAULT_BRANCH" \
+  flow_complete swarm.dispatch.phase.ensure_main
 
 log "Done: $PLATFORM/$REPO#$ISSUE_NUM ($QUEUE) → $RESULT"
 exit $([[ "$RESULT" == "success" ]] && echo 0 || echo 1)


### PR DESCRIPTION
## Summary

Instruments `scripts/swarm/dispatch.sh` with `chitin flow emit` calls bracketing each of the 12 phases from the `concepts/swarm-dispatch-pipeline` wiki article, plus a parent `swarm.dispatch` span.

- Adds `flow_start` / `flow_complete` / `flow_fail` helpers. All errors are swallowed (`|| true`) — a missing or broken `chitin` CLI cannot abort dispatch.
- Fields pass via `FIELDS` env var as space-separated `key=value` pairs to avoid quoting hell.
- `DISPATCH_ID` (uuidgen-or-fallback) correlates every phase event for one dispatch run.
- Parent span closes via `EXIT` trap, chained with the existing `cleanup_chitin_session` so both always run on `die` and non-zero exits.
- Existing log output is unchanged — flow events are additive.

All 12 phase names from the wiki are emitted:
`pre_checks, prompt_building, claim, worktree, agent_execution, post_validation, label_advance, telemetry_emit, sentinel_eval, pr_creation, cleanup, ensure_main`

## Notes / follow-ups

- `pr_creation` is emitted as a zero-duration span — dispatch.sh doesn't currently run `gh pr create` itself (the build agent does it mid-Phase-5). Tracked as a follow-up so `pr_number` can be plumbed out.
- `post_validation` emits `tests_passed`/`lint_passed` both derived from the single exit code of `post-dispatch.sh`. Splitting those into separate signals is a follow-up on `post-dispatch.sh`.
- `worktree` phase for `intake`/`groom` queues emits a start/complete pair with `skipped=true` so the phase stays observable.

## Test plan

- [x] `bash -n scripts/swarm/dispatch.sh` parses clean
- [ ] Wait for next live dispatch and verify 14 flow events (parent + 12 phases, 12 completed events) land in the flow sink
- [ ] Confirm no regression when `chitin` CLI lacks `flow` subcommand (errors swallowed)

Closes #188

🤖 Generated with [Claude Code](https://claude.com/claude-code)