### PR TITLE
fix(coordination): ZREM zset member on ReleaseClaim (#213)

### DIFF
--- a/internal/coordination/engine.go
+++ b/internal/coordination/engine.go
@@ -135,8 +135,27 @@ func (e *Engine) ActiveClaims(ctx context.Context) ([]Claim, error) {
 
 // ReleaseClaim explicitly removes an agent's claim before TTL expiry.
 // Called by workers when an agent finishes execution.
+//
+// Fixes #213 (claim-leak): the `active-claims` zset is value-keyed on the
+// full claim JSON blob, so a plain ZREM by claim_id silently no-ops and
+// wedges dispatch. We look up the exact bytes stored under `claim:<agent>`
+// and ZREM that member in the same pipeline as the DEL. If the SET key
+// has already expired we skip the ZREM — ActiveClaims' lazy-prune (#206)
+// will clean the zset member on the next read.
 func (e *Engine) ReleaseClaim(ctx context.Context, agentID string) error {
-	return e.rdb.Del(ctx, e.key("claim:"+agentID)).Err()
+	claimKey := e.key("claim:" + agentID)
+	data, getErr := e.rdb.Get(ctx, claimKey).Bytes()
+	if getErr != nil && getErr != redis.Nil {
+		return fmt.Errorf("get claim for release: %w", getErr)
+	}
+
+	pipe := e.rdb.Pipeline()
+	pipe.Del(ctx, claimKey)
+	if getErr != redis.Nil && len(data) > 0 {
+		pipe.ZRem(ctx, e.key("active-claims"), data)
+	}
+	_, err := pipe.Exec(ctx)
+	return err
 }
 
 // Broadcast sends a signal to the swarm via pub/sub.

--- a/internal/coordination/engine_test.go
+++ b/internal/coordination/engine_test.go
@@ -316,6 +316,60 @@ func TestActiveClaims_LegacyMemberMissingTTLUsesDefault(t *testing.T) {
 	}
 }
 
+// TestReleaseClaim_RemovesZsetMember covers issue #213: ReleaseClaim used to
+// only DEL the `claim:<agent>` SET key and never ZREM the corresponding
+// value-keyed member from `octi:active-claims`, wedging dispatch with
+// phantom claims even on clean worker shutdown.
+func TestReleaseClaim_RemovesZsetMember(t *testing.T) {
+	e, ctx := testSetup(t)
+	zkey := e.key("active-claims")
+
+	if _, err := e.ClaimTask(ctx, "leak-agent", "ship the fix", 300); err != nil {
+		t.Fatalf("ClaimTask: %v", err)
+	}
+
+	if n, _ := e.rdb.ZCard(ctx, zkey).Result(); n != 1 {
+		t.Fatalf("pre: want 1 zset member, got %d", n)
+	}
+
+	if err := e.ReleaseClaim(ctx, "leak-agent"); err != nil {
+		t.Fatalf("ReleaseClaim: %v", err)
+	}
+
+	n, err := e.rdb.ZCard(ctx, zkey).Result()
+	if err != nil {
+		t.Fatalf("ZCard: %v", err)
+	}
+	if n != 0 {
+		members, _ := e.rdb.ZRange(ctx, zkey, 0, -1).Result()
+		t.Errorf("expected empty zset after ReleaseClaim, got %d members: %v", n, members)
+	}
+
+	exists, _ := e.rdb.Exists(ctx, e.key("claim:leak-agent")).Result()
+	if exists != 0 {
+		t.Error("claim SET key should be DELeted after ReleaseClaim")
+	}
+}
+
+// TestReleaseClaim_IdempotentAfterTTLExpiry covers the case where the
+// `claim:<agent>` SET key already expired before ReleaseClaim runs. The
+// call must still succeed (no error) and must not attempt to ZREM a stale
+// member we can't look up. Lazy-prune (#206) in ActiveClaims handles the
+// orphaned zset entry on the next read.
+func TestReleaseClaim_IdempotentAfterTTLExpiry(t *testing.T) {
+	e, ctx := testSetup(t)
+
+	// No ClaimTask first — simulate a fully-expired claim.
+	if err := e.ReleaseClaim(ctx, "ghost-agent"); err != nil {
+		t.Fatalf("ReleaseClaim on absent claim should be idempotent: %v", err)
+	}
+
+	// And second call must also succeed.
+	if err := e.ReleaseClaim(ctx, "ghost-agent"); err != nil {
+		t.Fatalf("ReleaseClaim second call: %v", err)
+	}
+}
+
 func TestClose_NoError(t *testing.T) {
 	e, _ := testSetup(t)
 	// Close is called via t.Cleanup, but we verify explicit close works too.


### PR DESCRIPTION
## Summary
`ReleaseClaim` only `DEL`ed the `claim:<agent>` SET key and never `ZREM`ed the corresponding member from `octi:active-claims`, so every clean worker shutdown leaked a phantom claim that wedged dispatch until `ActiveClaims` lazy-prune (#206) eventually evicted it.

## What changed
- `internal/coordination/engine.go` — `ReleaseClaim` now `GET`s the exact JSON bytes stored under `claim:<agent>` and issues `DEL` + `ZREM` in a single pipeline.
- If the SET key has already expired (`GET` -> `redis.Nil`), the `ZREM` is skipped and lazy-prune handles the orphan on the next `ActiveClaims` read — `ReleaseClaim` stays idempotent.
- `internal/coordination/engine_test.go` — two new tests:
  - `TestReleaseClaim_RemovesZsetMember` (happy path: claim -> release -> zset empty)
  - `TestReleaseClaim_IdempotentAfterTTLExpiry` (SET key already gone -> no error, double-call safe)

## Why now
Fixes #213. Paired fix to #206 — lazy-prune was the safety net; this closes the active leak at the source.

## How to verify
```
cd internal/coordination && go test -run ReleaseClaim -v
go test ./...
```
Expected: all 784 tests pass (requires Redis on `localhost:6379`; tests skip gracefully otherwise).

## Risks / follow-ups
- `GET` adds one extra round-trip per release. Acceptable — release is not hot-path, and the alternative (Lua) is heavier than the payoff.
- Pre-existing orphans in production zsets continue to be cleaned by lazy-prune (#206) — no migration needed.

## Related
- Fixes #213
- Paired with #208 (lazy-prune on read)