### PR TITLE
fix(memory): surface silent qdrant/embed failures (#215)

### DIFF
--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log"
 	"strings"
 	"time"
 
@@ -88,14 +89,18 @@ func (s *Store) Put(ctx context.Context, agentID, content string, topics []strin
 	// Best-effort: index embedding for semantic search.
 	if s.vectorClient != nil && s.embedder != nil {
 		text := content + " " + strings.Join(topics, " ")
-		if vec, embErr := s.embedder.Embed(ctx, text); embErr == nil {
+		if vec, embErr := s.embedder.Embed(ctx, text); embErr != nil {
+			log.Printf("WARN memory.Put: embed failed (collection=%s id=%s agent=%s): %v", s.collectionName(), id, agentID, embErr)
+		} else {
 			payload := map[string]interface{}{
 				"entry_id": id,
 				"agent_id": agentID,
 				"content":  content,
 				"topics":   strings.Join(topics, " "),
 			}
-			_ = s.vectorClient.Upsert(ctx, s.collectionName(), id, vec, payload)
+			if upErr := s.vectorClient.Upsert(ctx, s.collectionName(), id, vec, payload); upErr != nil {
+				log.Printf("WARN memory.Put: qdrant upsert failed (collection=%s id=%s): %v", s.collectionName(), id, upErr)
+			}
 		}
 	}
 
@@ -122,11 +127,13 @@ func (s *Store) Recall(ctx context.Context, query string, limit int) ([]Entry, e
 
 	vec, err := s.embedder.Embed(ctx, query)
 	if err != nil {
+		log.Printf("WARN memory.Recall: embed failed (collection=%s): %v — falling back to keyword", s.collectionName(), err)
 		return kwResults, nil // fallback: embedding unavailable
 	}
 
 	vecHits, err := s.vectorClient.Search(ctx, s.collectionName(), vec, limit)
 	if err != nil {
+		log.Printf("WARN memory.Recall: qdrant search failed (collection=%s): %v — falling back to keyword", s.collectionName(), err)
 		return kwResults, nil // fallback: vector DB unavailable
 	}
 


### PR DESCRIPTION
Closes #215.

## Problem
Qdrant collections sat empty despite 582 Redis memory entries. Three paths in internal/memory/store.go swallowed errors silently:

1. Put() — embedder Embed() failure dropped the embedding with no log
2. Put() — vectorClient.Upsert() error discarded with _ =
3. Recall() — vectorClient.Search() failure fell back to keyword with only a comment

## Fix
Three WARN log lines via log.Printf (already imported). No control-flow change — best-effort fallback preserved; failures are now visible.

## Log lines now emitted
- WARN memory.Put: embed failed (collection=%s id=%s agent=%s): %v
- WARN memory.Put: qdrant upsert failed (collection=%s id=%s): %v
- WARN memory.Recall: embed failed (collection=%s): %v — falling back to keyword
- WARN memory.Recall: qdrant search failed (collection=%s): %v — falling back to keyword

## Verification
- go build ./... clean
- No new deps