### PR TITLE
fix(mcp): don't respond to JSON-RPC notifications

### DIFF
--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -150,6 +150,10 @@ func (s *Server) Serve() error {
 			return fmt.Errorf("decode request: %w", err)
 		}
 
+		// JSON-RPC 2.0: notifications (no id) must not receive a response.
+		if req.ID == nil {
+			continue
+		}
 		resp := s.handle(req)
 		if err := encoder.Encode(resp); err != nil {
 			return fmt.Errorf("encode response: %w", err)


### PR DESCRIPTION
## Summary
- MCP stdio server was sending a response for every decoded message, including JSON-RPC notifications (no \`id\` field). Per JSON-RPC 2.0 §4.1 notifications MUST NOT receive a response.
- Claude Code's MCP client zod-validates every inbound frame and rejects the orphan \`{"id":null,"result":{}}\` that octi sent after \`notifications/initialized\`, tearing down the stdio transport before \`tools/list\` is ever requested.
- Net effect: \`claude mcp list\` showed ✓ Connected but no \`mcp__octi__*\` tools appeared in the session. Atlas MCP was unaffected because it doesn't reply to notifications.
- One-liner: skip encoding when \`req.ID == nil\`.

## Test plan
- [x] Manual JSON-RPC handshake: send \`initialize\` + \`notifications/initialized\` + \`tools/list\`, confirm only 2 responses come back (not 3), and the tool list has all 34 tools.
- [x] Restart Claude Code — all 34 \`mcp__octi__*\` tools register.
- [ ] Unit test for notification handling in \`internal/mcp/handle_test.go\` (follow-up; current tests only cover request/response paths).

🤖 Generated with [Claude Code](https://claude.com/claude-code)