### PR TITLE
fix(telemetry): benchmark_status + health_report truthfulness

### DIFF
--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -1008,8 +1008,10 @@ type EnrichedHealthEntry struct {
 	Failures           int    `json:"failures"`
 	LastFailure        string `json:"last_failure,omitempty"`
 	LastSuccess        string `json:"last_success,omitempty"`
-	SecsSinceSuccess   int64  `json:"secs_since_last_success,omitempty"`
-	Recommendation     string `json:"recommendation"`
+	SecsSinceSuccess     int64  `json:"secs_since_last_success,omitempty"`
+	DaysSinceLastSuccess int    `json:"days_since_last_success"`
+	Stale                bool   `json:"stale"`
+	Recommendation       string `json:"recommendation"`
 }
 
 // enrichHealthReport adds derived fields to each DriverHealth entry.
@@ -1030,11 +1032,22 @@ func enrichHealthReport(drivers []routing.DriverHealth) []EnrichedHealthEntry {
 				e.SecsSinceSuccess = int64(now.Sub(t).Seconds())
 			}
 		}
+		e.DaysSinceLastSuccess = d.DaysSinceLastSuccess
+		// Stale = >=2d since last success, OR no recorded success at all.
+		// Stale drivers are unhealthy regardless of circuit state — a CLOSED
+		// circuit on a decommissioned driver is the classic false-positive.
+		e.Stale = (d.DaysSinceLastSuccess >= 2) || (d.LastSuccess == "" && d.DaysSinceLastSuccess == -1)
 
