### PR TITLE
feat(dispatch): add dispatch_prompt_to_cli MCP tool (free CLI, no API key)

### DIFF
--- a/internal/dispatch/prompt_cli_adapter.go
+++ b/internal/dispatch/prompt_cli_adapter.go
@@ -14,10 +14,29 @@ import (
 const DefaultPromptCLITimeout = 120 * time.Second
 
 // PromptCLIRunner executes a CLI subprocess and returns its combined stdout.
-// The prompt is delivered on stdin to avoid shell-injection via argv.
+// The prompt is passed via argv; this is safe because exec.Command does not
+// spawn a shell, so no shell interpolation/injection is possible.
 // Injected in tests to exercise selection/timeout/fallback logic without
 // real subprocesses.
 type PromptCLIRunner func(ctx context.Context, driver, binary, systemPrompt, prompt string) (stdout []byte, err error)
+
+// AllowedDrivers is the allowlist of accepted driver names. Unknown values
+// are rejected at the boundary to prevent arbitrary-binary execution via a
+// user-controlled `preferred_driver` falling through to a default case.
+var AllowedDrivers = map[string]bool{
+	"copilot":     true,
+	"codex":       true,
+	"claude-code": true,
+	"":            true, // empty → use default fallback chain
+}
+
+// ValidatePreferredDriver returns an error if driver is not on the allowlist.
+func ValidatePreferredDriver(driver string) error {
+	if !AllowedDrivers[driver] {
+		return fmt.Errorf("invalid preferred_driver %q: allowed values are copilot, codex, claude-code, or empty", driver)
+	}
+	return nil
+}
 
 // PromptCLIRequest is a freeform prompt-to-CLI dispatch input.
 type PromptCLIRequest struct {
@@ -38,7 +57,8 @@ type PromptCLIResult struct {
 // PromptCLIAdapter dispatches a freeform prompt to a local CLI agent
 // (Copilot CLI, Codex, or Claude Code) without requiring a git worktree
 // or an API key. It picks a driver by simple fallback policy and executes
-// one subprocess with stdin-delivered prompt.
+// one subprocess, passing the prompt via argv (safe under exec.Command,
+// which does not spawn a shell).
 type PromptCLIAdapter struct {
 	// DriverOrder overrides the default fallback chain when non-empty.
 	DriverOrder []string
@@ -127,22 +147,36 @@ func (a *PromptCLIAdapter) Dispatch(ctx context.Context, req *PromptCLIRequest) 
 		return res
 	}
 
+	if err := ValidatePreferredDriver(req.PreferredDriver); err != nil {
+		res.Error = err.Error()
+		res.DurationMS = time.Since(start).Milliseconds()
+		return res
+	}
+
 	timeout := req.Timeout
 	if timeout <= 0 {
 		timeout = DefaultPromptCLITimeout
 	}
+	// Compute a single cumulative deadline shared across all fallback
+	// candidates so that N drivers × timeout can never multiply into
+	// N*timeout worst-case runtime.
+	deadline := time.Now().Add(timeout)
 
 	drivers := a.driversToTry(req.PreferredDriver)
 
 	var lastErr error
 	for _, driver := range drivers {
+		if time.Now().After(deadline) {
+			lastErr = fmt.Errorf("timeout: cumulative deadline exceeded before trying %s", driver)
+			break
+		}
 		bin := a.binaryFor(driver)
 		if _, err := a.lookPath(bin); err != nil {
 			lastErr = fmt.Errorf("%s: not installed (%s)", driver, bin)
 			continue
 		}
 
-		cctx, cancel := context.WithTimeout(ctx, timeout)
+		cctx, cancel := context.WithDeadline(ctx, deadline)
 		runner := a.Runner
 		if runner == nil {
 			runner = realPromptCLIRunner
@@ -152,6 +186,10 @@ func (a *PromptCLIAdapter) Dispatch(ctx context.Context, req *PromptCLIRequest) 
 
 		if err != nil {
 			lastErr = fmt.Errorf("%s: %w", driver, err)
+			// If the shared deadline fired, stop trying further drivers.
+			if cctx.Err() == context.DeadlineExceeded || time.Now().After(deadline) {
+				break
+			}
 			// Treat transient errors as a reason to fall back.
 			continue
 		}
@@ -171,9 +209,18 @@ func (a *PromptCLIAdapter) Dispatch(ctx context.Context, req *PromptCLIRequest) 
 }
 
 // realPromptCLIRunner invokes the real CLI subprocess. The prompt is
-// written to the process stdin to avoid argv/shell injection risk.
+// passed via argv; this is safe because exec.Command does not spawn a
+// shell, so there is no shell interpolation. Driver names are validated
+// against AllowedDrivers at the Dispatch boundary so buildPromptCLIArgs
+// will never receive an unknown driver here.
 func realPromptCLIRunner(ctx context.Context, driver, binary, systemPrompt, prompt string) ([]byte, error) {
+	if !AllowedDrivers[driver] || driver == "" {
+		return nil, fmt.Errorf("refusing to exec unknown driver %q", driver)
+	}
 	args, stdinPayload := buildPromptCLIArgs(driver, systemPrompt, prompt)
+	if len(args) == 0 {
+		return nil, fmt.Errorf("refusing to exec driver %q with empty args", driver)
+	}
 
 	cmd := exec.CommandContext(ctx, binary, args...)
 	cmd.Env = os.Environ()
@@ -197,7 +244,9 @@ func realPromptCLIRunner(ctx context.Context, driver, binary, systemPrompt, prom
 }
 
 // buildPromptCLIArgs returns (args, stdin) for a driver. The prompt is
-// delivered on stdin where possible to avoid shell injection.
+// passed via argv, which is safe because exec.Command does not spawn a
+// shell. Unknown drivers return (nil, "") and MUST be rejected by the
+// caller — never exec'd.
 func buildPromptCLIArgs(driver, systemPrompt, prompt string) ([]string, string) {
 	switch driver {
 	case "copilot":
@@ -221,6 +270,7 @@ func buildPromptCLIArgs(driver, systemPrompt, prompt string) ([]string, string) 
 		}
 		return args, ""
 	}
-	// Unknown driver: pass prompt on stdin as a safe default.
-	return []string{}, prompt
+	// Unknown driver: refuse to build any args. Callers must validate
+	// against AllowedDrivers before reaching here.
+	return nil, ""
 }

--- a/internal/dispatch/prompt_cli_adapter.go
+++ b/internal/dispatch/prompt_cli_adapter.go
@@ -1,0 +1,226 @@
+package dispatch
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"time"
+)
+
+// DefaultPromptCLITimeout is the fallback timeout for a freeform prompt.
+const DefaultPromptCLITimeout = 120 * time.Second
+
+// PromptCLIRunner executes a CLI subprocess and returns its combined stdout.
+// The prompt is delivered on stdin to avoid shell-injection via argv.
+// Injected in tests to exercise selection/timeout/fallback logic without
+// real subprocesses.
+type PromptCLIRunner func(ctx context.Context, driver, binary, systemPrompt, prompt string) (stdout []byte, err error)
+
+// PromptCLIRequest is a freeform prompt-to-CLI dispatch input.
+type PromptCLIRequest struct {
+	Prompt          string
+	SystemPrompt    string
+	PreferredDriver string        // "copilot" | "codex" | "claude-code" | ""
+	Timeout         time.Duration // 0 → DefaultPromptCLITimeout
+}
+
+// PromptCLIResult mirrors the MCP tool's output shape.
+type PromptCLIResult struct {
+	DriverUsed string `json:"driver_used"`
+	Output     string `json:"output"`
+	DurationMS int64  `json:"duration_ms"`
+	Error      string `json:"error,omitempty"`
+}
+
+// PromptCLIAdapter dispatches a freeform prompt to a local CLI agent
+// (Copilot CLI, Codex, or Claude Code) without requiring a git worktree
+// or an API key. It picks a driver by simple fallback policy and executes
+// one subprocess with stdin-delivered prompt.
+type PromptCLIAdapter struct {
+	// DriverOrder overrides the default fallback chain when non-empty.
+	DriverOrder []string
+	// Binaries maps driver name → binary path. Zero-values fall back to
+	// each driver's canonical name on PATH.
+	Binaries map[string]string
+	// Runner is injected in tests. nil → real exec.
+	Runner PromptCLIRunner
+	// LookPath is injected in tests to simulate missing CLIs. nil → exec.LookPath.
+	LookPath func(string) (string, error)
+}
+
+// DefaultDriverOrder is the fallback chain when PreferredDriver is unset.
+var DefaultDriverOrder = []string{"copilot", "codex", "claude-code"}
+
+// NewPromptCLIAdapter returns an adapter with defaults wired in.
+func NewPromptCLIAdapter() *PromptCLIAdapter {
+	return &PromptCLIAdapter{
+		DriverOrder: append([]string(nil), DefaultDriverOrder...),
+		Binaries: map[string]string{
+			"copilot":     "copilot",
+			"codex":       "codex",
+			"claude-code": "claude",
+		},
+	}
+}
+
+// Name identifies this adapter.
+func (a *PromptCLIAdapter) Name() string { return "prompt-cli" }
+
+// binaryFor resolves the binary path for a driver, falling back to the
+// canonical name if not configured.
+func (a *PromptCLIAdapter) binaryFor(driver string) string {
+	if a.Binaries != nil {
+		if b, ok := a.Binaries[driver]; ok && b != "" {
+			return b
+		}
+	}
+	switch driver {
+	case "copilot":
+		return "copilot"
+	case "codex":
+		return "codex"
+	case "claude-code":
+		return "claude"
+	}
+	return driver
+}
+
+// driversToTry builds the ordered candidate list honoring a preference.
+func (a *PromptCLIAdapter) driversToTry(preferred string) []string {
+	order := a.DriverOrder
+	if len(order) == 0 {
+		order = DefaultDriverOrder
+	}
+	if preferred == "" {
+		return append([]string(nil), order...)
+	}
+	// Put preferred first, then the remainder of the chain as fallback.
+	out := []string{preferred}
+	for _, d := range order {
+		if d != preferred {
+			out = append(out, d)
+		}
+	}
+	return out
+}
+
+// lookPath resolves a binary via the injected LookPath or exec.LookPath.
+func (a *PromptCLIAdapter) lookPath(bin string) (string, error) {
+	if a.LookPath != nil {
+		return a.LookPath(bin)
+	}
+	return exec.LookPath(bin)
+}
+
+// Dispatch runs the freeform prompt against the first available CLI.
+// It never calls a paid API and never creates a worktree.
+func (a *PromptCLIAdapter) Dispatch(ctx context.Context, req *PromptCLIRequest) *PromptCLIResult {
+	start := time.Now()
+	res := &PromptCLIResult{DriverUsed: "none"}
+
+	if req == nil || req.Prompt == "" {
+		res.Error = "prompt is required"
+		res.DurationMS = time.Since(start).Milliseconds()
+		return res
+	}
+
+	timeout := req.Timeout
+	if timeout <= 0 {
+		timeout = DefaultPromptCLITimeout
+	}
+
+	drivers := a.driversToTry(req.PreferredDriver)
+
+	var lastErr error
+	for _, driver := range drivers {
+		bin := a.binaryFor(driver)
+		if _, err := a.lookPath(bin); err != nil {
+			lastErr = fmt.Errorf("%s: not installed (%s)", driver, bin)
+			continue
+		}
+
+		cctx, cancel := context.WithTimeout(ctx, timeout)
+		runner := a.Runner
+		if runner == nil {
+			runner = realPromptCLIRunner
+		}
+		out, err := runner(cctx, driver, bin, req.SystemPrompt, req.Prompt)
+		cancel()
+
+		if err != nil {
+			lastErr = fmt.Errorf("%s: %w", driver, err)
+			// Treat transient errors as a reason to fall back.
+			continue
+		}
+
+		res.DriverUsed = driver
+		res.Output = string(out)
+		res.DurationMS = time.Since(start).Milliseconds()
+		return res
+	}
+
+	if lastErr == nil {
+		lastErr = errors.New("no CLI driver available")
+	}
+	res.Error = lastErr.Error()
+	res.DurationMS = time.Since(start).Milliseconds()
+	return res
+}
+
+// realPromptCLIRunner invokes the real CLI subprocess. The prompt is
+// written to the process stdin to avoid argv/shell injection risk.
+func realPromptCLIRunner(ctx context.Context, driver, binary, systemPrompt, prompt string) ([]byte, error) {
+	args, stdinPayload := buildPromptCLIArgs(driver, systemPrompt, prompt)
+
+	cmd := exec.CommandContext(ctx, binary, args...)
+	cmd.Env = os.Environ()
+	cmd.Stdin = bytes.NewReader([]byte(stdinPayload))
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			return stdout.Bytes(), fmt.Errorf("timeout: %w", err)
+		}
+		msg := stderr.String()
+		if msg == "" {
+			msg = err.Error()
+		}
+		return stdout.Bytes(), fmt.Errorf("exit: %s", msg)
+	}
+	return stdout.Bytes(), nil
+}
+
+// buildPromptCLIArgs returns (args, stdin) for a driver. The prompt is
+// delivered on stdin where possible to avoid shell injection.
+func buildPromptCLIArgs(driver, systemPrompt, prompt string) ([]string, string) {
+	switch driver {
+	case "copilot":
+		// copilot -p reads prompt from argv; use env-independent flags and
+		// disable confirmations for non-interactive use. We still pass the
+		// prompt via argv (exec, not shell) which is injection-safe.
+		args := []string{"-p", prompt, "--allow-all-tools", "--no-ask-user"}
+		if systemPrompt != "" {
+			args = append(args, "--append-system-prompt", systemPrompt)
+		}
+		return args, ""
+	case "codex":
+		// `codex exec <prompt>` runs non-interactively.
+		args := []string{"exec", prompt}
+		return args, ""
+	case "claude-code":
+		// `claude -p <prompt>` non-interactive print mode.
+		args := []string{"-p", prompt}
+		if systemPrompt != "" {
+			args = append(args, "--append-system-prompt", systemPrompt)
+		}
+		return args, ""
+	}
+	// Unknown driver: pass prompt on stdin as a safe default.
+	return []string{}, prompt
+}

--- a/internal/dispatch/prompt_cli_adapter_test.go
+++ b/internal/dispatch/prompt_cli_adapter_test.go
@@ -155,6 +155,96 @@ func TestPromptCLI_EmptyPrompt(t *testing.T) {
 	}
 }
 
