### PR TITLE
fix(bootcheck): empty driver name display bug

### DIFF
--- a/internal/bootcheck/bootcheck.go
+++ b/internal/bootcheck/bootcheck.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log"
 	"strings"
 	"sync"
 	"time"
@@ -145,6 +146,14 @@ func checkHealthFresh(ctx context.Context, d Deps, now func() time.Time) Result 
 	}
 	var stale []string
 	for _, h := range report {
+		if h.Name == "" {
+			// Defensive: a corrupt/legacy health file produced an entry with no
+			// driver name. Log and skip so it doesn't surface as a ghost in the
+			// bootcheck output (see workspace#408). Source file should be
+			// cleaned up by hopper's orphan-cleanup pass.
+			log.Printf("bootcheck: skipping health entry with empty driver name in %s (corrupt file; flag for orphan-cleanup)", d.Router.HealthDir())
+			continue
+		}
 		if h.CircuitState != "CLOSED" {
 			continue
 		}

--- a/internal/bootcheck/bootcheck_test.go
+++ b/internal/bootcheck/bootcheck_test.go
@@ -128,6 +128,33 @@ func TestCheckHealthFresh_StaleClosedIsLie(t *testing.T) {
 	}
 }
 
+func TestCheckHealthFresh_EmptyNameStemIsSkipped(t *testing.T) {
+	// Regression: a file literally named ".json" (empty stem) used to surface
+	// as an empty-name ghost entry like " (never-succeeded)" in the bootcheck
+	// output. It must be skipped at the discovery layer.
+	dir := t.TempDir()
+	// Write a corrupt stemless health file and a valid one alongside it.
+	if err := os.WriteFile(dir+"/.json", []byte(`{"state":"CLOSED"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	hf := routing.HealthFile{
+		State:       "CLOSED",
+		LastSuccess: time.Now().UTC().Add(-1 * time.Hour).Format(time.RFC3339),
+		Updated:     time.Now().UTC().Format(time.RFC3339),
+	}
+	if err := routing.WriteDriverHealthFile(dir, "claude-code", hf); err != nil {
+		t.Fatal(err)
+	}
+	r := routing.NewRouter(dir)
+	res := checkHealthFresh(context.Background(), Deps{Router: r}, time.Now)
+	if res.Status != StatusGreen {
+		t.Fatalf("expected green (ghost skipped), got %s: %s", res.Status, res.Message)
+	}
+	if strings.Contains(res.Message, " (never-succeeded)") {
+		t.Fatalf("output leaked empty-name ghost entry: %q", res.Message)
+	}
+}
+
 func TestCheckHealthFresh_NoDrivers(t *testing.T) {
 	r := routing.NewRouter(t.TempDir())
 	res := checkHealthFresh(context.Background(), Deps{Router: r}, time.Now)

--- a/internal/routing/health.go
+++ b/internal/routing/health.go
@@ -101,7 +101,13 @@ func DiscoverDrivers(healthDir string) []string {
 		}
 		name := e.Name()
 		if strings.HasSuffix(name, ".json") {
-			drivers = append(drivers, strings.TrimSuffix(name, ".json"))
+			stem := strings.TrimSuffix(name, ".json")
+			if stem == "" {
+				// Skip files with no driver-name stem (e.g., ".json") — these
+				// would surface as empty-name ghosts in health reports.
+				continue
+			}
+			drivers = append(drivers, stem)
 		}
 	}
 	return drivers


### PR DESCRIPTION
## Summary

- PR #235 (bootcheck) shipped clean, but running it surfaced a minor display bug: ``stale CLOSED drivers:  (never-succeeded), openclaw (never-succeeded)`` — an empty driver name before the first comma.
- Root cause: ``routing.DiscoverDrivers`` treats any ``*.json`` file as a driver, including a stemless ``.json`` file which produces an empty driver name after ``TrimSuffix``. That ghost entry then flows through ``HealthReport()`` into the bootcheck output.
- Fix at two layers:
  - ``routing.DiscoverDrivers``: skip ``.json`` files with an empty stem so they never enter ``HealthReport()``.
  - ``bootcheck.checkHealthFresh``: defensively skip any entry with empty ``Name`` and ``log.Printf`` a warning pointing at the health dir, so hopper's orphan-cleanup can sweep the corrupt file.

Refs chitinhq/workspace#408.

## Test plan

- [x] New regression test ``TestCheckHealthFresh_EmptyNameStemIsSkipped`` writes both a ``.json``-stemmed corrupt file and a valid driver file; asserts green status and no ``(never-succeeded)`` leak.
- [x] ``go build ./...`` clean
- [x] ``go test ./...`` clean (all packages green)

## Environment note

In my local ``~/.chitin/driver-health/`` only ``openclaw.json`` exists (no ``name`` field in payload but filename-derived name works fine). The original reported ghost must have come from a transient ``.json``-named file on another box; the fix is defensive either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)