### PR TITLE
feat(telemetry): tier-tagged dispatch log + tier_activity MCP tool

### DIFF
--- a/internal/dispatch/dispatcher.go
+++ b/internal/dispatch/dispatcher.go
@@ -34,7 +34,37 @@ type DispatchRecord struct {
 	Result    string `json:"result"` // action taken
 	Reason    string `json:"reason"`
 	Driver    string `json:"driver"`
+	Tier      string `json:"tier,omitempty"` // Ladder Forge tier: local|actions|cloud|desktop|human|unknown
 	Timestamp string `json:"timestamp"`
+}
+
+// ClassifyTier maps a driver (and event context) to a Ladder Forge tier.
+// v0 rules:
+//   - gh-actions          -> actions
+//   - clawta, openclaw    -> local
+//   - anthropic, remote-* -> cloud
+//   - needs-human relabel -> human
+//   - unknown/blank       -> unknown (T1 local and T4 desktop will report 0 until online)
+func ClassifyTier(driver string, event Event) string {
+	// Human escalation detected via label on issue.labeled events.
+	if event.Type == EventIssueLabeled {
+		if lbl := event.Payload["label"]; lbl == "needs-human" || lbl == "agent:blocked" {
+			return "human"
+		}
+	}
+	switch driver {
+	case "gh-actions", "ghactions", "github-actions":
+		return "actions"
+	case "clawta", "openclaw", "claude-code", "copilot-cli":
+		return "local"
+	case "anthropic", "claude", "remote", "remote-trigger":
+		return "cloud"
+	case "desktop", "claude-desktop":
+		return "desktop"
+	case "":
+		return "unknown"
+	}
+	return "unknown"
 }
 
 // Dispatcher coordinates all agent scheduling based on events.
@@ -402,6 +432,7 @@ func (d *Dispatcher) recordDispatch(ctx context.Context, agentName string, event
 		Result:    result.Action,
 		Reason:    result.Reason,
 		Driver:    result.Driver,
+		Tier:      ClassifyTier(result.Driver, event),
 		Timestamp: result.Timestamp,
 	}
 	data, err := json.Marshal(record)

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -282,6 +282,28 @@ func (s *Server) handleToolCall(req Request) (resp Response) {
 		}
 		return textResult(req.ID, strings.Join(lines, "\n"))
 
+	case "tier_activity":
+		if s.rdb == nil {
+			return errorResp(req.ID, -32000, "redis not configured")
+		}
+		var args struct {
+			WindowHours int `json:"windowHours"`
+			Limit       int `json:"limit"`
+		}
+		_ = json.Unmarshal(params.Arguments, &args)
+		if args.WindowHours == 0 {
+			args.WindowHours = 24
+		}
+		if args.Limit == 0 {
+			args.Limit = 500
+		}
+		summary, err := tierActivitySummary(ctx, s.rdb, s.redisNS, args.WindowHours, args.Limit)
+		if err != nil {
+			return errorResp(req.ID, -32000, err.Error())
+		}
+		out, _ := json.MarshalIndent(summary, "", "  ")
+		return textResult(req.ID, string(out))
+
 	case "coord_claim":
 		var args struct {
 			Task       string `json:"task"`
@@ -1159,6 +1181,17 @@ func toolDefs() []ToolDef {
 			Name:        "memory_status",
 			Description: "See what other agents in the swarm are currently working on.",
 			InputSchema: map[string]interface{}{"type": "object", "properties": map[string]interface{}{}},
+		},
+		{
+			Name:        "tier_activity",
+			Description: "Summarize dispatch activity by Ladder Forge tier (local/actions/cloud/desktop/human/unknown) over the last N hours. v0 telemetry — T1 local and T4 desktop report 0 until those tiers come online; legacy entries without a tier field are counted as unknown.",
+			InputSchema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"windowHours": map[string]interface{}{"type": "integer", "description": "Lookback window in hours (default 24)."},
+					"limit":       map[string]interface{}{"type": "integer", "description": "Max log entries to scan (default 500)."},
+				},
+			},
 		},
 		{
 			Name:        "coord_claim",

--- a/internal/mcp/tier_activity.go
+++ b/internal/mcp/tier_activity.go
@@ -1,0 +1,80 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+
+	"github.com/chitinhq/octi-pulpo/internal/dispatch"
+	"github.com/redis/go-redis/v9"
+)
+
+// TierBucket is one row of the tier_activity summary.
+type TierBucket struct {
+	Dispatches int    `json:"dispatches"`
+	LastAt     string `json:"last_at,omitempty"`
+}
+
+// TierActivitySummary is the shape returned by the tier_activity MCP tool.
+type TierActivitySummary struct {
+	WindowHours int                    `json:"window_hours"`
+	Scanned     int                    `json:"scanned"`
+	Tiers       map[string]*TierBucket `json:"tiers"`
+}
+
+// knownTiers is the canonical tier set reported by v0. Buckets are always
+// present (dispatches=0) so clients get a stable shape.
+var knownTiers = []string{"local", "actions", "cloud", "desktop", "human", "unknown"}
+
+// tierActivitySummary scans the last `limit` entries of the dispatch log in
+// Redis namespace `ns` and groups them by tier over the last `windowHours`.
+func tierActivitySummary(ctx context.Context, rdb *redis.Client, ns string, windowHours, limit int) (*TierActivitySummary, error) {
+	key := ns + ":dispatch-log"
+	raw, err := rdb.LRange(ctx, key, 0, int64(limit)-1).Result()
+	if err != nil {
+		return nil, err
+	}
+
+	summary := &TierActivitySummary{
+		WindowHours: windowHours,
+		Tiers:       make(map[string]*TierBucket, len(knownTiers)),
+	}
+	for _, t := range knownTiers {
+		summary.Tiers[t] = &TierBucket{}
+	}
+
+	cutoff := time.Now().UTC().Add(-time.Duration(windowHours) * time.Hour)
+
+	for _, entry := range raw {
+		var rec dispatch.DispatchRecord
+		if err := json.Unmarshal([]byte(entry), &rec); err != nil {
+			continue
+		}
+
+		ts, tsErr := time.Parse(time.RFC3339, rec.Timestamp)
+		if tsErr == nil && ts.Before(cutoff) {
+			continue
+		}
+		summary.Scanned++
+
+		tier := rec.Tier
+		if tier == "" {
+			tier = "unknown"
+		}
+		bucket, ok := summary.Tiers[tier]
+		if !ok {
+			bucket = &TierBucket{}
+			summary.Tiers[tier] = bucket
+		}
+		bucket.Dispatches++
+		if tsErr == nil {
+			if bucket.LastAt == "" {
+				bucket.LastAt = rec.Timestamp
+			} else if prev, err := time.Parse(time.RFC3339, bucket.LastAt); err == nil && ts.After(prev) {
+				bucket.LastAt = rec.Timestamp
+			}
+		}
+	}
+
+	return summary, nil
+}

