### PR TITLE
chore(mcp): GITHUB_TOKEN env wiring for octi-pulpo

### DIFF
--- a/scripts/octi-pulpo-mcp.sh
+++ b/scripts/octi-pulpo-mcp.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# octi-pulpo-mcp.sh — wrapper that ensures GITHUB_TOKEN (and related env) is
+# populated before exec'ing the octi-pulpo binary as an MCP server.
+#
+# Claude Code spawns MCP servers in a stripped environment — it inherits only
+# what the parent shell exports AND what the server's `.mcp.json` env block
+# declares. Interactive shells typically rely on `gh auth` or a gitignored
+# env file for GITHUB_TOKEN, which the spawn environment doesn't see. Without
+# GITHUB_TOKEN, bootcheck's `adapter_reachability` probe stays YELLOW.
+#
+# This wrapper resolves the token from the first available source:
+#   1. $GITHUB_TOKEN (already set — honored as-is)
+#   2. $COPILOT_PAT  (legacy name, same scope)
+#   3. ~/.config/octi/env (gitignored KEY=VALUE file the user maintains)
+#   4. `gh auth token` (if the gh CLI is authenticated)
+#   5. ~/.config/gh/hosts.yml oauth_token (fallback for old gh versions)
+#
+# Format of ~/.config/octi/env (create it yourself — never commit):
+#   GITHUB_TOKEN=ghp_xxx
+#   # optional extras:
+#   # ANTHROPIC_API_KEY=sk-ant-xxx
+#
+# Permissions: chmod 600 ~/.config/octi/env
+
+set -euo pipefail
+
+# 3) gitignored env file
+ENV_FILE="${OCTI_ENV_FILE:-${HOME}/.config/octi/env}"
+if [ -z "${GITHUB_TOKEN:-}" ] && [ -f "${ENV_FILE}" ]; then
+  set -a
+  # shellcheck disable=SC1090
+  source "${ENV_FILE}"
+  set +a
+fi
+
+# 2) COPILOT_PAT legacy alias
+if [ -z "${GITHUB_TOKEN:-}" ] && [ -n "${COPILOT_PAT:-}" ]; then
+  export GITHUB_TOKEN="${COPILOT_PAT}"
+fi
+
+# 4) gh CLI (modern)
+if [ -z "${GITHUB_TOKEN:-}" ] && command -v gh >/dev/null 2>&1; then
+  if tok="$(gh auth token 2>/dev/null)" && [ -n "${tok}" ]; then
+    export GITHUB_TOKEN="${tok}"
+  fi
+fi
+
+# 5) gh hosts.yml fallback (pre-2.x gh lacks `auth token`)
+if [ -z "${GITHUB_TOKEN:-}" ]; then
+  HOSTS_YML="${HOME}/.config/gh/hosts.yml"
+  if [ -f "${HOSTS_YML}" ]; then
+    tok="$(awk '/oauth_token:/ {print $2; exit}' "${HOSTS_YML}" 2>/dev/null || true)"
+    if [ -n "${tok}" ]; then
+      export GITHUB_TOKEN="${tok}"
+    fi
+  fi
+fi
+
+# Default MCP env (mirrors wire-mcp.sh)
+export OCTI_REDIS_URL="${OCTI_REDIS_URL:-redis://localhost:6379}"
+export OCTI_NAMESPACE="${OCTI_NAMESPACE:-octi}"
+
+BINARY="${OCTI_PULPO_BIN:-${HOME}/.chitin/bin/octi-pulpo}"
+if [ ! -x "${BINARY}" ]; then
+  # Fallback to workspace build path
+  ALT="${HOME}/workspace/octi/bin/octi-pulpo"
+  if [ -x "${ALT}" ]; then
+    BINARY="${ALT}"
+  else
+    echo "ERROR: octi-pulpo binary not found at ${BINARY} or ${ALT}" >&2
+    exit 1
+  fi
+fi
+
+exec "${BINARY}" "$@"