-		switch d.CircuitState {
-		case "OPEN":
+		switch {
+		case e.Stale && d.CircuitState != "OPEN":
+			if d.LastSuccess == "" {
+				e.Recommendation = fmt.Sprintf("%s: stale — no recorded success, investigate or remove", d.Name)
+			} else {
+				e.Recommendation = fmt.Sprintf("%s: stale — last success %dd ago, investigate or remove", d.Name, d.DaysSinceLastSuccess)
+			}
+		case d.CircuitState == "OPEN":
 			e.Recommendation = fmt.Sprintf("%s: budget exhausted or unreachable — check quota and reset circuit", d.Name)
-		case "HALF":
+		case d.CircuitState == "HALF":
 			e.Recommendation = fmt.Sprintf("%s: recovering — use with caution, monitor next run", d.Name)
 		default:
 			if e.SecsSinceSuccess > 3600 {

--- a/internal/routing/health.go
+++ b/internal/routing/health.go
@@ -46,7 +46,21 @@ func ReadDriverHealth(healthDir, driver string) DriverHealth {
 	dh.LastSuccess = hf.LastSuccess
 	dh.OpenedAt = hf.OpenedAt
 	dh.LastSuccessAgo = humanAgo(hf.LastSuccess)
+	dh.DaysSinceLastSuccess = daysSince(hf.LastSuccess)
 	return dh
+}
+
+// daysSince returns whole-day count since an RFC3339 timestamp. Returns -1
+// when the timestamp is empty or unparseable.
+func daysSince(ts string) int {
+	if ts == "" {
+		return -1
+	}
+	t, err := time.Parse(time.RFC3339, ts)
+	if err != nil {
+		return -1
+	}
+	return int(time.Since(t).Hours() / 24)
 }
 
 // humanAgo returns a human-readable duration since the given RFC3339 timestamp,

--- a/internal/routing/router.go
+++ b/internal/routing/router.go
@@ -68,6 +68,10 @@ type DriverHealth struct {
 	OpenedAt       string `json:"opened_at,omitempty"`
 	LastSuccessAgo string `json:"last_success_ago,omitempty"`
 
+	// DaysSinceLastSuccess is the integer day-count since LastSuccess. -1 means
+	// never succeeded. Populated by ReadDriverHealth.
+	DaysSinceLastSuccess int `json:"days_since_last_success"`
+
 	// BudgetPct is the estimated remaining budget percentage (0-100).
 	// nil means unknown. Populated from Redis by the MCP health_report handler.
 	BudgetPct *int `json:"budget_pct,omitempty"`
@@ -309,6 +313,12 @@ func tierIndex(t CostTier) int {
 // on its circuit state, age, and optional budget percentage.
 func RecommendAction(h DriverHealth) string {
 	budgetLow := h.BudgetPct != nil && *h.BudgetPct < 15
+
+	// Staleness trumps CLOSED/HALF: a circuit that never opened can still be
+	// decommissioned/unreachable. Flag when LastSuccess is set AND >=2d old.
+	if h.CircuitState != "OPEN" && h.LastSuccess != "" && h.DaysSinceLastSuccess >= 2 {
+		return fmt.Sprintf("stale — last success %dd ago, investigate or remove", h.DaysSinceLastSuccess)
+	}
 
 	switch h.CircuitState {
 	case "OPEN":

--- a/internal/routing/staleness_test.go
+++ b/internal/routing/staleness_test.go
@@ -1,0 +1,69 @@
+package routing
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestRecommendAction_Healthy(t *testing.T) {
+	h := DriverHealth{
+		CircuitState:         "CLOSED",
+		LastSuccess:          time.Now().UTC().Add(-10 * time.Minute).Format(time.RFC3339),
+		DaysSinceLastSuccess: 0,
+	}
+	if got := RecommendAction(h); got != "healthy" {
+		t.Fatalf("want healthy, got %q", got)
+	}
+}
+
+// Canonical decommissioned-driver bug: CLOSED circuit, 5d stale.
+func TestRecommendAction_StaleClosed(t *testing.T) {
+	h := DriverHealth{
+		CircuitState:         "CLOSED",
+		LastSuccess:          time.Now().UTC().Add(-5 * 24 * time.Hour).Format(time.RFC3339),
+		DaysSinceLastSuccess: 5,
+	}
+	got := RecommendAction(h)
+	if !strings.Contains(got, "stale") || !strings.Contains(got, "5d") {
+		t.Fatalf("expected stale+5d, got %q", got)
+	}
+}
+
+// New driver (empty LastSuccess) not library-stale; MCP layer judges.
+func TestRecommendAction_NewDriverNotStale(t *testing.T) {
+	h := DriverHealth{CircuitState: "CLOSED", LastSuccess: "", DaysSinceLastSuccess: -1}
+	if got := RecommendAction(h); strings.Contains(got, "stale") {
+		t.Fatalf("empty LastSuccess should not be library-stale, got %q", got)
+	}
+}
+
+func TestRecommendAction_OpenTrumpsStale(t *testing.T) {
+	h := DriverHealth{
+		CircuitState:         "OPEN",
+		LastSuccess:          time.Now().UTC().Add(-10 * 24 * time.Hour).Format(time.RFC3339),
+		DaysSinceLastSuccess: 10,
+		OpenedAt:             time.Now().UTC().Format(time.RFC3339),
+	}
+	got := RecommendAction(h)
+	if strings.Contains(got, "stale") {
+		t.Fatalf("OPEN should not report stale, got %q", got)
+	}
+}
+
+func TestReadDriverHealth_DaysSinceLastSuccess(t *testing.T) {
+	dir := t.TempDir()
+	ts := time.Now().UTC().Add(-3 * 24 * time.Hour).Format(time.RFC3339)
+	if err := WriteHealthFile(dir, "stale-driver", HealthFile{State: "CLOSED", LastSuccess: ts}); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if got := ReadDriverHealth(dir, "stale-driver"); got.DaysSinceLastSuccess != 3 {
+		t.Fatalf("want 3 days, got %d", got.DaysSinceLastSuccess)
+	}
+	if err := WriteHealthFile(dir, "never-ran", HealthFile{State: "CLOSED"}); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if got := ReadDriverHealth(dir, "never-ran"); got.DaysSinceLastSuccess != -1 {
+		t.Fatalf("want -1, got %d", got.DaysSinceLastSuccess)
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `DaysSinceLastSuccess` to `DriverHealth` and a `Stale` flag on the MCP `EnrichedHealthEntry`.
- A CLOSED circuit on a driver with no success in >=48h now reports `"stale — investigate or remove"` instead of falsely claiming healthy (the canonical decommissioned-driver bug from audit #225).
- `benchmark_status` was already wired to real Redis sources (`worker-results`, `dispatch-log`, `kernel-health`). The audit's "all zeros" output reflects empty Redis in local dev, not a code bug; no change needed there.

## Behavior change
- `routing.RecommendAction`: stale check fires when `CircuitState != OPEN` AND `LastSuccess` is set AND `DaysSinceLastSuccess >= 2`. Newly-registered drivers (empty `LastSuccess`) remain library-healthy so on-disk library stays conservative.
- `mcp.enrichHealthReport` (MCP layer, richer context): also flags `Stale = true` for drivers with no recorded success at all, emits `"stale — no recorded success"`.

## Sample: stale driver now correctly flagged
Given a driver `codex` with `state: CLOSED, last_success: 2026-04-10` (4d ago), `health_report` now returns:
```json
{"name":"codex","circuit_state":"CLOSED","days_since_last_success":4,"stale":true,"recommendation":"codex: stale — last success 4d ago, investigate or remove"}
```
Previously: `"recommendation":"codex: healthy"` — false positive.

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./internal/routing/ ./internal/mcp/` passes (5 new tests in `staleness_test.go`)
- [ ] Deploy + spot-check `mcp__octi__health_report` against a real fleet with at least one decommissioned driver

Refs chitinhq/workspace#408.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>