### PR TITLE
fix(leaderboard): wire dispatch sink so agent_leaderboard isn't empty

### DIFF
--- a/internal/dispatch/agent_stats.go
+++ b/internal/dispatch/agent_stats.go
@@ -1,0 +1,113 @@
+package dispatch
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"time"
+)
+
+// AgentStats is the per-agent productivity counter record stored in Redis as a hash.
+//
+// Redis key schema: {namespace}:agent_stats:{agent}
+// Fields:
+//
+//	dispatches_total   — counter, incremented on every successful Dispatch
+//	successes_total    — counter, incremented on completion with exit_code=0 && had_commits
+//	last_pr_merged_at  — RFC3339 timestamp of last successful completion
+//	last_pr_url        — URL of the last merged PR (optional, may be empty)
+//
+// This is the sink that powers agent_leaderboard. Prior to this, RecordRun was the
+// only writer and only fired from octi-worker — meaning leaderboard was empty in
+// production where dispatches go to GitHub Actions / Anthropic API.
+type AgentStats struct {
+	Agent           string `json:"agent"`
+	DispatchesTotal int64  `json:"dispatches_total"`
+	SuccessesTotal  int64  `json:"successes_total"`
+	LastPRMergedAt  string `json:"last_pr_merged_at,omitempty"`
+	LastPRURL       string `json:"last_pr_url,omitempty"`
+}
+
+// SuccessRate returns successes_total / dispatches_total, or 0 if no dispatches.
+func (s AgentStats) SuccessRate() float64 {
+	if s.DispatchesTotal == 0 {
+		return 0
+	}
+	return float64(s.SuccessesTotal) / float64(s.DispatchesTotal)
+}
+
+func (ps *ProfileStore) statsKey(agent string) string {
+	return ps.namespace + ":agent_stats:" + agent
+}
+
+// RecordDispatch increments the dispatches_total counter for an agent.
+// Called from Dispatcher.Dispatch after a successful dispatch (action="dispatched").
+func (ps *ProfileStore) RecordDispatch(ctx context.Context, agent string) error {
+	if ps == nil || ps.rdb == nil || agent == "" {
+		return nil
+	}
+	return ps.rdb.HIncrBy(ctx, ps.statsKey(agent), "dispatches_total", 1).Err()
+}
+
+// RecordSuccess increments the successes_total counter and records the merge timestamp + PR URL.
+// Called from Dispatcher.RecordWorkerResult on a successful run with commits.
+// prURL may be empty (we don't always know the PR at completion time).
+func (ps *ProfileStore) RecordSuccess(ctx context.Context, agent string, prURL string) error {
+	if ps == nil || ps.rdb == nil || agent == "" {
+		return nil
+	}
+	pipe := ps.rdb.Pipeline()
+	pipe.HIncrBy(ctx, ps.statsKey(agent), "successes_total", 1)
+	pipe.HSet(ctx, ps.statsKey(agent), "last_pr_merged_at", time.Now().UTC().Format(time.RFC3339))
+	if prURL != "" {
+		pipe.HSet(ctx, ps.statsKey(agent), "last_pr_url", prURL)
+	}
+	_, err := pipe.Exec(ctx)
+	return err
+}
+
+// GetStats reads the agent_stats hash for one agent.
+func (ps *ProfileStore) GetStats(ctx context.Context, agent string) (AgentStats, error) {
+	stats := AgentStats{Agent: agent}
+	if ps == nil || ps.rdb == nil {
+		return stats, nil
+	}
+	m, err := ps.rdb.HGetAll(ctx, ps.statsKey(agent)).Result()
+	if err != nil {
+		return stats, fmt.Errorf("hgetall agent_stats %s: %w", agent, err)
+	}
+	if v, ok := m["dispatches_total"]; ok {
+		stats.DispatchesTotal, _ = strconv.ParseInt(v, 10, 64)
+	}
+	if v, ok := m["successes_total"]; ok {
+		stats.SuccessesTotal, _ = strconv.ParseInt(v, 10, 64)
+	}
+	stats.LastPRMergedAt = m["last_pr_merged_at"]
+	stats.LastPRURL = m["last_pr_url"]
+	return stats, nil
+}
+
+// AllStats scans every agent_stats hash in this namespace.
+func (ps *ProfileStore) AllStats(ctx context.Context) (map[string]AgentStats, error) {
+	out := map[string]AgentStats{}
+	if ps == nil || ps.rdb == nil {
+		return out, nil
+	}
+	pattern := ps.namespace + ":agent_stats:*"
+	prefix := ps.namespace + ":agent_stats:"
+
+	iter := ps.rdb.Scan(ctx, 0, pattern, 100).Iterator()
+	for iter.Next(ctx) {
+		key := iter.Val()
+		agent := key[len(prefix):]
+		stats, err := ps.GetStats(ctx, agent)
+		if err != nil {
+			continue
+		}
+		out[agent] = stats
+	}
+	if err := iter.Err(); err != nil {
+		return out, fmt.Errorf("scan agent_stats: %w", err)
+	}
+	return out, nil
+}

