### PR TITLE
fix(coordination): lazy-prune orphaned active-claims zset (#206)

### DIFF
--- a/internal/coordination/engine.go
+++ b/internal/coordination/engine.go
@@ -60,23 +60,75 @@ func (e *Engine) ClaimTask(ctx context.Context, agentID, task string, ttlSeconds
 	return claim, err
 }
 
+// defaultClaimTTLSeconds is used to prune zset members whose embedded TTL is
+// missing or non-positive (defensive fallback for legacy / malformed claims).
+const defaultClaimTTLSeconds = 900
+
 // ActiveClaims returns all non-expired claims across the swarm.
+//
+// Lazy-prune (issue #206): the underlying `active-claims` zset has no per-member
+// TTL — when a holder dies mid-work without calling ReleaseClaim, the entry
+// wedged dispatch forever. We now ZREM any member whose score (claimed-at
+// UnixMilli) plus its embedded TTL is in the past relative to the Redis server
+// clock, AND whose `claim:<agentID>` TTL key is gone. Server time is used so
+// that clock skew between octi-pulpo and Redis can't keep dead members alive.
 func (e *Engine) ActiveClaims(ctx context.Context) ([]Claim, error) {
-	raw, err := e.rdb.ZRevRange(ctx, e.key("active-claims"), 0, 50).Result()
+	zkey := e.key("active-claims")
+	raw, err := e.rdb.ZRangeByScoreWithScores(ctx, zkey, &redis.ZRangeBy{
+		Min: "-inf",
+		Max: "+inf",
+	}).Result()
 	if err != nil {
 		return nil, err
 	}
+
+	// Use Redis server time to avoid local clock skew.
+	nowMilli := time.Now().UnixMilli()
+	if t, err := e.rdb.Time(ctx).Result(); err == nil {
+		nowMilli = t.UnixMilli()
+	}
+
 	var claims []Claim
-	for _, r := range raw {
+	var stale []interface{}
+	for _, z := range raw {
+		member, _ := z.Member.(string)
 		var c Claim
-		if err := json.Unmarshal([]byte(r), &c); err != nil {
+		if err := json.Unmarshal([]byte(member), &c); err != nil {
+			// unparseable garbage — prune.
+			stale = append(stale, member)
 			continue
 		}
-		// Check if the claim TTL key still exists
-		exists, _ := e.rdb.Exists(ctx, e.key("claim:"+c.AgentID)).Result()
-		if exists > 0 {
-			claims = append(claims, c)
+		ttl := c.TTLSeconds
+		if ttl <= 0 {
+			ttl = defaultClaimTTLSeconds
 		}
+		expiresAtMilli := int64(z.Score) + int64(ttl)*1000
+
+		// The `claim:<agentID>` SET key has its own Redis TTL; if it is gone,
+		// the holder either released or the TTL fired. Treat as absent.
+		exists, _ := e.rdb.Exists(ctx, e.key("claim:"+c.AgentID)).Result()
+
+		if exists == 0 || expiresAtMilli < nowMilli {
+			stale = append(stale, member)
+			continue
+		}
+		claims = append(claims, c)
+	}
+
+	if len(stale) > 0 {
+		// Best-effort prune; failures here must not break dispatch.
+		_ = e.rdb.ZRem(ctx, zkey, stale...).Err()
+	}
+
+	// Preserve previous "newest first, capped at 50" semantics.
+	if len(claims) > 1 {
+		// raw was ascending by score; reverse and cap.
+		for i, j := 0, len(claims)-1; i < j; i, j = i+1, j-1 {
+			claims[i], claims[j] = claims[j], claims[i]
+		}
+	}
+	if len(claims) > 50 {
+		claims = claims[:50]
 	}
 	return claims, nil
 }

--- a/internal/coordination/engine_test.go
+++ b/internal/coordination/engine_test.go
@@ -252,6 +252,70 @@ func TestActiveClaims_PrunesOrphanedZsetMembers(t *testing.T) {
 	}
 }
 
+// TestActiveClaims_LegacyMemberMissingTTLUsesDefault covers the fallback path
+// in ActiveClaims where a pre-#206 zset member was persisted without a
+// `ttl_seconds` field. The prune arithmetic must treat ttl<=0 as the default
+// (900s), so a legacy member whose score is ~1h old (well under 900s... wait:
+// 900s == 15min, so 1h > 900s) MUST be pruned — and a recent legacy member
+// (score = now) MUST survive even without an explicit ttl_seconds, provided
+// its `claim:<agent>` SET key exists.
+func TestActiveClaims_LegacyMemberMissingTTLUsesDefault(t *testing.T) {
+	e, ctx := testSetup(t)
+	zkey := e.key("active-claims")
+
+	// Legacy payload: no ttl_seconds field. Marshal a minimal JSON by hand so
+	// the Claim.TTLSeconds defaults to 0 on the wire (tests the fallback code
+	// path even if struct tags change in the future).
+	recentLegacy := `{"claim_id":"legacy:recent","agent_id":"legacy-recent","task":"x","claimed_at":"2026-04-13T00:00:00Z"}`
+	oldLegacy := `{"claim_id":"legacy:old","agent_id":"legacy-old","task":"x","claimed_at":"2026-04-12T00:00:00Z"}`
+
+	now := time.Now().UnixMilli()
+	// Recent: score = now, default TTL 900s would keep it alive.
+	if err := e.rdb.ZAdd(ctx, zkey, redis.Z{Score: float64(now), Member: recentLegacy}).Err(); err != nil {
+		t.Fatalf("seed recent: %v", err)
+	}
+	// Old: score = 1h ago, default TTL 900s means expired by ~45min.
+	if err := e.rdb.ZAdd(ctx, zkey, redis.Z{Score: float64(now - 3600*1000), Member: oldLegacy}).Err(); err != nil {
+		t.Fatalf("seed old: %v", err)
+	}
+
+	// The recent legacy entry needs a live `claim:` SET key to survive the
+	// exists==0 branch (pruning requires BOTH a live SET key AND unexpired
+	// score+ttl to keep the entry).
+	if err := e.rdb.Set(ctx, e.key("claim:legacy-recent"), recentLegacy, 900*time.Second).Err(); err != nil {
+		t.Fatalf("seed SET: %v", err)
+	}
+
+	claims, err := e.ActiveClaims(ctx)
+	if err != nil {
+		t.Fatalf("ActiveClaims: %v", err)
+	}
+
+	var sawRecent, sawOld bool
+	for _, c := range claims {
+		if c.AgentID == "legacy-recent" {
+			sawRecent = true
+		}
+		if c.AgentID == "legacy-old" {
+			sawOld = true
+		}
+	}
+	if !sawRecent {
+		t.Error("recent legacy claim (missing ttl_seconds) should survive via default 900s fallback")
+	}
+	if sawOld {
+		t.Error("1h-old legacy claim should be pruned — default TTL 900s is well expired")
+	}
+
+	// Expired legacy must be ZREMed from the zset, not just filtered.
+	members, _ := e.rdb.ZRange(ctx, zkey, 0, -1).Result()
+	for _, m := range members {
+		if strings.Contains(m, "legacy-old") {
+			t.Error("expired legacy member should be ZREMed from zset")
+		}
+	}
+}
+
 func TestClose_NoError(t *testing.T) {
 	e, _ := testSetup(t)
 	// Close is called via t.Cleanup, but we verify explicit close works too.

--- a/internal/coordination/engine_test.go
+++ b/internal/coordination/engine_test.go
@@ -2,6 +2,7 @@ package coordination
 
 import (
 	"context"
+	"encoding/json"
 	"strings"
 	"testing"
 	"time"
@@ -188,6 +189,66 @@ func TestClaimTask_ClaimIDContainsAgentID(t *testing.T) {
 	}
 	if !strings.HasPrefix(claim.ClaimID, "my-agent:") {
 		t.Errorf("ClaimID %q should start with agent ID prefix", claim.ClaimID)
+	}
+}
+
+// TestActiveClaims_PrunesOrphanedZsetMembers covers issue #206:
+// when a claim holder dies without calling ReleaseClaim, the `claim:<agent>`
+// SET key auto-expires via Redis TTL but the zset member lingers forever.
+// ActiveClaims must ZREM stale members on read.
+func TestActiveClaims_PrunesOrphanedZsetMembers(t *testing.T) {
+	e, ctx := testSetup(t)
+	zkey := e.key("active-claims")
+
+	// Inject an orphaned claim: score far in the past, TTL short, no `claim:` SET key.
+	orphan := Claim{
+		ClaimID:    "ghost:1",
+		AgentID:    "ghost-agent",
+		Task:       "wedged forever",
+		ClaimedAt:  time.Now().UTC().Add(-1 * time.Hour).Format(time.RFC3339),
+		TTLSeconds: 60,
+	}
+	data, _ := json.Marshal(orphan)
+	pastMilli := time.Now().Add(-1 * time.Hour).UnixMilli()
+	if err := e.rdb.ZAdd(ctx, zkey, redis.Z{Score: float64(pastMilli), Member: data}).Err(); err != nil {
+		t.Fatalf("seed zset: %v", err)
+	}
+
+	// Pre-check: member is present.
+	if n, _ := e.rdb.ZCard(ctx, zkey).Result(); n != 1 {
+		t.Fatalf("pre: want 1 zset member, got %d", n)
+	}
+
+	// Add a live claim so dispatch has something to return.
+	if _, err := e.ClaimTask(ctx, "live-agent", "real work", 300); err != nil {
+		t.Fatalf("ClaimTask: %v", err)
+	}
+
+	claims, err := e.ActiveClaims(ctx)
+	if err != nil {
+		t.Fatalf("ActiveClaims: %v", err)
+	}
+
+	// Orphan must not appear.
+	for _, c := range claims {
+		if c.AgentID == "ghost-agent" {
+			t.Error("orphaned ghost-agent claim leaked into ActiveClaims")
+		}
+	}
+
+	// Orphan must be ZREMed — the zset should only contain the live claim.
+	n, err := e.rdb.ZCard(ctx, zkey).Result()
+	if err != nil {
+		t.Fatalf("ZCard: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("expected zset pruned to 1 member, got %d", n)
+	}
+
+	// Confirm the surviving member is the live one.
+	members, _ := e.rdb.ZRange(ctx, zkey, 0, -1).Result()
+	if len(members) != 1 || !strings.Contains(members[0], "live-agent") {
+		t.Errorf("surviving member not live-agent: %v", members)
 	}
 }
 


### PR DESCRIPTION
## Summary
- `octi:active-claims` zset had no per-member TTL — dead holders wedged dispatch forever (workspace-pr-review-agent wedged twice in 15 min today).
- `ActiveClaims` now ZREMs stale members on read, using Redis `TIME` + embedded `TTLSeconds` (default 900s). Also prunes if the companion `claim:<agentID>` SET key has already expired.

## Root cause
Per thread: `wiki/ganglia/go-2026-04-13-1340/thread.md` — the SET key auto-expires via Redis TTL, but the zset member was never removed, so every subsequent `ActiveClaims` still saw the ghost.

## Test plan
- [x] `go test ./internal/coordination/ -run 'TestActiveClaims|TestClaimTask|TestReleaseClaim' -count=1` passes against local Redis
- [x] New `TestActiveClaims_PrunesOrphanedZsetMembers` seeds an orphan zset member (no matching SET key, score 1h in the past) and asserts it is ZREMed on read
- [x] Existing `TestReleaseClaim_RemovesFromActiveClaims` still passes (release path unchanged)

## Assumptions
- zset score is claim-time UnixMilli (confirmed via `ClaimTask`)
- zset value is JSON-encoded `Claim` with `ttl_seconds` field
- Redis `TIME` available (standard; falls back to local clock if unavailable)

Closes #206.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>