### PR TITLE
fix(brain): populate event.Repo so dispatch isn't auto-rejected

### DIFF
--- a/internal/dispatch/brain.go
+++ b/internal/dispatch/brain.go
@@ -1395,6 +1395,7 @@ func (b *Brain) executeLeverageAction(ctx context.Context, action LeverageAction
 	event := Event{
 		Type:   EventType("brain.leverage"),
 		Source: "brain",
+		Repo:   action.Repo, // populate top-level so adapter CanAccept() sees it (workspace#408)
 		Payload: map[string]string{
 			"reason":    action.Reason,
 			"issue_num": fmt.Sprintf("%d", action.IssueNum),

--- a/internal/dispatch/dispatcher.go
+++ b/internal/dispatch/dispatcher.go
@@ -92,6 +92,20 @@ func (d *Dispatcher) DispatchBudget(ctx context.Context, event Event, agentName 
 		Timestamp: now.Format(time.RFC3339),
 	}
 
+	// 0. Validate: repo-scoped events must carry a non-empty Repo.
+	// Adapter CanAccept() rejects empty-repo dispatches, so such events
+	// evaporate silently at the adapter layer — the silent-loss bug from
+	// workspace#408. Reject loudly here with telemetry instead so the
+	// producer can be located via recent-dispatches. System-wide events
+	// (timer, manual, signal, slack.action, budget.change, completion,
+	// brain.recovery) are exempt — they legitimately have no repo.
+	if event.RequiresRepo() && event.Repo == "" {
+		result.Action = "skipped"
+		result.Reason = fmt.Sprintf("event.Repo empty for repo-scoped type %q (producer bug)", event.Type)
+		d.recordDispatch(ctx, agentName, event, result)
+		return result, fmt.Errorf("dispatch: event.Repo required for event type %q (agent=%s source=%s)", event.Type, agentName, event.Source)
+	}
+
 	// 1. Check cooldown
 	cooldownKey := d.key("cooldown:" + agentName)
 	exists, err := d.rdb.Exists(ctx, cooldownKey).Result()

--- a/internal/dispatch/dispatcher_test.go
+++ b/internal/dispatch/dispatcher_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -606,5 +607,45 @@ func TestDispatchBudget_LowBlocksCLI(t *testing.T) {
 	}
 	if result.Budget != "low" {
 		t.Fatalf("expected budget=low in result, got %s", result.Budget)
+	}
+}
+
+// TestDispatch_RejectsRepoScopedEventWithEmptyRepo guards the
+// silent-loss bug from workspace#408: repo-scoped events (pr.*,
+// issue.*, ci.completed, push, brain.leverage) must carry a non-empty
+// Repo or adapter CanAccept() rejects the dispatch invisibly. The
+// dispatcher must fail loudly instead so the producer can be traced.
+func TestDispatch_RejectsRepoScopedEventWithEmptyRepo(t *testing.T) {
+	d, ctx := testSetup(t)
+
+	event := Event{
+		Type:   EventType("brain.leverage"),
+		Source: "brain",
+		// Repo intentionally omitted — this is the bug we're guarding.
+	}
+	result, err := d.Dispatch(ctx, event, "some-agent", 2)
+	if err == nil {
+		t.Fatalf("expected error for empty Repo on repo-scoped event, got nil (action=%s)", result.Action)
+	}
+	if result.Action != "skipped" {
+		t.Fatalf("expected action=skipped, got %s", result.Action)
+	}
+	if !strings.Contains(result.Reason, "Repo empty") {
+		t.Fatalf("expected reason to mention empty Repo, got %q", result.Reason)
+	}
+}
+
+// TestDispatch_AcceptsExemptEventWithEmptyRepo confirms system-wide
+// events (timer, manual, signal) are still allowed without a Repo.
+func TestDispatch_AcceptsExemptEventWithEmptyRepo(t *testing.T) {
+	d, ctx := testSetup(t)
+
+	event := Event{Type: EventTimer, Source: "timer"} // no Repo
+	result, err := d.Dispatch(ctx, event, "kernel-sr", 2)
+	if err != nil {
+		t.Fatalf("expected no error for exempt event, got %v", err)
+	}
+	if result.Action == "skipped" && strings.Contains(result.Reason, "Repo empty") {
+		t.Fatalf("exempt event should not be rejected for empty Repo: %s", result.Reason)
 	}
 }

--- a/internal/dispatch/events.go
+++ b/internal/dispatch/events.go
@@ -33,6 +33,26 @@ type Event struct {
 	Priority int               `json:"priority"` // 0=critical, 1=high, 2=normal, 3=background
 }
 
+// RequiresRepo returns true if the event type is meaningless without a
+// Repo — adapter CanAccept() rejects empty-repo dispatches, so events
+// missing a Repo evaporate silently. System-wide events (pure timers,
+// backpressure recovery, budget changes, slack meta-commands, raw
+// signals) are exempt. Used by the dispatcher to fail loudly with
+// telemetry instead of letting the dispatch vanish (workspace#408).
+func (e Event) RequiresRepo() bool {
+	switch e.Type {
+	case EventIssueOpened, EventIssueLabeled,
+		EventPROpened, EventPRUpdated, EventPRLabeled,
+		EventCICompleted, EventPush:
+		return true
+	case EventType("brain.leverage"):
+		// brain.leverage always targets a specific repo; empty Repo
+		// means the producer forgot to populate it.
+		return true
+	}
+	return false
+}
+
 // EventRule maps an event pattern to an agent that should handle it.
 type EventRule struct {
 	EventType EventType     // which event triggers this rule

--- a/internal/dispatch/signals.go
+++ b/internal/dispatch/signals.go
@@ -66,6 +66,7 @@ type signalPayload struct {
 	AgentID   string `json:"agent_id"`
 	Type      string `json:"type"`    // completed, blocked, need-help, directive
 	Payload   string `json:"payload"`
+	Repo      string `json:"repo"`    // optional repo context (e.g. "chitinhq/kernel")
 	Timestamp string `json:"timestamp"`
 }
 
@@ -136,6 +137,7 @@ func (sw *SignalWatcher) handleNeedHelp(ctx context.Context, sig signalPayload) 
 	event := Event{
 		Type:   EventSignal,
 		Source: sig.AgentID,
+		Repo:   sig.Repo,
 		Payload: map[string]string{
 			"signal_type":  "need-help",
 			"from_agent":   sig.AgentID,
@@ -164,6 +166,7 @@ func (sw *SignalWatcher) handleBlocked(ctx context.Context, sig signalPayload) {
 	event := Event{
 		Type:   EventSignal,
 		Source: sig.AgentID,
+		Repo:   sig.Repo,
 		Payload: map[string]string{
 			"signal_type":    "blocked",
 			"from_agent":     sig.AgentID,

--- a/internal/dispatch/webhook.go
+++ b/internal/dispatch/webhook.go
@@ -568,6 +568,7 @@ func (ws *WebhookServer) handleTrigger(w http.ResponseWriter, r *http.Request) {
 	var req struct {
 		Agent    string `json:"agent"`
 		Priority int    `json:"priority"`
+		Repo     string `json:"repo"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		http.Error(w, "invalid JSON body", http.StatusBadRequest)
@@ -581,6 +582,7 @@ func (ws *WebhookServer) handleTrigger(w http.ResponseWriter, r *http.Request) {
 	event := Event{
 		Type:     EventManual,
 		Source:   "http",
+		Repo:     req.Repo,
 		Priority: req.Priority,
 		Payload:  map[string]string{"triggered_by": "http_api"},
 	}
@@ -605,6 +607,7 @@ func (ws *WebhookServer) handleTimerTrigger(w http.ResponseWriter, r *http.Reque
 	var req struct {
 		Agent    string `json:"agent"`
 		Priority int    `json:"priority"`
+		Repo     string `json:"repo"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		http.Error(w, "invalid JSON body", http.StatusBadRequest)
@@ -621,6 +624,7 @@ func (ws *WebhookServer) handleTimerTrigger(w http.ResponseWriter, r *http.Reque
 	event := Event{
 		Type:     EventTimer,
 		Source:   "timer",
+		Repo:     req.Repo, // empty for system-wide SR/EM timers; set when scoped
 		Priority: req.Priority,
 		Payload:  map[string]string{"triggered_by": "octi-timer"},
 	}


### PR DESCRIPTION
## Summary

Root cause of [workspace#408](https://github.com/chitinhq/workspace/issues/408) silent-loss: 500/500 recent octi dispatch events had `repo:""` empty. `brain-leverage` and several other producers built `dispatch.Event` without populating the top-level `Repo` field — they stuffed it into `Payload["repo"]` instead. Adapter `CanAccept()` reads `event.Repo`, so every brain dispatch got auto-rejected at the adapter layer with no useful trace.

This PR fixes the upstream so events carry a repo, and adds a loud-fail guard in the dispatcher so future producer regressions don't vanish.

## Producers fixed
- `internal/dispatch/brain.go` `executeLeverageAction` — set `Repo: action.Repo` on the `brain.leverage` event.
- `internal/dispatch/signals.go` `handleNeedHelp` / `handleBlocked` — propagate optional `signalPayload.Repo` so agent signals can carry repo context.
- `internal/dispatch/webhook.go` `handleTrigger` / `handleTimerTrigger` — accept a `repo` field in the JSON body so HTTP API callers scope their dispatch.

## Dispatcher guard
- `internal/dispatch/events.go`: new `Event.RequiresRepo()` classifying repo-scoped types (`pr.*`, `issue.*`, `ci.completed`, `push`, `brain.leverage`) vs exempt system-wide types.
- `internal/dispatch/dispatcher.go` `DispatchBudget`: if `RequiresRepo()` and `Repo` is empty, return an error + skipped result with a clear `"producer bug"` reason. Recorded in dispatch-log so the producer can be traced.

## Producers legitimately exempt
Explicitly no-repo events, called out in commit body:
- `brain.go checkBackpressureRecovery` — `brain.recovery` system queue drain.
- `slack_events.go buildDispatchBlocks` — Slack meta-command.
- `webhook.go` slack action handlers (`switch_tier`, `merge_pr`) — global tier switches / PR IDs, not repo-scoped.
- `chains.go TriggerChains` — completion chains; caller doesn't thread a repo. Could be plumbed later through the worker, out of scope.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/dispatch/...` — 384/384 pass.
- [x] New test `TestDispatch_RejectsRepoScopedEventWithEmptyRepo` — asserts a `brain.leverage` event with empty `Repo` is rejected with clear telemetry.
- [x] New test `TestDispatch_AcceptsExemptEventWithEmptyRepo` — confirms `EventTimer` (system-wide) still dispatches without a `Repo`.

Refs: workspace#408