### PR TITLE
fix(dispatcher): honest-dispatch for copilot_cli adapter (silent-loss #242)

### DIFF
--- a/internal/dispatch/copilot_cli_adapter.go
+++ b/internal/dispatch/copilot_cli_adapter.go
@@ -140,11 +140,21 @@ func (a *CopilotCLIAdapter) Dispatch(ctx context.Context, task *Task) (*AdapterR
 	}
 
 	// Push branch and open PR if Copilot produced commits.
+	//
+	// Honest-dispatch contract (refs: chitinhq/octi#242, chitinhq/octi#245,
+	// workspace#408): Status="completed" must mean the agent's work reached
+	// an observable surface (PR on origin). If `git push` or `gh pr create`
+	// fails, revert Status to "failed" so the outer dispatcher in
+	// dispatcher.go:264 maps it to Action="failed" instead of silently
+	// claiming Action="dispatched" on a branch the remote never saw — the
+	// worktree is about to be torn down by `cleanupWorktree`, so any such
+	// claim is a silent loss.
 	if result.Status == "completed" {
 		if hasNewCommits(worktreePath, "origin/"+defaultBranch) {
 			pushCmd := exec.CommandContext(ctx, "git", "push", "-u", "origin", branchName)
 			pushCmd.Dir = worktreePath
 			if pushOut, pushErr := pushCmd.CombinedOutput(); pushErr != nil {
+				result.Status = "failed"
 				result.Error = fmt.Sprintf("push failed: %s: %s", pushErr, string(pushOut))
 			} else {
 				prTitle := truncate(task.Prompt, 60)
@@ -157,6 +167,7 @@ func (a *CopilotCLIAdapter) Dispatch(ctx context.Context, task *Task) (*AdapterR
 				)
 				prCmd.Dir = worktreePath
 				if prOut, prErr := prCmd.CombinedOutput(); prErr != nil {
+					result.Status = "failed"
 					result.Error = fmt.Sprintf("pr create failed: %s: %s", prErr, string(prOut))
 				} else {
 					result.Output = string(prOut)

--- a/internal/dispatch/copilot_cli_adapter_silentloss_test.go
+++ b/internal/dispatch/copilot_cli_adapter_silentloss_test.go
@@ -1,0 +1,132 @@
+package dispatch
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestCopilotCLIAdapter_Dispatch_PushFailure_SilentLossRegression pins the
+// honest-dispatch contract for the copilot_cli adapter: when the agent CLI
+// exits 0 AND produces a commit, but `git push` to origin fails, the adapter
+// MUST return Status="failed" (NOT "completed"). Before chitinhq/octi#242's
+// fix, Status was set to "completed" on CLI exit 0 and never reverted on push
+// failure — the outer dispatcher (dispatcher.go:264) then mapped that to
+// Action="dispatched" while the worktree was being torn down by
+// cleanupWorktree, silently dropping the work. Mirrors the shape of
+// TestDispatchBudget_CallsAdapter_SilentLossRegression from chitinhq/octi#245.
+//
+// refs: chitinhq/octi#242, chitinhq/octi#245, workspace#408
+func TestCopilotCLIAdapter_Dispatch_PushFailure_SilentLossRegression(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-script stub binary not portable to windows")
+	}
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+
+	// 1. Build a fake workspace with a repo whose `origin` is a bare remote
+	//    configured to REJECT pushes (non-existent path). The `git push` in
+	//    the adapter will fail deterministically.
+	workspace := t.TempDir()
+	repoName := "silentloss-242"
+	repoPath := filepath.Join(workspace, repoName)
+	if err := os.MkdirAll(repoPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Initialize a local origin bare repo that we can push to (main branch).
+	originPath := filepath.Join(workspace, "origin.git")
+	runGit(t, workspace, "init", "--bare", "-b", "main", originPath)
+
+	// Working repo with `main` branch + initial commit + origin pointing at
+	// the bare repo. After the initial push, we DELETE origin.git so that
+	// subsequent pushes fail — simulating a remote-reject / network-down path.
+	runGit(t, repoPath, "init", "-b", "main")
+	runGit(t, repoPath, "config", "user.email", "test@example.com")
+	runGit(t, repoPath, "config", "user.name", "Test")
+	if err := os.WriteFile(filepath.Join(repoPath, "README.md"), []byte("hi\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, repoPath, "add", ".")
+	runGit(t, repoPath, "commit", "-m", "init")
+	runGit(t, repoPath, "remote", "add", "origin", originPath)
+	runGit(t, repoPath, "push", "-u", "origin", "main")
+
+	// Now nuke the origin so the adapter's `git push` fails.
+	if err := os.RemoveAll(originPath); err != nil {
+		t.Fatal(err)
+	}
+
+	// 2. Build a stub `copilot` binary that exits 0 AND produces a commit
+	//    in cwd (which will be the adapter's worktree). This simulates the
+	//    agent succeeding — the silent-loss gap is between CLI-exit-0 and
+	//    origin actually receiving the branch.
+	stubDir := t.TempDir()
+	stubPath := filepath.Join(stubDir, "copilot")
+	stub := `#!/bin/sh
+# Write a file and commit it — so hasNewCommits() returns true and the
+# adapter proceeds to push.
+echo "work" > silentloss-work.txt
+git add silentloss-work.txt >/dev/null 2>&1
+git -c user.email=stub@example.com -c user.name=stub commit -m "stub work" >/dev/null 2>&1
+echo '{"ok":true}'
+exit 0
+`
+	if err := os.WriteFile(stubPath, []byte(stub), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// 3. Dispatch. The adapter will:
+	//    a) create a worktree off origin/main
+	//    b) run the stub → exit 0 → Status="completed"
+	//    c) hasNewCommits → true (stub committed)
+	//    d) `git push` → FAIL (origin.git was deleted)
+	//    e) MUST flip Status to "failed" (the regression contract)
+	a := NewCopilotCLIAdapter(stubPath, workspace)
+	task := &Task{
+		ID:      fmt.Sprintf("silentloss-242-%d", time.Now().UnixNano()),
+		Type:    "bugfix",
+		Repo:    "chitinhq/" + repoName,
+		Prompt:  "regression test — push will fail",
+		Context: "low",
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	result, err := a.Dispatch(ctx, task)
+	if err != nil {
+		t.Fatalf("Dispatch returned transport error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("Dispatch returned nil result")
+	}
+
+	// THE assertion: on push failure, Status must be "failed", not "completed".
+	// This is the honest-dispatch contract the fix in copilot_cli_adapter.go
+	// establishes. If this test fails with Status="completed", silent loss
+	// has regressed.
+	if result.Status != "failed" {
+		t.Fatalf("silent-loss regression: push failed but Status=%q, want %q; Error=%q",
+			result.Status, "failed", result.Error)
+	}
+	if !strings.Contains(result.Error, "push failed") {
+		t.Errorf("expected Error to mention 'push failed', got %q", result.Error)
+	}
+}
+
+func runGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %v failed in %s: %v: %s", args, dir, err, string(out))
+	}
+}

--- a/internal/dispatch/dispatcher.go
+++ b/internal/dispatch/dispatcher.go
@@ -79,7 +79,17 @@ type Dispatcher struct {
 	presUser  string                // user ID for presence checks
 	queueFile string                // ~/.chitin/queue.txt (compatibility bridge)
 	namespace string
+	adapters  []Adapter // execution-surface adapters (registered via SetAdapters)
 }
+
+// SetAdapters registers adapters that execute a dispatched task on a real
+// surface. Restored after merge #226 clobbered the wiring from #245 —
+// tests in this package still reference it. The dispatcher does not yet
+// invoke these adapters in DispatchBudget (the #245 adapter-gating was lost
+// in the same merge); that invocation is tracked separately. For this PR's
+// scope (chitinhq/octi#242, adapter-level honest-dispatch), the adapter's
+// own Status="failed" semantics carry the contract.
+func (d *Dispatcher) SetAdapters(adapters ...Adapter) { d.adapters = adapters }
 
 // NewDispatcher creates an event-driven dispatcher.
 func NewDispatcher(rdb *redis.Client, router *routing.Router, coord *coordination.Engine, events *EventRouter, queueFile, namespace string) *Dispatcher {


### PR DESCRIPTION
## Summary

Fixes the **claim-without-execution** silent-loss in the `copilot_cli`
adapter (`internal/dispatch/copilot_cli_adapter.go`). Same class as the
dispatcher-level bug fixed in #245; this PR extends the honest-dispatch
contract down into the adapter.

### The lie

`CopilotCLIAdapter.Dispatch` set `result.Status = "completed"` on CLI
exit 0, then attempted `git push` + `gh pr create` as best-effort. On
push or PR-create failure only `result.Error` was populated — Status
stayed `"completed"`. The outer dispatcher (`dispatcher.go:264`) maps
Status=`"completed"` to Action=`"dispatched"`, so a branch that never
reached origin was logged as a successful dispatch while
`cleanupWorktree` deleted the evidence. Textbook silent loss.

### The fix

On `push failed` or `pr create failed`, flip `result.Status = "failed"`
so the outer dispatcher honestly maps it to `Action = "failed"`. Three
adapter outcomes now line up with three real states of the world.

### Regression test

`TestCopilotCLIAdapter_Dispatch_PushFailure_SilentLossRegression`
mirrors #245's `TestDispatchBudget_CallsAdapter_SilentLossRegression`
shape. Builds a local git repo with a deleted origin + a stub `copilot`
binary that produces a commit. Runs the adapter end-to-end; push
fails; asserts `Status == "failed"`. Fails against pre-fix code,
passes with the fix.

### Drive-by

Restores a minimal `Dispatcher.SetAdapters` stub. The full adapter-
gating wiring from #245 was clobbered when #226 (tier telemetry) merged
on top of it — the dispatch test package no longer built on `main`. This
PR's scope is the adapter-level contract for `copilot_cli`; full
restoration of the dispatcher-level gating is tracked separately.

## Test plan

- [x] `go test ./internal/dispatch/ -run TestCopilotCLI` → all pass
- [x] New regression test passes with fix, fails without it
- [ ] Siblings #241 (`claude_code`) and #243 (`clawta`) carry the same
      pattern; separate PRs.

refs: chitinhq/octi#242, chitinhq/octi#245, workspace#408

🤖 Generated with [Claude Code](https://claude.com/claude-code)