--- a/internal/dispatch/agent_stats_test.go
+++ b/internal/dispatch/agent_stats_test.go
@@ -1,0 +1,82 @@
+package dispatch
+
+import (
+	"testing"
+)
+
+func TestAgentStats_RecordDispatchAndSuccess(t *testing.T) {
+	d, ctx := testSetup(t)
+	ps := NewProfileStore(d.rdb, d.namespace, d.events.CooldownFor)
+
+	for i := 0; i < 3; i++ {
+		if err := ps.RecordDispatch(ctx, "agent-a"); err != nil {
+			t.Fatalf("record dispatch: %v", err)
+		}
+	}
+	if err := ps.RecordSuccess(ctx, "agent-a", "https://example/pr/1"); err != nil {
+		t.Fatalf("record success: %v", err)
+	}
+
+	s, err := ps.GetStats(ctx, "agent-a")
+	if err != nil {
+		t.Fatalf("get stats: %v", err)
+	}
+	if s.DispatchesTotal != 3 {
+		t.Fatalf("want 3 dispatches, got %d", s.DispatchesTotal)
+	}
+	if s.SuccessesTotal != 1 {
+		t.Fatalf("want 1 success, got %d", s.SuccessesTotal)
+	}
+	if s.LastPRURL != "https://example/pr/1" {
+		t.Fatalf("want pr url, got %q", s.LastPRURL)
+	}
+	if s.LastPRMergedAt == "" {
+		t.Fatalf("want timestamp, got empty")
+	}
+	if rate := s.SuccessRate(); rate < 0.33 || rate > 0.34 {
+		t.Fatalf("want success rate ~0.333, got %.3f", rate)
+	}
+}
+
+func TestLeaderboard_IncludesStatsOnlyAgents(t *testing.T) {
+	d, ctx := testSetup(t)
+	ps := NewProfileStore(d.rdb, d.namespace, d.events.CooldownFor)
+
+	// Three agents, dispatch-only (no RecordRun completion callbacks).
+	// agent-high: 10 dispatches, 5 successes -> score 25.0 + 1.0 = 26.0
+	// agent-mid:  5 dispatches,  1 success   -> score 5.0 + 0.5 = 5.5
+	// agent-low:  2 dispatches,  0 successes -> score 0 + 0.2 = 0.2
+	for i := 0; i < 10; i++ {
+		ps.RecordDispatch(ctx, "agent-high")
+	}
+	for i := 0; i < 5; i++ {
+		ps.RecordSuccess(ctx, "agent-high", "")
+	}
+	for i := 0; i < 5; i++ {
+		ps.RecordDispatch(ctx, "agent-mid")
+	}
+	ps.RecordSuccess(ctx, "agent-mid", "")
+	for i := 0; i < 2; i++ {
+		ps.RecordDispatch(ctx, "agent-low")
+	}
+
+	entries, err := ps.Leaderboard(ctx)
+	if err != nil {
+		t.Fatalf("leaderboard: %v", err)
+	}
+	if len(entries) != 3 {
+		t.Fatalf("want 3 entries, got %d: %+v", len(entries), entries)
+	}
+	if entries[0].Agent != "agent-high" {
+		t.Fatalf("want agent-high first, got %s", entries[0].Agent)
+	}
+	if entries[1].Agent != "agent-mid" {
+		t.Fatalf("want agent-mid second, got %s", entries[1].Agent)
+	}
+	if entries[2].Agent != "agent-low" {
+		t.Fatalf("want agent-low third, got %s", entries[2].Agent)
+	}
+	if entries[0].Rank != 1 || entries[2].Rank != 3 {
+		t.Fatalf("ranks not assigned: %+v", entries)
+	}
+}

--- a/internal/dispatch/dispatcher.go
+++ b/internal/dispatch/dispatcher.go
@@ -204,6 +204,14 @@ func (d *Dispatcher) DispatchBudget(ctx context.Context, event Event, agentName 
 	result.QueuePos = queueDepth
 
 	d.recordDispatch(ctx, agentName, event, result)
+
+	// Wire agent_leaderboard sink: increment dispatches_total counter so the
+	// MCP leaderboard tool has something to report even when the completion
+	// callback (RecordWorkerResult) never fires — which is the norm for
+	// GH-Actions and Anthropic-API drivers. See workspace#408.
+	if d.profiles != nil {
+		_ = d.profiles.RecordDispatch(ctx, agentName)
+	}
 	return result, nil
 }
 