+func TestPromptCLI_RejectsUnknownPreferredDriver(t *testing.T) {
+	// Arbitrary binary execution guard: unknown driver must be rejected
+	// at the Dispatch boundary without invoking the runner.
+	runnerCalled := false
+	runner := func(ctx context.Context, driver, binary, system, prompt string) ([]byte, error) {
+		runnerCalled = true
+		return nil, nil
+	}
+	a := newTestAdapter(map[string]bool{"copilot": true, "codex": true, "claude-code": true}, runner)
+	res := a.Dispatch(context.Background(), &PromptCLIRequest{
+		Prompt:          "hi",
+		PreferredDriver: "/bin/sh",
+	})
+	if res.Error == "" {
+		t.Fatal("expected rejection error for unknown preferred_driver")
+	}
+	if !strings.Contains(res.Error, "invalid preferred_driver") {
+		t.Fatalf("expected invalid preferred_driver error, got %q", res.Error)
+	}
+	if runnerCalled {
+		t.Fatal("runner must not be called when preferred_driver is rejected")
+	}
+	if res.DriverUsed != "none" {
+		t.Fatalf("expected driver_used=none, got %q", res.DriverUsed)
+	}
+}
+
+func TestValidatePreferredDriver(t *testing.T) {
+	good := []string{"", "copilot", "codex", "claude-code"}
+	for _, d := range good {
+		if err := ValidatePreferredDriver(d); err != nil {
+			t.Errorf("expected %q allowed, got err=%v", d, err)
+		}
+	}
+	bad := []string{"sh", "../../../bin/rm", "copilot ", "COPILOT", "/bin/sh"}
+	for _, d := range bad {
+		if err := ValidatePreferredDriver(d); err == nil {
+			t.Errorf("expected %q rejected", d)
+		}
+	}
+}
+
+func TestPromptCLI_CumulativeDeadline(t *testing.T) {
+	// With 3 fallback candidates each taking ~timeout, the overall
+	// dispatch must not exceed timeout by a large factor. Regression
+	// test for multiplied-timeout bug (context.WithTimeout in loop).
+	var calls int
+	runner := func(ctx context.Context, driver, binary, system, prompt string) ([]byte, error) {
+		calls++
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(5 * time.Second):
+			return []byte("should not happen"), nil
+		}
+	}
+	a := newTestAdapter(map[string]bool{"copilot": true, "codex": true, "claude-code": true}, runner)
+
+	start := time.Now()
+	res := a.Dispatch(context.Background(), &PromptCLIRequest{
+		Prompt:  "hi",
+		Timeout: 100 * time.Millisecond,
+	})
+	elapsed := time.Since(start)
+
+	// With a cumulative deadline, total elapsed must be ~timeout, not 3x.
+	if elapsed > 800*time.Millisecond {
+		t.Fatalf("cumulative deadline not enforced: elapsed=%s (expected ~100ms, must be <800ms)", elapsed)
+	}
+	if res.Error == "" {
+		t.Fatal("expected error from cumulative timeout")
+	}
+	if calls > 3 {
+		t.Fatalf("runner called %d times, expected ≤3", calls)
+	}
+}
+
+func TestPromptCLI_UnknownDriverViaDriverOrder(t *testing.T) {
+	// Even if DriverOrder is tampered with, realPromptCLIRunner must
+	// refuse to exec an unknown driver. We exercise buildPromptCLIArgs
+	// and the guard directly.
+	args, stdin := buildPromptCLIArgs("evil-binary", "", "prompt")
+	if args != nil {
+		t.Fatalf("expected nil args for unknown driver, got %v", args)
+	}
+	if stdin != "" {
+		t.Fatalf("expected empty stdin for unknown driver, got %q", stdin)
+	}
+}
+
 func TestBuildPromptCLIArgs(t *testing.T) {
 	cases := []struct {
 		driver    string

--- a/internal/dispatch/prompt_cli_adapter_test.go
+++ b/internal/dispatch/prompt_cli_adapter_test.go
@@ -1,0 +1,179 @@
+package dispatch
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+// newTestAdapter builds an adapter with an injected LookPath that treats
+// any driver in `available` as installed. The runner is customizable.
+func newTestAdapter(available map[string]bool, runner PromptCLIRunner) *PromptCLIAdapter {
+	a := NewPromptCLIAdapter()
+	a.LookPath = func(bin string) (string, error) {
+		// Map binary name → driver via default table.
+		driver := ""
+		switch bin {
+		case "copilot":
+			driver = "copilot"
+		case "codex":
+			driver = "codex"
+		case "claude":
+			driver = "claude-code"
+		}
+		if available[driver] {
+			return "/usr/bin/" + bin, nil
+		}
+		return "", errors.New("not found")
+	}
+	a.Runner = runner
+	return a
+}
+
+func TestPromptCLI_DriverSelection_PrefersRequested(t *testing.T) {
+	var called string
+	runner := func(ctx context.Context, driver, binary, system, prompt string) ([]byte, error) {
+		called = driver
+		return []byte("ok"), nil
+	}
+	a := newTestAdapter(map[string]bool{"copilot": true, "codex": true, "claude-code": true}, runner)
+
+	res := a.Dispatch(context.Background(), &PromptCLIRequest{
+		Prompt:          "hello",
+		PreferredDriver: "codex",
+	})
+	if res.Error != "" {
+		t.Fatalf("unexpected error: %s", res.Error)
+	}
+	if called != "codex" {
+		t.Fatalf("expected codex, got %q", called)
+	}
+	if res.DriverUsed != "codex" {
+		t.Fatalf("result driver = %q", res.DriverUsed)
+	}
+	if res.Output != "ok" {
+		t.Fatalf("result output = %q", res.Output)
+	}
+}
+
+func TestPromptCLI_FallbackOrder(t *testing.T) {
+	// Only claude-code installed — adapter must skip copilot & codex.
+	var called []string
+	runner := func(ctx context.Context, driver, binary, system, prompt string) ([]byte, error) {
+		called = append(called, driver)
+		return []byte("claude output"), nil
+	}
+	a := newTestAdapter(map[string]bool{"claude-code": true}, runner)
+
+	res := a.Dispatch(context.Background(), &PromptCLIRequest{Prompt: "hi"})
+	if res.Error != "" {
+		t.Fatalf("unexpected error: %s", res.Error)
+	}
+	if res.DriverUsed != "claude-code" {
+		t.Fatalf("expected claude-code, got %q", res.DriverUsed)
+	}
+	if len(called) != 1 || called[0] != "claude-code" {
+		t.Fatalf("expected single claude-code invocation, got %v", called)
+	}
+}
+
+func TestPromptCLI_AllMissing(t *testing.T) {
+	runner := func(ctx context.Context, driver, binary, system, prompt string) ([]byte, error) {
+		t.Fatalf("runner should not be called when no CLIs installed")
+		return nil, nil
+	}
+	a := newTestAdapter(map[string]bool{}, runner)
+
+	res := a.Dispatch(context.Background(), &PromptCLIRequest{Prompt: "hi"})
+	if res.Error == "" {
+		t.Fatal("expected error when no CLI available")
+	}
+	if res.DriverUsed != "none" {
+		t.Fatalf("expected driver_used=none, got %q", res.DriverUsed)
+	}
+}
+
+func TestPromptCLI_FallsBackOnRunnerError(t *testing.T) {
+	var called []string
+	runner := func(ctx context.Context, driver, binary, system, prompt string) ([]byte, error) {
+		called = append(called, driver)
+		if driver == "copilot" {
+			return nil, errors.New("copilot crashed")
+		}
+		return []byte("codex worked"), nil
+	}
+	a := newTestAdapter(map[string]bool{"copilot": true, "codex": true}, runner)
+
+	res := a.Dispatch(context.Background(), &PromptCLIRequest{Prompt: "hi"})
+	if res.Error != "" {
+		t.Fatalf("unexpected error: %s", res.Error)
+	}
+	if res.DriverUsed != "codex" {
+		t.Fatalf("expected fallback to codex, got %q", res.DriverUsed)
+	}
+	if len(called) != 2 || called[0] != "copilot" || called[1] != "codex" {
+		t.Fatalf("expected copilot→codex, got %v", called)
+	}
+}
+
+func TestPromptCLI_Timeout(t *testing.T) {
+	runner := func(ctx context.Context, driver, binary, system, prompt string) ([]byte, error) {
+		// Block until the injected timeout fires.
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(5 * time.Second):
+			return []byte("should not happen"), nil
+		}
+	}
+	a := newTestAdapter(map[string]bool{"copilot": true}, runner)
+
+	start := time.Now()
+	res := a.Dispatch(context.Background(), &PromptCLIRequest{
+		Prompt:  "hi",
+		Timeout: 50 * time.Millisecond,
+	})
+	elapsed := time.Since(start)
+	if elapsed > 2*time.Second {
+		t.Fatalf("timeout not enforced, elapsed=%s", elapsed)
+	}
+	if res.Error == "" {
+		t.Fatal("expected error from timeout")
+	}
+	if res.DriverUsed != "none" {
+		t.Fatalf("expected driver_used=none on timeout, got %q", res.DriverUsed)
+	}
+}
+
+func TestPromptCLI_EmptyPrompt(t *testing.T) {
+	a := newTestAdapter(map[string]bool{"copilot": true}, nil)
+	res := a.Dispatch(context.Background(), &PromptCLIRequest{})
+	if res.Error == "" {
+		t.Fatal("expected error for empty prompt")
+	}
+}
+
+func TestBuildPromptCLIArgs(t *testing.T) {
+	cases := []struct {
+		driver    string
+		prompt    string
+		system    string
+		mustHave  []string
+	}{
+		{"copilot", "do thing", "", []string{"-p", "do thing", "--allow-all-tools"}},
+		{"copilot", "do thing", "be terse", []string{"--append-system-prompt", "be terse"}},
+		{"codex", "do thing", "", []string{"exec", "do thing"}},
+		{"claude-code", "do thing", "", []string{"-p", "do thing"}},
+	}
+	for _, tc := range cases {
+		args, _ := buildPromptCLIArgs(tc.driver, tc.system, tc.prompt)
+		joined := strings.Join(args, "|")
+		for _, want := range tc.mustHave {
+			if !strings.Contains(joined, want) {
+				t.Errorf("driver=%s args=%v missing %q", tc.driver, args, want)
+			}
+		}
+	}
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -69,6 +69,7 @@ type Server struct {
 	anthropicAdapter *dispatch.AnthropicAdapter
 	ghActionsAdapter *dispatch.GHActionsAdapter
 	copilotAdapter   *dispatch.CopilotAdapter
+	promptCLIAdapter *dispatch.PromptCLIAdapter
 	rdb              *redis.Client
 	redisNS          string
 }
@@ -130,6 +131,10 @@ func (s *Server) SetAdmissionGate(g *admission.Gate) {
 func (s *Server) SetAnthropicAdapter(a *dispatch.AnthropicAdapter) { s.anthropicAdapter = a }
 func (s *Server) SetGHActionsAdapter(a *dispatch.GHActionsAdapter) { s.ghActionsAdapter = a }
 func (s *Server) SetCopilotAdapter(a *dispatch.CopilotAdapter) { s.copilotAdapter = a }
+
+// SetPromptCLIAdapter enables the dispatch_prompt_to_cli MCP tool.
+// If never called, the handler lazily constructs a default adapter.
+func (s *Server) SetPromptCLIAdapter(a *dispatch.PromptCLIAdapter) { s.promptCLIAdapter = a }
 
 // Serve runs the MCP server on stdio (stdin/stdout JSON-RPC).
 func (s *Server) Serve() error {
@@ -961,6 +966,33 @@ func (s *Server) handleToolCall(req Request) (resp Response) {
 		b, _ := json.Marshal(adResult)
 		return textResult(req.ID, string(b))
 
+	case "dispatch_prompt_to_cli":
+		var args struct {
+			Prompt          string `json:"prompt"`
+			PreferredDriver string `json:"preferred_driver"`
+			TimeoutSeconds  int    `json:"timeout_seconds"`
+			SystemPrompt    string `json:"system_prompt"`
+		}
+		if err := json.Unmarshal(params.Arguments, &args); err != nil {
+			return errorResp(req.ID, -32602, fmt.Sprintf("invalid args: %v", err))
+		}
+		if args.Prompt == "" {
+			return errorResp(req.ID, -32602, "prompt is required")
+		}
+		adapter := s.promptCLIAdapter
+		if adapter == nil {
+			adapter = dispatch.NewPromptCLIAdapter()
+		}
+		timeout := time.Duration(args.TimeoutSeconds) * time.Second
+		res := adapter.Dispatch(ctx, &dispatch.PromptCLIRequest{
+			Prompt:          args.Prompt,
+			SystemPrompt:    args.SystemPrompt,
+			PreferredDriver: args.PreferredDriver,
+			Timeout:         timeout,
+		})
+		b, _ := json.Marshal(res)
+		return textResult(req.ID, string(b))
+
 	default:
 		return errorResp(req.ID, -32601, fmt.Sprintf("unknown tool: %s", params.Name))
 	}
@@ -1443,6 +1475,20 @@ func toolDefs() []ToolDef {
 					"repo":     map[string]any{"type": "string", "description": "Target repo (owner/name)"},
 					"type":     map[string]any{"type": "string", "description": "Task type: code-gen, bugfix, pr-review, qa, triage"},
 					"priority": map[string]any{"type": "string", "description": "Priority: critical, high, normal, background"},
+				},
+				"required": []string{"prompt"},
+			},
+		},
+		{
+			Name:        "dispatch_prompt_to_cli",
+			Description: "Dispatch a freeform prompt to a local CLI agent (copilot, codex, or claude-code). No API key, no worktree. Picks first available driver with fallback.",
+			InputSchema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"prompt":           map[string]any{"type": "string", "description": "Freeform prompt to send"},
+					"preferred_driver": map[string]any{"type": "string", "description": "copilot | codex | claude-code (optional)"},
+					"timeout_seconds":  map[string]any{"type": "integer", "description": "Timeout in seconds (default 120)"},
+					"system_prompt":    map[string]any{"type": "string", "description": "Optional system prompt appended to the driver's default"},
 				},
 				"required": []string{"prompt"},
 			},

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -979,6 +979,9 @@ func (s *Server) handleToolCall(req Request) (resp Response) {
 		if args.Prompt == "" {
 			return errorResp(req.ID, -32602, "prompt is required")
 		}
+		if err := dispatch.ValidatePreferredDriver(args.PreferredDriver); err != nil {
+			return errorResp(req.ID, -32602, err.Error())
+		}
 		adapter := s.promptCLIAdapter
 		if adapter == nil {
 			adapter = dispatch.NewPromptCLIAdapter()


### PR DESCRIPTION
## Summary
- New `PromptCLIAdapter` in `internal/dispatch/prompt_cli_adapter.go` — dispatches freeform prompts to a local CLI agent (copilot, codex, or claude-code) with fallback ordering. No git worktree. No API key. No Anthropic fallback.
- New MCP tool `dispatch_prompt_to_cli` registered in `internal/mcp/server.go` with schema `{prompt, preferred_driver?, timeout_seconds? (default 120), system_prompt?}` → `{driver_used, output, duration_ms, error?}`.
- Prompts are passed to subprocesses via argv (exec, not shell) — no string interpolation — to avoid injection.
- Driver selection policy: honor `preferred_driver` first, then fall back through `copilot → codex → claude-code`, skipping any CLI not on PATH or that errors out.

## Test plan
- [x] `go build ./...` green
- [x] `go test ./...` green (778 tests across 24 packages)
- [x] Unit tests cover driver selection, fallback order, timeout, all-missing, empty-prompt, and per-driver arg shape
- [ ] Manual MCP smoke: call `dispatch_prompt_to_cli` with a trivial prompt and inspect `driver_used`

🤖 Generated with [Claude Code](https://claude.com/claude-code)