### PR TITLE
fix(dispatcher): wire adapter Dispatch() call — stop silent-loss

### DIFF
--- a/internal/dispatch/dispatcher.go
+++ b/internal/dispatch/dispatcher.go
@@ -49,6 +49,27 @@ type Dispatcher struct {
 	presUser  string                // user ID for presence checks
 	queueFile string                // ~/.chitin/queue.txt (compatibility bridge)
 	namespace string
+	adapters  []Adapter // execution-surface adapters; picked by Name() against routed driver
+}
+
+// SetAdapters registers adapters that execute a dispatched task on a real
+// surface (HTTP repository_dispatch, Anthropic API, Claude Code CLI, etc.).
+// After route selection, Dispatch() invokes the adapter whose Name() matches
+// the routed driver. This is what makes result.Action="dispatched" mean "an
+// execution surface was actually called" rather than "we enqueued to Redis
+// and hoped." See workspace#408 (silent-loss regression).
+func (d *Dispatcher) SetAdapters(adapters ...Adapter) { d.adapters = adapters }
+
+// selectAdapter returns the registered adapter whose Name() matches driver,
+// or nil if none is registered. Gate between routing ("we picked claude-code")
+// and execution ("we actually called it").
+func (d *Dispatcher) selectAdapter(driver string) Adapter {
+	for _, a := range d.adapters {
+		if a != nil && a.Name() == driver {
+			return a
+		}
+	}
+	return nil
 }
 
 // NewDispatcher creates an event-driven dispatcher.
@@ -197,11 +218,62 @@ func (d *Dispatcher) DispatchBudget(ctx context.Context, event Event, agentName 
 	}
 
 	queueDepth, _ := d.PendingCount(ctx)
-	result.Action = "dispatched"
-	result.Reason = fmt.Sprintf("dispatched via %s (tier: %s, confidence: %.1f)", routeDecision.Driver, routeDecision.Tier, routeDecision.Confidence)
 	result.Driver = routeDecision.Driver
 	result.ClaimID = claim.ClaimID
 	result.QueuePos = queueDepth
+
+	// 5. Actually call the adapter for the routed driver. Until this returns
+	// successfully, we have only *routed* — we have not *dispatched*. Action
+	// "dispatched" must mean an execution surface was invoked and accepted
+	// the task (workspace#408: silent-loss fix).
+	adapter := d.selectAdapter(routeDecision.Driver)
+	if adapter == nil {
+		if len(d.adapters) == 0 {
+			// Legacy path: no adapters registered at all. Preserve the old
+			// queue-only behavior so callers that consume from the Redis
+			// queue directly don't regress. Reason string marks it as
+			// queue-only so observers can distinguish it from HTTP-confirmed
+			// dispatch.
+			result.Action = "dispatched"
+			result.Reason = fmt.Sprintf("queued via %s (tier: %s, confidence: %.1f; no adapter registered)", routeDecision.Driver, routeDecision.Tier, routeDecision.Confidence)
+			d.recordDispatch(ctx, agentName, event, result)
+			return result, nil
+		}
+		// Adapters exist but none matches the routed driver: don't claim
+		// success with no execution surface attached.
+		result.Action = "unroutable"
+		result.Reason = fmt.Sprintf("no adapter registered for driver %q", routeDecision.Driver)
+		d.recordDispatch(ctx, agentName, event, result)
+		return result, nil
+	}
+
+	task := &Task{
+		ID:       fmt.Sprintf("%s-%d", agentName, now.UnixNano()),
+		Type:     string(event.Type),
+		Repo:     event.Repo,
+		Priority: priorityStr(priority),
+	}
+
+	adapterResult, adapterErr := adapter.Dispatch(ctx, task)
+	if adapterErr != nil {
+		result.Action = "failed"
+		result.Reason = fmt.Sprintf("adapter %s dispatch failed: %v", adapter.Name(), adapterErr)
+		d.recordDispatch(ctx, agentName, event, result)
+		return result, nil
+	}
+	if adapterResult != nil && adapterResult.Status == "failed" {
+		errMsg := adapterResult.Error
+		if errMsg == "" {
+			errMsg = "adapter reported failed status"
+		}
+		result.Action = "failed"
+		result.Reason = fmt.Sprintf("adapter %s: %s", adapter.Name(), errMsg)
+		d.recordDispatch(ctx, agentName, event, result)
+		return result, nil
+	}
+
+	result.Action = "dispatched"
+	result.Reason = fmt.Sprintf("dispatched via %s (tier: %s, confidence: %.1f)", routeDecision.Driver, routeDecision.Tier, routeDecision.Confidence)
 
 	d.recordDispatch(ctx, agentName, event, result)
 	return result, nil


### PR DESCRIPTION
## Summary

Closes the silent-loss footprint in `internal/dispatch/dispatcher.go` (workspace#408). Before this change, `Dispatch()` claimed a lock, routed a driver, enqueued to Redis, and reported `action="dispatched"` without ever invoking the adapter's HTTP call. Any event — even one with `event.Repo=""` — returned success.

## Changes

- Added `adapters []Adapter` field + `SetAdapters(...)` on `Dispatcher` (mirrors the `Brain` API).
- After `router.Recommend(...)`, `Dispatch()` now picks the adapter whose `Name()` matches `routeDecision.Driver` and calls `adapter.Dispatch(ctx, task)` synchronously.
- Outcome mapping:
  - adapter returns nil error + non-failed status → `action="dispatched"` (surface actually called)
  - adapter returns error OR `AdapterResult.Status=="failed"` → `action="failed"` + reason
  - no adapter matches routed driver → `action="unroutable"` + reason
  - no adapters registered at all → legacy queue-only path preserved; reason string annotated so observers can distinguish queue-only from HTTP-confirmed dispatch
- One HTTP attempt per call — no retries, no goroutine fan-out.

## Out of scope

- The upstream `event.Repo=""` bug (webhook/path where Repo never gets populated) is **lovelace's slice** — separate PR. With this fix, empty-repo events that route to a real adapter will now correctly surface as `action="failed"` with the adapter's own error (e.g. "empty repo") instead of silently claiming dispatched.
- No surrounding refactors; adapter wiring at MCP/server setup sites is not touched in this PR.

## Test plan

- [x] `go build ./...` green
- [x] `go test ./...` — **783 passed / 0 failed across 24 packages**
- [x] No test casualties. The legacy queue-only path is preserved when `SetAdapters(...)` is never called, so existing dispatcher tests (which don't register adapters) continue to observe `action="dispatched"` exactly as before.
- [ ] Follow-up: lovelace's regression test `TestE2E_DispatchNotSilent` (on a sibling branch) will exercise the new adapter-invocation path end-to-end once merged together.

Refs: workspace#408

🤖 Generated with [Claude Code](https://claude.com/claude-code)