--- a/scripts/wire-mcp.sh
+++ b/scripts/wire-mcp.sh
@@ -15,10 +15,18 @@ INSTALL_DIR="${INSTALL_DIR:-${HOME}/.chitin/bin}"
 BINARY="${INSTALL_DIR}/octi-pulpo"
 WORKSPACE="${CHITIN_WORKSPACE:-${HOME}/workspace}"
 SETTINGS="${WORKSPACE}/.claude/settings.json"
+# Wrapper resolves GITHUB_TOKEN from gh/env-file so MCP spawns can reach GH.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WRAPPER="${SCRIPT_DIR}/octi-pulpo-mcp.sh"
 
 if [ ! -f "${BINARY}" ]; then
   echo "ERROR: octi-pulpo binary not found at ${BINARY}" >&2
   echo "Run 'make install' or 'make wire-mcp' first." >&2
+  exit 1
+fi
+
+if [ ! -x "${WRAPPER}" ]; then
+  echo "ERROR: MCP wrapper not found or not executable: ${WRAPPER}" >&2
   exit 1
 fi
 
@@ -32,13 +40,16 @@ if ! command -v jq &>/dev/null; then
   exit 1
 fi
 
-# Build the mcpServers entry.
+# Build the mcpServers entry. The wrapper script resolves GITHUB_TOKEN from
+# the user's gh auth / ~/.config/octi/env so the GH adapter can actually probe
+# (bootcheck adapter_reachability flips YELLOW → GREEN).
 MCP_ENTRY=$(cat <<EOF
 {
-  "command": "${BINARY}",
+  "command": "${WRAPPER}",
   "env": {
     "OCTI_REDIS_URL": "redis://localhost:6379",
-    "OCTI_NAMESPACE": "octi"
+    "OCTI_NAMESPACE": "octi",
+    "OCTI_PULPO_BIN": "${BINARY}"
   }
 }
 EOF


### PR DESCRIPTION
## Summary

Closes the gap where bootcheck reports `adapter_reachability: YELLOW — no GH token configured; skipped`. octi-pulpo runs as an MCP server spawned by Claude Code in a stripped environment; GITHUB_TOKEN from the interactive shell doesn't propagate, so the GH adapter can't probe.

**Method: wrapper script (Option B).** `.mcp.json` doesn't reliably expand `${VAR}` refs across Claude Code versions, and the workspace-level `.mcp.json` isn't tracked in this repo. A wrapper is more robust and self-contained.

## Changes

- `scripts/octi-pulpo-mcp.sh` (new) — resolves `GITHUB_TOKEN` from (in order):
  1. existing env var
  2. `$COPILOT_PAT` (legacy alias, mirrors `start.sh`)
  3. `~/.config/octi/env` (gitignored KEY=VALUE file — user-maintained, never committed)
  4. `gh auth token`
  5. `~/.config/gh/hosts.yml` `oauth_token:` (fallback for old gh)
  Then `exec`s the real binary (`$OCTI_PULPO_BIN` or default paths).
- `scripts/wire-mcp.sh` — now registers the wrapper (not the raw binary) as the MCP command, and passes `OCTI_PULPO_BIN` via the env block.

No token is committed. The gitignored `~/.config/octi/env` format is documented inline in the wrapper.

## User action required after merge

1. Rebuild/install: `make install && bash scripts/wire-mcp.sh`
2. Ensure `gh auth status` is green, OR create `~/.config/octi/env` with `GITHUB_TOKEN=...` (`chmod 600`).
3. Restart Claude Code.

After restart, bootcheck's `adapter_reachability` will flip **YELLOW → GREEN** (assuming the token has the expected repo scopes — the probe itself already lives in `internal/bootcheck/bootcheck.go:187`, gated only on `d.GitHubToken != ""`, which is sourced from `os.Getenv("GITHUB_TOKEN")` at `cmd/octi-pulpo/main.go:169`).

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./...` all packages pass
- [x] `bash -n` on both scripts
- [ ] Manual: rerun `wire-mcp.sh`, restart Claude Code, confirm bootcheck GREEN

Refs workspace#408.

🤖 Generated with [Claude Code](https://claude.com/claude-code)