### PR TITLE
docs: standardize PR template + CONTRIBUTING (hopper-lens pass)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,25 @@
+<!--
+Keep this short. A tired reviewer at 11pm should grok it in 30 seconds.
+Delete sections that don't apply. Don't add new ones.
+-->
+
+## Summary
+<!-- 1-3 sentences. What does this PR do, in plain language? -->
+
+## What changed
+- <!-- bulleted facts; one change per bullet -->
+
+## Why now
+<!-- One line. Link an issue or motivation. e.g. "Fixes #123" or "Unblocks rollout N." -->
+
+## How to verify
+```
+# commands a reviewer can paste
+```
+Expected: <!-- what they should see -->
+
+## Risks / follow-ups
+<!-- Be honest. "None known" is a valid answer. List follow-up issues if any. -->
+
+## Related
+<!-- PRs, issues, umbrella work. Delete if none. -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,51 @@
+# Contributing
+
+Thanks for showing up. This doc exists so your first PR lands without a scavenger hunt.
+
+## Setup
+
+```bash
+git clone <this-repo>
+cd <repo>
+# Chitin-platform repos: `chitin init` bootstraps deps
+# Go repos: `go build ./...`
+# Python repos: `uv sync` or `pip install -e .`
+```
+
+If setup takes more than one command and a coffee, that's a bug — file an issue.
+
+## PR naming
+
+We use [Conventional Commits](https://www.conventionalcommits.org/):
+
+```
+<type>(<scope>): <summary>
+```
+
+Types: `feat`, `fix`, `docs`, `chore`, `refactor`, `test`, `perf`.
+
+Real examples from this org:
+
+- `feat(session): enrich triple with SoulContext`
+- `fix(hook): tag governance events with active soul`
+- `docs: add claws wrapper to GETTING_STARTED`
+
+Scope is optional but helps reviewers route. Keep the summary under 70 chars.
+
+## PR template
+
+`.github/PULL_REQUEST_TEMPLATE.md` fills in when you open a PR. It's short on purpose. If a section doesn't apply, delete it. If you feel like adding a section, don't — open an issue instead.
+
+## Review flow
+
+1. CI + Copilot review run automatically on open.
+2. Address Copilot comments before requesting human review (most are legit).
+3. A human reviewer merges. Squash-merge is the default.
+
+## Optional: soul context
+
+If you wrote the PR under a specific cognitive lens (e.g. `hopper`, `feynman`, `turing`), mention it in the Summary. It's a hint for reviewers, not a requirement.
+
+## Questions
+
+Open an issue or ping in the workspace chat. Silent struggles help no one.


### PR DESCRIPTION
## Summary
Stamps the workspace-level PR template and CONTRIBUTING.md into this repo so contributor first-contact is consistent across chitinhq.

## What changed
- Adds `.github/PULL_REQUEST_TEMPLATE.md` (short-form, under 40 lines)
- Adds `CONTRIBUTING.md` (setup, PR naming, review flow)

## Why now
Unifies contributor docs across chitinhq repos. Source of truth lives in `workspace/.github/templates/`; re-synced via `scripts/sync-pr-templates.sh`.

## How to verify
```
gh pr create --help  # confirms template picks up on next PR open
cat .github/PULL_REQUEST_TEMPLATE.md
cat CONTRIBUTING.md
```

## Risks / follow-ups
None known. If a repo wants a section added, add it to the workspace template and re-run the sync script.

## Related
Hopper-lens documentation pass across chitinhq.