@@ -333,6 +341,11 @@ func (d *Dispatcher) RecordWorkerResult(ctx context.Context, agentName string, e
 			HadCommits: hadCommits,
 			Timestamp:  now.Format(time.RFC3339),
 		})
+		// Leaderboard sink: on a real successful run (exit=0 + commits), bump the
+		// successes_total counter + timestamp so agent_leaderboard can surface it.
+		if exitCode == 0 && hadCommits {
+			_ = d.profiles.RecordSuccess(ctx, agentName, "")
+		}
 	}
 }
 

--- a/internal/dispatch/leaderboard.go
+++ b/internal/dispatch/leaderboard.go
@@ -77,19 +77,23 @@ func scoreVerdict(score float64, triageFlag bool) string {
 	}
 }
 
-// Leaderboard ranks all agents with run history by productivity score (highest first).
-// Agents with no recorded runs are omitted.
+// Leaderboard ranks all agents by productivity score (highest first). Agents with
+// only dispatch-counter stats (no completion callbacks) are included with a
+// stats-derived score so production dispatches to GH Actions / Anthropic
+// (which never call RecordWorkerResult) still show up. See workspace#408.
 func (ps *ProfileStore) Leaderboard(ctx context.Context) ([]LeaderboardEntry, error) {
 	profiles, err := ps.AllProfiles(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("leaderboard: %w", err)
 	}
 
+	seen := make(map[string]bool, len(profiles))
 	entries := make([]LeaderboardEntry, 0, len(profiles))
 	for _, p := range profiles {
 		if len(p.RecentResults) == 0 {
 			continue
 		}
+		seen[p.Name] = true
 		s := round2(Score(p))
 		entries = append(entries, LeaderboardEntry{
 			Agent:       p.Name,
@@ -102,6 +106,26 @@ func (ps *ProfileStore) Leaderboard(ctx context.Context) ([]LeaderboardEntry, er
 			TriageFlag:  p.TriageFlag,
 			RunCount:    len(p.RecentResults),
 		})
+	}
+
+	// Fold in agents known only via the agent_stats hash (dispatches-only, no
+	// completion callbacks). Score = successes*5 + dispatches*0.1 so a
+	// dispatched-but-never-completed agent ranks above absent but below a
+	// confirmed-successful one.
+	if stats, statsErr := ps.AllStats(ctx); statsErr == nil {
+		for name, s := range stats {
+			if seen[name] || s.DispatchesTotal == 0 {
+				continue
+			}
+			score := round2(float64(s.SuccessesTotal)*5.0 + float64(s.DispatchesTotal)*0.1)
+			entries = append(entries, LeaderboardEntry{
+				Agent:      name,
+				Score:      score,
+				Verdict:    scoreVerdict(score, false),
+				AvgCommits: round2(s.SuccessRate()),
+				RunCount:   int(s.DispatchesTotal),
+			})
+		}
 	}
 
 	sort.Slice(entries, func(i, j int) bool {


### PR DESCRIPTION
## Summary

turing's audit ([octi#225](https://github.com/chitinhq/octi-pulpo/issues/225) / workspace#408) found `agent_leaderboard` permanently empty despite 19 dispatches in Redis. The sink was unwired: the only writer into `ProfileStore` was `RecordRun`, called from `octi-worker` — which never runs in production where dispatches go to GitHub Actions / Anthropic API.

## Change

Introduces `internal/dispatch/agent_stats.go` — an always-on Redis-hash sink wired into the dispatch path:

```
{namespace}:agent_stats:{agent}
  dispatches_total   HINCRBY on every action="dispatched"
  successes_total    HINCRBY on exit=0 && had_commits
  last_pr_merged_at  RFC3339
  last_pr_url        optional
```

- `Dispatcher.Dispatch` now calls `profiles.RecordDispatch(agent)` after the existing `recordDispatch` log write.
- `Dispatcher.RecordWorkerResult` calls `profiles.RecordSuccess` on confirmed successful runs.
- `Leaderboard()` folds stats-only agents into its output with score = `successes*5 + dispatches*0.1`, so production agents (no completion callbacks) rank above absent but below profile-backed.

## Retroactive fill

The existing `dispatch-log` list (LRange key used by `RecentDispatches`) contains the 19 stale dispatch records keyed by agent — a one-shot script could replay those into the new hash without code changes. Not included in this PR; filed as a follow-up.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` (785 passed)
- [x] New test `TestAgentStats_RecordDispatchAndSuccess` — counters + schema
- [x] New test `TestLeaderboard_IncludesStatsOnlyAgents` — 3-agent ordering

Refs: workspace#408, octi#225

🤖 Generated with [Claude Code](https://claude.com/claude-code)