### PR TITLE
chore(health): prune orphan driver health files

### DIFF
--- a/cmd/octi-pulpo/main.go
+++ b/cmd/octi-pulpo/main.go
@@ -73,6 +73,22 @@ func main() {
 	healthDir := os.Getenv("CHITIN_HEALTH_DIR")
 	router := routing.NewRouter(healthDir) // defaults to ~/.chitin/driver-health/
 
+	// Orphan health sweep: report (and optionally delete) health files for
+	// drivers that are no longer in the driverTiers registry. Ladder Forge II
+	// (2026-04-14) pruned 8 drivers from the router but left their .json files
+	// on disk, where they surfaced in health_report as stale. Default is
+	// log-only; set OCTI_PRUNE_ORPHAN_HEALTH=1 to actually delete.
+	pruneOrphans := os.Getenv("OCTI_PRUNE_ORPHAN_HEALTH") == "1"
+	if orphans, err := router.PruneOrphanHealth(pruneOrphans); err != nil {
+		fmt.Fprintf(os.Stderr, "octi-pulpo: orphan health sweep: %v\n", err)
+	} else if len(orphans) > 0 {
+		if pruneOrphans {
+			fmt.Fprintf(os.Stderr, "octi-pulpo: deleted %d orphan health files: %v\n", len(orphans), orphans)
+		} else {
+			fmt.Fprintf(os.Stderr, "octi-pulpo: WARNING — %d orphan health files in %s: %v (set OCTI_PRUNE_ORPHAN_HEALTH=1 to delete)\n", len(orphans), router.HealthDir(), orphans)
+		}
+	}
+
 	// Set up the event-driven dispatcher
 	opts, err := redis.ParseURL(redisURL)
 	if err != nil {

--- a/internal/routing/prune_orphan_test.go
+++ b/internal/routing/prune_orphan_test.go
@@ -1,0 +1,70 @@
+package routing
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+)
+
+func TestPruneOrphanHealth(t *testing.T) {
+	dir := t.TempDir()
+	// Known driver (in tiers map)
+	writeJSON(t, dir, "clawta.json", `{"state":"CLOSED"}`)
+	// Orphans (pruned in Ladder Forge II)
+	writeJSON(t, dir, "claude-code.json", `{"state":"OPEN"}`)
+	writeJSON(t, dir, "copilot.json", `{"state":"OPEN"}`)
+	writeJSON(t, dir, "goose.json", `{"state":"OPEN"}`)
+
+	tiers := map[string]CostTier{"clawta": TierLocal}
+	r := NewRouterWithTiers(dir, tiers)
+
+	// Dry run: report but don't delete
+	orphans, err := r.PruneOrphanHealth(false)
+	if err != nil {
+		t.Fatalf("dry-run: %v", err)
+	}
+	sort.Strings(orphans)
+	want := []string{"claude-code", "copilot", "goose"}
+	if len(orphans) != 3 || orphans[0] != want[0] || orphans[1] != want[1] || orphans[2] != want[2] {
+		t.Fatalf("dry-run orphans = %v, want %v", orphans, want)
+	}
+	// Files should still exist
+	if _, err := os.Stat(filepath.Join(dir, "copilot.json")); err != nil {
+		t.Fatalf("dry-run should not delete: %v", err)
+	}
+
+	// Real run: delete
+	orphans, err = r.PruneOrphanHealth(true)
+	if err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	if len(orphans) != 3 {
+		t.Fatalf("delete orphans = %v, want 3", orphans)
+	}
+	for _, name := range want {
+		if _, err := os.Stat(filepath.Join(dir, name+".json")); !os.IsNotExist(err) {
+			t.Fatalf("expected %s deleted, stat err = %v", name, err)
+		}
+	}
+	// Known driver survived
+	if _, err := os.Stat(filepath.Join(dir, "clawta.json")); err != nil {
+		t.Fatalf("known driver deleted: %v", err)
+	}
+
+	// Idempotent
+	orphans, err = r.PruneOrphanHealth(true)
+	if err != nil {
+		t.Fatalf("idempotent: %v", err)
+	}
+	if len(orphans) != 0 {
+		t.Fatalf("second run orphans = %v, want empty", orphans)
+	}
+}
+
+func writeJSON(t *testing.T, dir, name, body string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/routing/router.go
+++ b/internal/routing/router.go
@@ -208,6 +208,33 @@ func (r *Router) HealthDir() string {
 	return r.healthDir
 }
 
+// PruneOrphanHealth scans the health directory for files whose driver name is
+// not present in the router's tier map. If delete is true, orphan files are
+// removed from disk; otherwise they are only reported. Returns the list of
+// orphan driver names discovered (regardless of delete flag).
+//
+// Use this on boot to keep ~/.chitin/driver-health/ in sync with the
+// driverTiers registry — pruned drivers (e.g. Ladder Forge II) leave behind
+// stale .json files that surface in health_report and bootcheck as
+// "unknown driver" noise.
+func (r *Router) PruneOrphanHealth(delete bool) ([]string, error) {
+	discovered := DiscoverDrivers(r.healthDir)
+	var orphans []string
+	for _, name := range discovered {
+		if _, known := r.tiers[name]; known {
+			continue
+		}
+		orphans = append(orphans, name)
+		if delete {
+			path := filepath.Join(r.healthDir, name+".json")
+			if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+				return orphans, fmt.Errorf("remove orphan %s: %w", path, err)
+			}
+		}
+	}
+	return orphans, nil
+}
+
 // ForceClose manually resets a driver circuit to CLOSED with zero failures.
 // Returns an error if no health file exists for the driver (nothing to reset).
 // On success returns the new DriverHealth state.


### PR DESCRIPTION
## Summary

Ladder Forge II (#223) pruned 8 drivers from octi's `driverTiers` map, but their `.json` health files stayed on disk and surfaced in `health_report` + bootcheck as stale.

- `Router.PruneOrphanHealth(delete bool)` — reports (and optionally deletes) health files whose driver name is no longer in `driverTiers`.
- `octi-pulpo` startup sweep — always logs orphans; deletes only when `OCTI_PRUNE_ORPHAN_HEALTH=1` (safe default — log-only).
- Unit test covers dry-run, delete, idempotency, and known-driver preservation.

Refs workspace#408.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` (all green)
- [ ] On a host with orphan files, boot pulpo and confirm WARNING log lists them
- [ ] Set `OCTI_PRUNE_ORPHAN_HEALTH=1`, reboot, confirm files gone + `health_report_fresh` goes GREEN

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>