--- a/internal/mcp/tier_activity_test.go
+++ b/internal/mcp/tier_activity_test.go
@@ -1,0 +1,121 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/chitinhq/octi-pulpo/internal/dispatch"
+	"github.com/redis/go-redis/v9"
+)
+
+// newTestRedis returns a real Redis client or skips the test if Redis is
+// unreachable. Uses a per-test namespace that is cleaned up via t.Cleanup.
+func newTestRedis(t *testing.T) (*redis.Client, string) {
+	t.Helper()
+	opts, err := redis.ParseURL("redis://localhost:6379")
+	if err != nil {
+		t.Skipf("skipping: cannot parse redis URL: %v", err)
+	}
+	rdb := redis.NewClient(opts)
+	ctx := context.Background()
+	if err := rdb.Ping(ctx).Err(); err != nil {
+		t.Skipf("skipping: redis not available: %v", err)
+	}
+	ns := "tier-test-" + strings.ReplaceAll(t.Name(), "/", "-")
+	t.Cleanup(func() {
+		keys, _ := rdb.Keys(ctx, ns+":*").Result()
+		if len(keys) > 0 {
+			rdb.Del(ctx, keys...)
+		}
+		rdb.Close()
+	})
+	return rdb, ns
+}
+
+func pushRecord(t *testing.T, rdb *redis.Client, key string, rec dispatch.DispatchRecord) {
+	t.Helper()
+	data, err := json.Marshal(rec)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if err := rdb.LPush(context.Background(), key, data).Err(); err != nil {
+		t.Fatalf("lpush: %v", err)
+	}
+}
+
+func TestTierActivitySummary_GroupsByTier(t *testing.T) {
+	rdb, ns := newTestRedis(t)
+	key := ns + ":dispatch-log"
+	now := time.Now().UTC()
+
+	pushRecord(t, rdb, key, dispatch.DispatchRecord{Agent: "a1", Driver: "clawta", Tier: "local", Timestamp: now.Add(-30 * time.Minute).Format(time.RFC3339)})
+	pushRecord(t, rdb, key, dispatch.DispatchRecord{Agent: "a2", Driver: "gh-actions", Tier: "actions", Timestamp: now.Add(-1 * time.Hour).Format(time.RFC3339)})
+	pushRecord(t, rdb, key, dispatch.DispatchRecord{Agent: "a3", Driver: "gh-actions", Tier: "actions", Timestamp: now.Add(-2 * time.Hour).Format(time.RFC3339)})
+	// legacy entry — no tier field
+	pushRecord(t, rdb, key, dispatch.DispatchRecord{Agent: "a4", Driver: "", Timestamp: now.Add(-3 * time.Hour).Format(time.RFC3339)})
+
+	sum, err := tierActivitySummary(context.Background(), rdb, ns, 24, 500)
+	if err != nil {
+		t.Fatalf("summary: %v", err)
+	}
+	if got := sum.Tiers["local"].Dispatches; got != 1 {
+		t.Errorf("local=%d, want 1", got)
+	}
+	if got := sum.Tiers["actions"].Dispatches; got != 2 {
+		t.Errorf("actions=%d, want 2", got)
+	}
+	if got := sum.Tiers["unknown"].Dispatches; got != 1 {
+		t.Errorf("unknown=%d, want 1", got)
+	}
+	if got := sum.Tiers["cloud"].Dispatches; got != 0 {
+		t.Errorf("cloud=%d, want 0 (T3 not online)", got)
+	}
+	if sum.Scanned != 4 {
+		t.Errorf("scanned=%d, want 4", sum.Scanned)
+	}
+	if sum.Tiers["actions"].LastAt == "" {
+		t.Errorf("actions last_at should be populated")
+	}
+}
+
+func TestTierActivitySummary_WindowExcludesOld(t *testing.T) {
+	rdb, ns := newTestRedis(t)
+	key := ns + ":dispatch-log"
+	now := time.Now().UTC()
+
+	pushRecord(t, rdb, key, dispatch.DispatchRecord{Agent: "recent", Tier: "local", Timestamp: now.Add(-1 * time.Hour).Format(time.RFC3339)})
+	pushRecord(t, rdb, key, dispatch.DispatchRecord{Agent: "old", Tier: "local", Timestamp: now.Add(-48 * time.Hour).Format(time.RFC3339)})
+
+	sum, err := tierActivitySummary(context.Background(), rdb, ns, 24, 500)
+	if err != nil {
+		t.Fatalf("summary: %v", err)
+	}
+	if got := sum.Tiers["local"].Dispatches; got != 1 {
+		t.Errorf("local=%d in 24h window, want 1 (old entry should be excluded)", got)
+	}
+}
+
+func TestClassifyTier(t *testing.T) {
+	cases := []struct {
+		name   string
+		driver string
+		evt    dispatch.Event
+		want   string
+	}{
+		{"actions", "gh-actions", dispatch.Event{}, "actions"},
+		{"clawta-local", "clawta", dispatch.Event{}, "local"},
+		{"openclaw-local", "openclaw", dispatch.Event{}, "local"},
+		{"anthropic-cloud", "anthropic", dispatch.Event{}, "cloud"},
+		{"needs-human-label", "", dispatch.Event{Type: dispatch.EventIssueLabeled, Payload: map[string]string{"label": "needs-human"}}, "human"},
+		{"blank", "", dispatch.Event{}, "unknown"},
+		{"mystery", "mystery-driver", dispatch.Event{}, "unknown"},
+	}
+	for _, c := range cases {
+		if got := dispatch.ClassifyTier(c.driver, c.evt); got != c.want {
+			t.Errorf("%s: ClassifyTier(%q) = %q, want %q", c.name, c.driver, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Minimum viable Ladder Forge II observability. Tags every dispatch with a `tier` field in `octi:dispatch-log` and exposes one MCP read path `tier_activity` that summarizes the last 24h grouped by tier.

- `DispatchRecord` gains a `tier` field (local | actions | cloud | desktop | human | unknown), populated at write time by a new `ClassifyTier(driver, event)` helper.
- Classification rules (v0):
  - `gh-actions` / `github-actions` -> `actions`
  - `clawta` / `openclaw` / `claude-code` / `copilot-cli` -> `local`
  - `anthropic` / `remote-trigger` -> `cloud`
  - `desktop` / `claude-desktop` -> `desktop`
  - `issue.labeled` with `needs-human` or `agent:blocked` -> `human`
  - anything else / blank -> `unknown`
- MCP tool `tier_activity` scans the last N entries of `octi:dispatch-log`, filters by `windowHours` (default 24), and returns a stable-shape JSON summary per tier with dispatch counts and `last_at`.

## Scope note

This is **v0**, not a full implementation of #221/#220/#219/#222. It is the minimum read surface JP asked for today:

- **T1 (local) and T4 (desktop) will report 0** until those tiers come online.
- **Legacy entries** without a `tier` field are counted as `tier:unknown`.
- **`tier:cloud` is a best-effort tag** based on driver name — we do not have a reliable way to attribute remote-trigger dispatches back to cloud until those dispatches write back into Redis with a driver string we recognize. Expect undercount on cloud until that loop closes.

Future PRs can layer the richer metrics from the Ladder Forge specs on top of this field.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` — 767 passed across 24 packages
- [x] New tests: `TestTierActivitySummary_GroupsByTier`, `TestTierActivitySummary_WindowExcludesOld`, `TestClassifyTier`

🤖 Generated with [Claude Code](https://claude.com/claude-code)