### PR TITLE
chore(router): delete unused CLI drivers

### DIFF
--- a/cmd/octi-pulpo/main.go
+++ b/cmd/octi-pulpo/main.go
@@ -250,8 +250,6 @@ func main() {
 			brain.SetNotifier(dispatch.NewNtfyNotifier(ntfyBase, ntfyTopic))
 			// Wire swarm CLI adapters
 			modelRouter := dispatch.NewModelRouter()
-			claudeCodeAdapter := dispatch.NewClaudeCodeAdapter("", filepath.Join(home, "workspace"))
-			copilotCLIAdapter := dispatch.NewCopilotCLIAdapter("", filepath.Join(home, "workspace"))
 			staggerTracker := dispatch.NewStaggerTracker(rdb, namespace)
 
 			// Load platform config for config-driven dispatch.
@@ -282,8 +280,6 @@ func main() {
 			escalationMgr := dispatch.NewEscalationManager(modelRouter)
 			queueMachine := dispatch.NewQueueMachine()
 			brain.SetModelRouter(modelRouter)
-			brain.SetClaudeCodeAdapter(claudeCodeAdapter)
-			brain.SetCopilotCLIAdapter(copilotCLIAdapter)
 			brain.SetStagger(staggerTracker)
 			brain.SetEscalationManager(escalationMgr)
 			brain.SetQueueMachine(queueMachine)

--- a/cmd/octi-worker/main.go
+++ b/cmd/octi-worker/main.go
@@ -298,11 +298,11 @@ func isCreditExhaustion(output string) bool {
 }
 
 // agentDriver looks up the driver for an agent in schedule.json.
-// Falls back to "claude-code" when the file is missing or the agent is not listed.
+// Falls back to "clawta" (T1 local) when the file is missing or the agent is not listed.
 func agentDriver(scheduleFile, agentName string) string {
 	data, err := os.ReadFile(scheduleFile)
 	if err != nil {
-		return "claude-code"
+		return "clawta"
 	}
 	var sched struct {
 		Agents map[string]struct {
@@ -310,12 +310,12 @@ func agentDriver(scheduleFile, agentName string) string {
 		} `json:"agents"`
 	}
 	if err := json.Unmarshal(data, &sched); err != nil {
-		return "claude-code"
+		return "clawta"
 	}
 	if a, ok := sched.Agents[agentName]; ok && a.Driver != "" {
 		return a.Driver
 	}
-	return "claude-code"
+	return "clawta"
 }
 
 func sleep(ctx context.Context, d time.Duration) {

--- a/cmd/octi-worker/worker_test.go
+++ b/cmd/octi-worker/worker_test.go
@@ -102,7 +102,7 @@ func TestAgentDriver_ReadsSchedule(t *testing.T) {
 		{"kernel-sr", "claude-code"},
 		{"kernel-qa", "copilot"},
 		{"codex-worker", "codex"},
-		{"unknown-agent", "claude-code"}, // default
+		{"unknown-agent", "clawta"}, // default
 	}
 
 	for _, tt := range tests {
@@ -117,8 +117,8 @@ func TestAgentDriver_ReadsSchedule(t *testing.T) {
 
 func TestAgentDriver_MissingFile(t *testing.T) {
 	got := agentDriver("/nonexistent/schedule.json", "any-agent")
-	if got != "claude-code" {
-		t.Errorf("agentDriver with missing file = %q, want claude-code", got)
+	if got != "clawta" {
+		t.Errorf("agentDriver with missing file = %q, want clawta", got)
 	}
 }
 
@@ -127,8 +127,8 @@ func TestAgentDriver_MalformedJSON(t *testing.T) {
 	os.WriteFile(f, []byte("{not valid json"), 0644)
 
 	got := agentDriver(f, "any-agent")
-	if got != "claude-code" {
-		t.Errorf("agentDriver with bad JSON = %q, want claude-code", got)
+	if got != "clawta" {
+		t.Errorf("agentDriver with bad JSON = %q, want clawta", got)
 	}
 }
 

--- a/internal/dispatch/brain.go
+++ b/internal/dispatch/brain.go
@@ -916,13 +916,10 @@ func (b *Brain) ProbeDrivers(ctx context.Context) {
 // driverProbeCommands maps driver names to the lightweight CLI command used
 // to verify reachability. Commands are intentionally non-destructive (version
 // checks or auth status only — no token consumption).
+// Ladder Forge II (2026-04-14): CLI-driver probes (claude-code, copilot,
+// codex, gemini, goose) pruned. Only openclaw retains a local CLI probe.
 var driverProbeCommands = map[string][]string{
-	"claude-code": {"claude", "--version"},
-	"copilot":     {"copilot", "--version"},
-	"codex":       {"codex", "--version"},
-	"gemini":      {"gemini", "--version"},
-	"goose":       {"goose", "--version"},
-	"openclaw":    {"openclaw", "--version"},
+	"openclaw": {"openclaw", "--version"},
 }
 
 // probeOneDriver runs a lightweight availability check for the given driver.

--- a/internal/dispatch/brain.go
+++ b/internal/dispatch/brain.go
@@ -102,8 +102,6 @@ type Brain struct {
 	stagger        *StaggerTracker
 	modelRouter    *ModelRouter
 	escalation     *EscalationManager
-	claudeAdapter  *ClaudeCodeAdapter
-	copilotAdapter *CopilotCLIAdapter
 
 	// Config-driven dispatch
 	platformConfig *PlatformConfigHolder
@@ -162,12 +160,6 @@ func (b *Brain) SetModelRouter(mr *ModelRouter) { b.modelRouter = mr }
 
 // SetEscalationManager wires the escalation manager into the brain.
 func (b *Brain) SetEscalationManager(em *EscalationManager) { b.escalation = em }
-
-// SetClaudeCodeAdapter wires the Claude Code CLI adapter into the brain.
-func (b *Brain) SetClaudeCodeAdapter(a *ClaudeCodeAdapter) { b.claudeAdapter = a }
-
-// SetCopilotCLIAdapter wires the Copilot CLI adapter into the brain.
-func (b *Brain) SetCopilotCLIAdapter(a *CopilotCLIAdapter) { b.copilotAdapter = a }
 
 // SetPlatformConfig wires the platform config holder into the brain.
 func (b *Brain) SetPlatformConfig(pc *PlatformConfigHolder) { b.platformConfig = pc }

--- a/internal/dispatch/pipeline_dispatch_test.go
+++ b/internal/dispatch/pipeline_dispatch_test.go
@@ -7,17 +7,17 @@ import (
 )
 
 func TestPipelineRoute(t *testing.T) {
+	// Ladder Forge II (2026-04-14): Mid tier now gh-actions + anthropic.
 	pr := PipelineRouter{}
 	decision := pr.RouteForStage("implement", 0, []routing.DriverHealth{
-		{Name: "copilot", CircuitState: "CLOSED"},
-		{Name: "claude-code", CircuitState: "CLOSED"},
-		{Name: "codex", CircuitState: "CLOSED"},
+		{Name: "gh-actions", CircuitState: "CLOSED"},
+		{Name: "anthropic", CircuitState: "CLOSED"},
 	})
 	if decision.Skip {
 		t.Fatal("expected a route, got skip")
 	}
-	if decision.Driver != "copilot" {
-		t.Errorf("driver = %s, want copilot (cheapest Mid)", decision.Driver)
+	if decision.Driver != "gh-actions" {
+		t.Errorf("driver = %s, want gh-actions (first Mid candidate)", decision.Driver)
 	}
 	if decision.Tier != string(routing.TierMid) {
 		t.Errorf("tier = %s, want mid", decision.Tier)
@@ -27,8 +27,7 @@ func TestPipelineRoute(t *testing.T) {
 func TestPipelineRouteNoHealthyFrontier(t *testing.T) {
 	pr := PipelineRouter{}
 	decision := pr.RouteForStage("architect", 0, []routing.DriverHealth{
-		{Name: "claude-code", CircuitState: "OPEN"},
-		{Name: "copilot", CircuitState: "OPEN"},
+		{Name: "anthropic", CircuitState: "OPEN"},
 	})
 	if !decision.Skip {
 		t.Error("expected skip when no healthy Frontier drivers")

--- a/internal/dispatch/prompt_cli_adapter.go
+++ b/internal/dispatch/prompt_cli_adapter.go
@@ -23,17 +23,18 @@ type PromptCLIRunner func(ctx context.Context, driver, binary, systemPrompt, pro
 // AllowedDrivers is the allowlist of accepted driver names. Unknown values
 // are rejected at the boundary to prevent arbitrary-binary execution via a
 // user-controlled `preferred_driver` falling through to a default case.
+//
+// Ladder Forge II (2026-04-14): CLI drivers (copilot, codex, claude-code)
+// pruned. Openclaw is the only remaining local-CLI surface.
 var AllowedDrivers = map[string]bool{
-	"copilot":     true,
-	"codex":       true,
-	"claude-code": true,
-	"":            true, // empty → use default fallback chain
+	"openclaw": true,
+	"":         true, // empty → use default fallback chain
 }
 
 // ValidatePreferredDriver returns an error if driver is not on the allowlist.
 func ValidatePreferredDriver(driver string) error {
 	if !AllowedDrivers[driver] {
-		return fmt.Errorf("invalid preferred_driver %q: allowed values are copilot, codex, claude-code, or empty", driver)
+		return fmt.Errorf("invalid preferred_driver %q: allowed values are openclaw or empty", driver)
 	}
 	return nil
 }
@@ -42,7 +43,7 @@ func ValidatePreferredDriver(driver string) error {
 type PromptCLIRequest struct {
 	Prompt          string
 	SystemPrompt    string
-	PreferredDriver string        // "copilot" | "codex" | "claude-code" | ""
+	PreferredDriver string        // "openclaw" | ""
 	Timeout         time.Duration // 0 → DefaultPromptCLITimeout
 }
 
@@ -55,10 +56,10 @@ type PromptCLIResult struct {
 }
 
 // PromptCLIAdapter dispatches a freeform prompt to a local CLI agent
-// (Copilot CLI, Codex, or Claude Code) without requiring a git worktree
-// or an API key. It picks a driver by simple fallback policy and executes
-// one subprocess, passing the prompt via argv (safe under exec.Command,
-// which does not spawn a shell).
+// (openclaw) without requiring a git worktree or an API key. It picks a
+// driver by simple fallback policy and executes one subprocess, passing
+// the prompt via argv (safe under exec.Command, which does not spawn a
+// shell). Ladder Forge II pruned copilot/codex/claude-code CLI drivers.
 type PromptCLIAdapter struct {
 	// DriverOrder overrides the default fallback chain when non-empty.
 	DriverOrder []string
@@ -72,16 +73,15 @@ type PromptCLIAdapter struct {
 }
 
 // DefaultDriverOrder is the fallback chain when PreferredDriver is unset.
-var DefaultDriverOrder = []string{"copilot", "codex", "claude-code"}
+// Ladder Forge II (2026-04-14): CLI drivers pruned; openclaw is sole remainder.
+var DefaultDriverOrder = []string{"openclaw"}
 
 // NewPromptCLIAdapter returns an adapter with defaults wired in.
 func NewPromptCLIAdapter() *PromptCLIAdapter {
 	return &PromptCLIAdapter{
 		DriverOrder: append([]string(nil), DefaultDriverOrder...),
 		Binaries: map[string]string{
-			"copilot":     "copilot",
-			"codex":       "codex",
-			"claude-code": "claude",
+			"openclaw": "openclaw",
 		},
 	}
 }
@@ -98,12 +98,8 @@ func (a *PromptCLIAdapter) binaryFor(driver string) string {
 		}
 	}
 	switch driver {
-	case "copilot":
-		return "copilot"
-	case "codex":
-		return "codex"
-	case "claude-code":
-		return "claude"
+	case "openclaw":
+		return "openclaw"
 	}
 	return driver
 }
@@ -249,21 +245,8 @@ func realPromptCLIRunner(ctx context.Context, driver, binary, systemPrompt, prom
 // caller — never exec'd.
 func buildPromptCLIArgs(driver, systemPrompt, prompt string) ([]string, string) {
 	switch driver {
-	case "copilot":
-		// copilot -p reads prompt from argv; use env-independent flags and
-		// disable confirmations for non-interactive use. We still pass the
-		// prompt via argv (exec, not shell) which is injection-safe.
-		args := []string{"-p", prompt, "--allow-all-tools", "--no-ask-user"}
-		if systemPrompt != "" {
-			args = append(args, "--append-system-prompt", systemPrompt)
-		}
-		return args, ""
-	case "codex":
-		// `codex exec <prompt>` runs non-interactively.
-		args := []string{"exec", prompt}
-		return args, ""
-	case "claude-code":
-		// `claude -p <prompt>` non-interactive print mode.
+	case "openclaw":
+		// openclaw accepts prompt via argv; system prompt appended if present.
 		args := []string{"-p", prompt}
 		if systemPrompt != "" {
 			args = append(args, "--append-system-prompt", systemPrompt)

--- a/internal/dispatch/prompt_cli_adapter_test.go
+++ b/internal/dispatch/prompt_cli_adapter_test.go
@@ -14,14 +14,11 @@ func newTestAdapter(available map[string]bool, runner PromptCLIRunner) *PromptCL
 	a := NewPromptCLIAdapter()
 	a.LookPath = func(bin string) (string, error) {
 		// Map binary name → driver via default table.
+		// Ladder Forge II (2026-04-14): openclaw is the sole surviving CLI driver.
 		driver := ""
 		switch bin {
-		case "copilot":
-			driver = "copilot"
-		case "codex":
-			driver = "codex"
-		case "claude":
-			driver = "claude-code"
+		case "openclaw":
+			driver = "openclaw"
 		}
 		if available[driver] {
 			return "/usr/bin/" + bin, nil
@@ -38,19 +35,19 @@ func TestPromptCLI_DriverSelection_PrefersRequested(t *testing.T) {
 		called = driver
 		return []byte("ok"), nil
 	}
-	a := newTestAdapter(map[string]bool{"copilot": true, "codex": true, "claude-code": true}, runner)
+	a := newTestAdapter(map[string]bool{"openclaw": true}, runner)
 
 	res := a.Dispatch(context.Background(), &PromptCLIRequest{
 		Prompt:          "hello",
-		PreferredDriver: "codex",
+		PreferredDriver: "openclaw",
 	})
 	if res.Error != "" {
 		t.Fatalf("unexpected error: %s", res.Error)
 	}
-	if called != "codex" {
-		t.Fatalf("expected codex, got %q", called)
+	if called != "openclaw" {
+		t.Fatalf("expected openclaw, got %q", called)
 	}
-	if res.DriverUsed != "codex" {
+	if res.DriverUsed != "openclaw" {
 		t.Fatalf("result driver = %q", res.DriverUsed)
 	}
 	if res.Output != "ok" {
@@ -59,23 +56,24 @@ func TestPromptCLI_DriverSelection_PrefersRequested(t *testing.T) {
 }
 
 func TestPromptCLI_FallbackOrder(t *testing.T) {
-	// Only claude-code installed — adapter must skip copilot & codex.
+	// Ladder Forge II (2026-04-14): CLI fallback chain collapsed to single
+	// openclaw driver. Test verifies it's invoked when present.
 	var called []string
 	runner := func(ctx context.Context, driver, binary, system, prompt string) ([]byte, error) {
 		called = append(called, driver)
-		return []byte("claude output"), nil
+		return []byte("openclaw output"), nil
 	}
-	a := newTestAdapter(map[string]bool{"claude-code": true}, runner)
+	a := newTestAdapter(map[string]bool{"openclaw": true}, runner)
 
 	res := a.Dispatch(context.Background(), &PromptCLIRequest{Prompt: "hi"})
 	if res.Error != "" {
 		t.Fatalf("unexpected error: %s", res.Error)
 	}
-	if res.DriverUsed != "claude-code" {
-		t.Fatalf("expected claude-code, got %q", res.DriverUsed)
+	if res.DriverUsed != "openclaw" {
+		t.Fatalf("expected openclaw, got %q", res.DriverUsed)
 	}
-	if len(called) != 1 || called[0] != "claude-code" {
-		t.Fatalf("expected single claude-code invocation, got %v", called)
+	if len(called) != 1 || called[0] != "openclaw" {
+		t.Fatalf("expected single openclaw invocation, got %v", called)
 	}
 }
 
@@ -96,25 +94,21 @@ func TestPromptCLI_AllMissing(t *testing.T) {
 }
 
 func TestPromptCLI_FallsBackOnRunnerError(t *testing.T) {
+	// Ladder Forge II (2026-04-14): single-driver chain (openclaw). When it
+	// errors, dispatch returns the error — no fallback candidates remain.
 	var called []string
 	runner := func(ctx context.Context, driver, binary, system, prompt string) ([]byte, error) {
 		called = append(called, driver)
-		if driver == "copilot" {
-			return nil, errors.New("copilot crashed")
-		}
-		return []byte("codex worked"), nil
+		return nil, errors.New("openclaw crashed")
 	}
-	a := newTestAdapter(map[string]bool{"copilot": true, "codex": true}, runner)
+	a := newTestAdapter(map[string]bool{"openclaw": true}, runner)
 
 	res := a.Dispatch(context.Background(), &PromptCLIRequest{Prompt: "hi"})
-	if res.Error != "" {
-		t.Fatalf("unexpected error: %s", res.Error)
+	if res.Error == "" {
+		t.Fatal("expected error when sole driver fails")
 	}
-	if res.DriverUsed != "codex" {
-		t.Fatalf("expected fallback to codex, got %q", res.DriverUsed)
-	}
-	if len(called) != 2 || called[0] != "copilot" || called[1] != "codex" {
-		t.Fatalf("expected copilot→codex, got %v", called)
+	if len(called) != 1 || called[0] != "openclaw" {
+		t.Fatalf("expected single openclaw attempt, got %v", called)
 	}
 }
 
@@ -128,7 +122,7 @@ func TestPromptCLI_Timeout(t *testing.T) {
 			return []byte("should not happen"), nil
 		}
 	}
-	a := newTestAdapter(map[string]bool{"copilot": true}, runner)
+	a := newTestAdapter(map[string]bool{"openclaw": true}, runner)
 
 	start := time.Now()
 	res := a.Dispatch(context.Background(), &PromptCLIRequest{
@@ -148,7 +142,7 @@ func TestPromptCLI_Timeout(t *testing.T) {
 }
 
 func TestPromptCLI_EmptyPrompt(t *testing.T) {
-	a := newTestAdapter(map[string]bool{"copilot": true}, nil)
+	a := newTestAdapter(map[string]bool{"openclaw": true}, nil)
 	res := a.Dispatch(context.Background(), &PromptCLIRequest{})
 	if res.Error == "" {
 		t.Fatal("expected error for empty prompt")
@@ -163,7 +157,7 @@ func TestPromptCLI_RejectsUnknownPreferredDriver(t *testing.T) {
 		runnerCalled = true
 		return nil, nil
 	}
-	a := newTestAdapter(map[string]bool{"copilot": true, "codex": true, "claude-code": true}, runner)
+	a := newTestAdapter(map[string]bool{"openclaw": true}, runner)
 	res := a.Dispatch(context.Background(), &PromptCLIRequest{
 		Prompt:          "hi",
 		PreferredDriver: "/bin/sh",
@@ -183,13 +177,14 @@ func TestPromptCLI_RejectsUnknownPreferredDriver(t *testing.T) {
 }
 
 func TestValidatePreferredDriver(t *testing.T) {
-	good := []string{"", "copilot", "codex", "claude-code"}
+	// Ladder Forge II (2026-04-14): openclaw is the sole remaining CLI driver.
+	good := []string{"", "openclaw"}
 	for _, d := range good {
 		if err := ValidatePreferredDriver(d); err != nil {
 			t.Errorf("expected %q allowed, got err=%v", d, err)
 		}
 	}
-	bad := []string{"sh", "../../../bin/rm", "copilot ", "COPILOT", "/bin/sh"}
+	bad := []string{"sh", "../../../bin/rm", "openclaw ", "OPENCLAW", "/bin/sh", "copilot", "codex", "claude-code"}
 	for _, d := range bad {
 		if err := ValidatePreferredDriver(d); err == nil {
 			t.Errorf("expected %q rejected", d)
@@ -211,7 +206,7 @@ func TestPromptCLI_CumulativeDeadline(t *testing.T) {
 			return []byte("should not happen"), nil
 		}
 	}
-	a := newTestAdapter(map[string]bool{"copilot": true, "codex": true, "claude-code": true}, runner)
+	a := newTestAdapter(map[string]bool{"openclaw": true}, runner)
 
 	start := time.Now()
 	res := a.Dispatch(context.Background(), &PromptCLIRequest{
@@ -252,10 +247,8 @@ func TestBuildPromptCLIArgs(t *testing.T) {
 		system    string
 		mustHave  []string
 	}{
-		{"copilot", "do thing", "", []string{"-p", "do thing", "--allow-all-tools"}},
-		{"copilot", "do thing", "be terse", []string{"--append-system-prompt", "be terse"}},
-		{"codex", "do thing", "", []string{"exec", "do thing"}},
-		{"claude-code", "do thing", "", []string{"-p", "do thing"}},
+		{"openclaw", "do thing", "", []string{"-p", "do thing"}},
+		{"openclaw", "do thing", "be terse", []string{"--append-system-prompt", "be terse"}},
 	}
 	for _, tc := range cases {
 		args, _ := buildPromptCLIArgs(tc.driver, tc.system, tc.prompt)

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -1361,7 +1361,7 @@ func toolDefs() []ToolDef {
 			InputSchema: map[string]interface{}{
 				"type": "object",
 				"properties": map[string]interface{}{
-					"driver": map[string]string{"type": "string", "description": "Driver name to reset (e.g. 'codex', 'copilot', 'gemini'). Must match an existing health file."},
+					"driver": map[string]string{"type": "string", "description": "Driver name to reset (e.g. 'openclaw', 'clawta', 'gh-actions', 'claude-api'). Must match an existing health file."},
 					"note":   map[string]string{"type": "string", "description": "Optional reason for the manual reset (logged in the response for audit purposes)."},
 				},
 				"required": []string{"driver"},
@@ -1385,7 +1385,7 @@ func toolDefs() []ToolDef {
 				"properties": map[string]interface{}{
 					"agent":                map[string]string{"type": "string", "description": "Agent name (e.g. sr-kernel-01)"},
 					"budget_monthly_cents": map[string]interface{}{"type": "number", "description": "Monthly budget limit in cents (e.g. 770 = $7.70)"},
-					"driver":               map[string]string{"type": "string", "description": "Driver name (e.g. claude-code). Optional when updating an existing record."},
+					"driver":               map[string]string{"type": "string", "description": "Driver name (e.g. clawta, openclaw, gh-actions). Optional when updating an existing record."},
 					"box":                  map[string]string{"type": "string", "description": "Box/host the agent runs on. Optional when updating an existing record."},
 				},
 				"required": []string{"agent", "budget_monthly_cents"},
@@ -1484,12 +1484,12 @@ func toolDefs() []ToolDef {
 		},
 		{
 			Name:        "dispatch_prompt_to_cli",
-			Description: "Dispatch a freeform prompt to a local CLI agent (copilot, codex, or claude-code). No API key, no worktree. Picks first available driver with fallback.",
+			Description: "Dispatch a freeform prompt to a local CLI agent (openclaw). No API key, no worktree.",
 			InputSchema: map[string]any{
 				"type": "object",
 				"properties": map[string]any{
 					"prompt":           map[string]any{"type": "string", "description": "Freeform prompt to send"},
-					"preferred_driver": map[string]any{"type": "string", "description": "copilot | codex | claude-code (optional)"},
+					"preferred_driver": map[string]any{"type": "string", "description": "openclaw (optional)"},
 					"timeout_seconds":  map[string]any{"type": "integer", "description": "Timeout in seconds (default 120)"},
 					"system_prompt":    map[string]any{"type": "string", "description": "Optional system prompt appended to the driver's default"},
 				},

--- a/internal/routing/health.go
+++ b/internal/routing/health.go
@@ -165,18 +165,16 @@ var creditErrorPatterns = []string{
 
 // driverCreditKeywords maps specific error substrings to driver names.
 // More specific patterns must come first.
+// Ladder Forge II (2026-04-14): CLI-driver keywords (claude-code, copilot,
+// codex, gemini) pruned. Surviving drivers (clawta, openclaw, gh-actions,
+// anthropic/claude-api) have their own error surfaces; keep only the
+// anthropic-API credit keywords here for claude-api budget exhaustion.
 var driverCreditKeywords = []struct {
 	keyword string
 	driver  string
 }{
-	{"claude.ai", "claude-code"},
-	{"credit balance", "claude-code"},
-	{"anthropic", "claude-code"},
-	{"github.com/copilot", "copilot"},
-	{"copilot", "copilot"},
-	{"openai.com", "codex"},
-	{"google.com/generativeai", "gemini"},
-	{"google generative", "gemini"},
+	{"anthropic", "claude-api"},
+	{"credit balance", "claude-api"},
 }
 
 // DetectExhaustedDriver scans agent output for known credit/quota error patterns.

--- a/internal/routing/health_write_test.go
+++ b/internal/routing/health_write_test.go
@@ -148,24 +148,30 @@ func TestForceCloseCircuit_AlwaysWrites(t *testing.T) {
 }
 
 func TestDetectExhaustedDriver_ClaudeCredit(t *testing.T) {
-	output := "Error: Credit balance is too low. Visit claude.ai to top up."
+	// Ladder Forge II (2026-04-14): claude.ai credit errors now route to
+	// the claude-api driver (Claude Code Cloud / Anthropic API). claude-code
+	// CLI driver was pruned.
+	output := "Error: Credit balance is too low. Visit anthropic.com to top up."
 	driver, found := DetectExhaustedDriver(output)
 	if !found {
 		t.Fatal("expected credit error to be detected")
 	}
-	if driver != "claude-code" {
-		t.Errorf("driver: got %q, want claude-code", driver)
+	if driver != "claude-api" {
+		t.Errorf("driver: got %q, want claude-api", driver)
 	}
 }
 
 func TestDetectExhaustedDriver_QuotaExceeded(t *testing.T) {
+	// Ladder Forge II (2026-04-14): codex CLI driver pruned; openai.com
+	// credit keyword dropped. A bare quota-exceeded message with no surviving
+	// driver keyword surfaces as "unknown".
 	output := "openai.com: You have exceeded your current quota, please check your plan."
 	driver, found := DetectExhaustedDriver(output)
 	if !found {
 		t.Fatal("expected quota error to be detected")
 	}
-	if driver != "codex" {
-		t.Errorf("driver: got %q, want codex", driver)
+	if driver != "unknown" {
+		t.Errorf("driver: got %q, want unknown (codex pruned)", driver)
 	}
 }
 

--- a/internal/routing/modeltier.go
+++ b/internal/routing/modeltier.go
@@ -6,10 +6,14 @@ const (
 	TierFrontier ModelTier = "frontier"
 	TierMid      ModelTier = "mid"
 	TierLight    ModelTier = "light"
-	TierFree     ModelTier = "free"
 	TierNone     ModelTier = "none"
 )
 
+// Ladder Forge II (2026-04-14): CLI drivers pruned. TierFree collapsed (was
+// goose-only). Remaining tiers map to the surviving substrates:
+//   frontier → anthropic (Claude Code Cloud, T3)
+//   mid      → gh-actions (T2) + anthropic
+//   light    → clawta (T1 local gateway)
 var stageTiers = map[string]ModelTier{
 	"architect": TierFrontier,
 	"implement": TierMid,
@@ -21,10 +25,9 @@ var stageTiers = map[string]ModelTier{
 const riskEscalationThreshold = 40
 
 var tierDrivers = map[ModelTier][]string{
-	TierFrontier: {"claude-code", "copilot"},
-	TierMid:      {"copilot", "codex", "gemini", "claude-code"},
-	TierLight:    {"claude-code", "codex", "gemini"},
-	TierFree:     {"goose"},
+	TierFrontier: {"anthropic"},
+	TierMid:      {"gh-actions", "anthropic"},
+	TierLight:    {"clawta"},
 	TierNone:     {},
 }
 

--- a/internal/routing/modeltier_test.go
+++ b/internal/routing/modeltier_test.go
@@ -25,12 +25,12 @@ func TestDriversForTier(t *testing.T) {
 	drivers := DriversForTier(TierFrontier)
 	found := false
 	for _, d := range drivers {
-		if d == "claude-code" {
+		if d == "anthropic" {
 			found = true
 		}
 	}
 	if !found {
-		t.Error("expected claude-code in Frontier drivers")
+		t.Error("expected anthropic in Frontier drivers")
 	}
 }
 

--- a/internal/routing/router.go
+++ b/internal/routing/router.go
@@ -23,30 +23,21 @@ const (
 var tierOrder = []CostTier{TierLocal, TierGHActions, TierSubscription, TierCLI, TierAPI}
 
 // driverTiers maps each known driver to its cost tier.
+//
+// Ladder Forge II (2026-04-14): CLI drivers (codex, gemini, goose, copilot,
+// claude-code) and the browser trio (chatgpt-browser, notebooklm-browser,
+// gemini-app-browser) were pruned. Only clawta (T1 local), openclaw (T1
+// subscription), gh-actions (T2), and claude-api/anthropic (T3-ish) remain.
 var driverTiers = map[string]CostTier{
-	// Subscription (browser-based, already paying)
-	//   openclaw: browser-automated Claude Max subscription
-	//   chatgpt-browser: OpenAI Plus subscription via chat.openai.com
-	//   notebooklm-browser: Google AI Premium via notebooklm.google.com
-	//   gemini-app-browser: Google AI Premium via gemini.google.com
-	"openclaw":           TierSubscription,
-	"chatgpt-browser":    TierSubscription,
-	"notebooklm-browser": TierSubscription,
-	"gemini-app-browser": TierSubscription,
-	// GitHub Actions (free with Enterprise)
+	// Local (T1 — gateway-arbitrated)
+	"clawta": TierLocal,
+	// Subscription (browser-automated Claude Max)
+	"openclaw": TierSubscription,
+	// GitHub Actions (T2 — free with Enterprise)
 	"gh-actions": TierGHActions,
-	// CLI (metered subscription)
-	"claude-code": TierCLI,
-	"copilot":     TierCLI,
-	"codex":       TierCLI,
-	"gemini":      TierCLI,
-	"goose":       TierCLI,
-	// Anthropic API (per-token)
-	"anthropic":  TierAPI,
-	// API (per-token, burst capacity)
-	"claude-api":  TierAPI,
-	"openai-api":  TierAPI,
-	"gemini-api":  TierAPI,
+	// Anthropic API (per-token — Claude Code Cloud dispatch)
+	"anthropic": TierAPI,
+	"claude-api": TierAPI,
 }
 
 // taskAffinityTiers maps task-type keywords to a minimum cost tier.
@@ -57,10 +48,10 @@ var taskAffinityTiers = []struct {
 	minTier  CostTier
 }{
 	{[]string{"code", "review", "pull-request", "commit", "implement", "debug", "refactor", "test"}, TierGHActions},
-	// Browser-tier tasks: general web interaction plus NotebookLM-specific capabilities
-	// (audio overview, podcast briefing, slide deck generation, Drive export).
-	{[]string{"browse", "web", "click", "screenshot", "briefing", "artifact", "document",
-		"audio-overview", "audio overview", "podcast", "slide", "upload document", "export to drive"}, TierSubscription},
+	// Browser-tier tasks: general web interaction via openclaw. NotebookLM-specific
+	// capabilities (audio-overview, podcast, slide, Drive export) dropped with the
+	// browser-trio prune (Ladder Forge II, 2026-04-14).
+	{[]string{"browse", "web", "click", "screenshot", "briefing", "artifact", "document"}, TierSubscription},
 	{[]string{"burst", "programmatic", "api-call"}, TierAPI},
 	// "simple", "classify", "triage" etc. get no override → defaults to TierLocal
 }

--- a/internal/routing/router_test.go
+++ b/internal/routing/router_test.go
@@ -221,7 +221,7 @@ func TestRecommend_SubscriptionTier(t *testing.T) {
 
 func TestRecommend_APITierDriversRegistered(t *testing.T) {
 	// Confirm all expected API tier drivers exist in the global map.
-	for _, name := range []string{"claude-api", "openai-api", "gemini-api"} {
+	for _, name := range []string{"claude-api"} {
 		if tier, ok := driverTiers[name]; !ok {
 			t.Errorf("driver %q missing from driverTiers", name)
 		} else if tier != TierAPI {
@@ -400,13 +400,9 @@ func TestTaskMinTier(t *testing.T) {
 		{"generate briefing", TierSubscription},
 		{"web screenshot", TierSubscription},
 		{"browse the page", TierSubscription},
-		// Browser-driver task keywords (issue #5)
-		{"generate audio-overview", TierSubscription},
-		{"audio overview from documents", TierSubscription},
-		{"podcast briefing", TierSubscription},
-		{"create slide deck", TierSubscription},
-		{"upload document to notebooklm", TierSubscription},
-		{"export to drive", TierSubscription},
+		// Browser-driver-trio keywords (audio-overview, podcast, slide, drive)
+		// were pruned in Ladder Forge II (2026-04-14).
+		{"podcast briefing", TierSubscription}, // still matches "briefing"
 		{"programmatic api-call", TierAPI},
 		{"burst workload", TierAPI},
 		{"simple triage", TierLocal},
@@ -422,19 +418,10 @@ func TestTaskMinTier(t *testing.T) {
 }
 
 // ── Browser driver routing tests (issue #5) ───────────────────────────────────
-
-func TestBrowserDriversRegistered(t *testing.T) {
-	for _, name := range []string{"chatgpt-browser", "notebooklm-browser", "gemini-app-browser"} {
-		tier, ok := driverTiers[name]
-		if !ok {
-			t.Errorf("driver %q missing from driverTiers", name)
-			continue
-		}
-		if tier != TierSubscription {
-			t.Errorf("driver %q: expected TierSubscription, got %s", name, tier)
-		}
-	}
-}
+// TestBrowserDriversRegistered removed in Ladder Forge II (2026-04-14):
+// chatgpt-browser, notebooklm-browser, gemini-app-browser dropped from
+// driverTiers. The routing behavior tests below continue to exercise
+// subscription-tier fallback using synthetic tier maps, which remain valid.
 
 func TestRecommend_BrowserDriverPreferredOverCLI(t *testing.T) {
 	// Browser tasks should route to subscription-tier browser drivers before CLI.

--- a/server/platforms.json
+++ b/server/platforms.json
@@ -1,5 +1,5 @@
 {
-  "priority": ["openclaw", "claude", "copilot", "gemini", "codex"],
+  "priority": ["openclaw", "claude"],
   "platforms": {
     "openclaw": {
       "queues": ["intake", "groom"],
@@ -11,24 +11,6 @@
       "queues": ["intake", "groom", "build", "validate"],
       "model": "opus",
       "daily_cap": 20,
-      "enabled": true
-    },
-    "copilot": {
-      "queues": ["intake", "groom", "build", "validate"],
-      "model": "gpt-5.4-mini",
-      "daily_cap": 20,
-      "enabled": true
-    },
-    "gemini": {
-      "queues": ["intake", "groom"],
-      "model": "gemini-2.5-pro",
-      "daily_cap": 10,
-      "enabled": true
-    },
-    "codex": {
-      "queues": ["intake", "groom"],
-      "model": "o3",
-      "daily_cap": 5,
       "enabled": true
     }
   }


### PR DESCRIPTION
## Summary

Ladder Forge II execution pass. Deletes drivers that aren't earning keep from code, config, and tests. Only `clawta` (T1), `openclaw` (T1), `gh-actions` (T2), and `anthropic` / `claude-api` (T3 — Claude Code Cloud) remain.

**Dropped:** `codex`, `gemini`, `goose`, `chatgpt-browser`, `notebooklm-browser`, `gemini-app-browser`, `copilot`, `claude-code`.

See wiki: `runs/octi/2026-04-14-tier-ladder-and-gateway.md` for the tier model and prune rationale.

## Changes

- `internal/routing/router.go` — `driverTiers` + `taskAffinityTiers` pruned; added `clawta` as T1.
- `internal/routing/modeltier.go` — `tierDrivers` rewired to surviving drivers; `TierFree` constant deleted.
- `internal/routing/health.go` — `driverCreditKeywords` collapsed to anthropic → claude-api.
- `internal/dispatch/brain.go` — `driverProbeCommands` trimmed to `openclaw` only.
- `internal/dispatch/prompt_cli_adapter.go` — whitelist + fallback chain + argv builder collapsed to `openclaw`.
- `internal/mcp/server.go` — tool-description strings scrubbed.
- `server/platforms.json` — priority + platforms map reduced to `{openclaw, claude}`.
- 6 test files mechanically updated; all green (`go build ./... && go test ./...`).

## Deferred / flagged

- `ClaudeCodeAdapter` and `CopilotCLIAdapter` types retained as dead code. Full structural removal (adapter types, stagger platform switches, webhook handlers) is a separate refactor PR — task brief said "prefer mechanical edits; do not refactor on the way through."
- `scripts/swarm/*.sh` and `workflows/*.yml` still reference dropped drivers. Non-blocking for Go build/test; flagged for a docs/scripts sweep.
- Wiki doc for this run explicitly says "Do not delete CLI drivers from driverTiers until Track A confirms none are rehabilitable." This PR overrides per direct JP instruction today — holding on merge for turing's #222-sibling audit.

## Do NOT merge until:

- turing's audit (#222-sibling) passes — confirms no live task type loses routing.
- T1 stays feature-flagged off (new GPU box not here until weekend).

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./...` all packages green
- [ ] Turing audit (sibling of #222) confirms task→tier coverage
- [ ] Manual smoke: dispatch_prompt_to_cli with `preferred_driver=openclaw`
- [ ] Verify no staged pipeline runs hit the deleted drivers

🤖 Generated with [Claude Code](https://claude.com/claude-code)