### PR TITLE
fix(sprint/store): verify Redis SET before counting marked (silent-loss #244)

### DIFF
--- a/internal/sprint/store.go
+++ b/internal/sprint/store.go
@@ -645,18 +645,31 @@ func (s *Store) SyncClosed(ctx context.Context, repo string) error {
 		nums[i] = issue.Number
 	}
 
-	marked := s.markClosedItems(ctx, repo, nums)
+	marked, err := s.markClosedItems(ctx, repo, nums)
 	if marked > 0 {
 		s.log.Printf("marked %d closed issues as done in %s", marked, repo)
+	}
+	if err != nil {
+		// Don't fail the whole sync — partial progress is still useful — but
+		// surface the Redis failure so the caller knows the count is best-effort.
+		s.log.Printf("markClosedItems %s: %v", repo, err)
 	}
 	return nil
 }
 
 // markClosedItems marks sprint items for the given issue numbers as "done"
-// if they are currently open or pr_open. Returns the number of items marked.
-func (s *Store) markClosedItems(ctx context.Context, repo string, issueNums []int) int {
+// if they are currently open or pr_open. Returns the number of items actually
+// persisted to Redis and the first Redis SET error encountered, if any.
+//
+// The counter is only incremented after s.rdb.Set returns without error —
+// mirroring tombstoneFromOpenSet below. Previously the counter incremented
+// regardless of the SET result, so a Redis flap produced a silent-loss:
+// the caller logged "marked N closed" while the persisted state was stale.
+// See chitinhq/octi#244 and the sibling fix in workspace#408 / octi#245.
+func (s *Store) markClosedItems(ctx context.Context, repo string, issueNums []int) (int, error) {
 	now := time.Now().UTC().Format(time.RFC3339)
 	var marked int
+	var firstErr error
 	for _, num := range issueNums {
 		key := s.itemKey(repo, num)
 		raw, err := s.rdb.Get(ctx, key).Result()
@@ -673,10 +686,16 @@ func (s *Store) markClosedItems(ctx context.Context, repo string, issueNums []in
 		item.Status = "done"
 		item.UpdatedAt = now
 		data, _ := json.Marshal(item)
-		s.rdb.Set(ctx, key, data, 0)
+		if err := s.rdb.Set(ctx, key, data, 0).Err(); err != nil {
+			s.log.Printf("markClosed %s#%d: %v", repo, num, err)
+			if firstErr == nil {
+				firstErr = fmt.Errorf("redis set %s#%d: %w", repo, num, err)
+			}
+			continue
+		}
 		marked++
 	}
-	return marked
+	return marked, firstErr
 }
 
 // tombstoneFromOpenSet marks sprint items as "done" when their issue number is

--- a/internal/sprint/store.go
+++ b/internal/sprint/store.go
@@ -3,6 +3,7 @@ package sprint
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -674,7 +675,16 @@ func (s *Store) markClosedItems(ctx context.Context, repo string, issueNums []in
 		key := s.itemKey(repo, num)
 		raw, err := s.rdb.Get(ctx, key).Result()
 		if err != nil {
-			continue // not in sprint store
+			if errors.Is(err, redis.Nil) {
+				continue // not in sprint store
+			}
+			// Real Redis error — record and skip this item, but propagate so
+			// the caller knows the marked count is best-effort (silent-loss #244).
+			s.log.Printf("markClosed get %s#%d: %v", repo, num, err)
+			if firstErr == nil {
+				firstErr = fmt.Errorf("redis get %s#%d: %w", repo, num, err)
+			}
+			continue
 		}
 		var item SprintItem
 		if err := json.Unmarshal([]byte(raw), &item); err != nil {

--- a/internal/sprint/store_test.go
+++ b/internal/sprint/store_test.go
@@ -431,16 +431,19 @@ func TestMarkClosedItems_SilentLossRegression(t *testing.T) {
 
 	// Failure path — close the client so the next call's Redis ops error out.
 	// Against the pre-fix code this test file does not compile (wrong return
-	// arity). Against the post-fix code we assert: marked==0 (no over-count)
-	// and the function runs without panicking. Note Get may also error here,
-	// causing the loop to `continue`; that is acceptable — the contract under
-	// test is "do not claim success when Redis is unhealthy".
+	// arity). Against the post-fix code we assert: marked==0 (no over-count),
+	// AND err != nil (the Get failure must propagate, not be silently swallowed
+	// as "untracked"). Discarding err here is exactly how silent-loss could
+	// re-regress unnoticed.
 	if cErr := s.rdb.Close(); cErr != nil {
 		t.Fatalf("close client: %v", cErr)
 	}
-	marked2, _ := s.markClosedItems(ctx, repo, []int{8})
+	marked2, err2 := s.markClosedItems(ctx, repo, []int{8})
 	if marked2 != 0 {
 		t.Fatalf("silent-loss: expected 0 marked with torn-down client, got %d", marked2)
+	}
+	if err2 == nil {
+		t.Fatalf("silent-loss: expected non-nil err from torn-down client, got nil (Get errors must propagate, not be treated as untracked)")
 	}
 }
 

--- a/internal/sprint/store_test.go
+++ b/internal/sprint/store_test.go
@@ -329,7 +329,10 @@ func TestMarkClosedItems_MarksOpenAndPROpen(t *testing.T) {
 	}
 
 	// Closed issues on GitHub: #8 and #9. #10 already done. #11 in_progress should still become done.
-	marked := s.markClosedItems(ctx, repo, []int{8, 9, 10, 11})
+	marked, err := s.markClosedItems(ctx, repo, []int{8, 9, 10, 11})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	if marked != 3 {
 		t.Fatalf("expected 3 marked, got %d", marked)
 	}
@@ -355,7 +358,10 @@ func TestMarkClosedItems_SkipsUntracked(t *testing.T) {
 	repo := "chitinhq/octi"
 
 	// Sprint store has no items for this repo
-	marked := s.markClosedItems(ctx, repo, []int{1, 2, 3})
+	marked, err := s.markClosedItems(ctx, repo, []int{1, 2, 3})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	if marked != 0 {
 		t.Fatalf("expected 0 marked for untracked items, got %d", marked)
 	}
@@ -363,9 +369,78 @@ func TestMarkClosedItems_SkipsUntracked(t *testing.T) {
 
 func TestMarkClosedItems_EmptyList(t *testing.T) {
 	s, ctx := testStore(t)
-	marked := s.markClosedItems(ctx, "chitinhq/octi", []int{})
+	marked, err := s.markClosedItems(ctx, "chitinhq/octi", []int{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	if marked != 0 {
 		t.Fatalf("expected 0 for empty list, got %d", marked)
+	}
+}
+
+// TestMarkClosedItems_SilentLossRegression mirrors PR #245
+// (DispatchBudget silent-loss fix) for chitinhq/octi#244.
+//
+// The pre-fix code did `s.rdb.Set(...)` with the error discarded and then
+// unconditionally `marked++`, producing a "marked N closed" log line while
+// the persisted Redis state was stale.
+//
+// Structural regression: the post-fix signature is `(int, error)`. This test
+// calls `marked, err := s.markClosedItems(...)` which does NOT compile against
+// the pre-fix signature (`int`) — i.e. merely applying this test file to the
+// parent commit is a build-break.
+//
+// Behavioral regression: we seed an open item, call markClosedItems, then
+// re-read the persisted item and confirm its Status == "done" (round-trip
+// honesty — counter and state agree on the happy path). We additionally
+// drive the failure path by pointing the store at a torn-down client and
+// asserting marked==0 (the counter cannot over-report). See also
+// tombstoneFromOpenSet in store.go for the sibling pattern this fix mirrors.
+func TestMarkClosedItems_SilentLossRegression(t *testing.T) {
+	s, ctx := testStore(t)
+	repo := "chitinhq/octi"
+	s.rdb.SAdd(ctx, s.key("sprint-repos"), repo)
+
+	item := SprintItem{
+		Squad: "octi-pulpo", IssueNum: 8, Repo: repo,
+		Title: "Cost routing", Priority: 0, Status: "open",
+	}
+	data, _ := json.Marshal(item)
+	s.rdb.Set(ctx, s.itemKey(repo, item.IssueNum), data, 0)
+
+	// Happy path — signature enforces (int, error). Pre-fix returned plain int.
+	marked, err := s.markClosedItems(ctx, repo, []int{8})
+	if err != nil {
+		t.Fatalf("happy path: unexpected err: %v", err)
+	}
+	if marked != 1 {
+		t.Fatalf("happy path: expected 1 marked, got %d", marked)
+	}
+	// Round-trip honesty: persisted state matches the claim.
+	raw, gErr := s.rdb.Get(ctx, s.itemKey(repo, 8)).Result()
+	if gErr != nil {
+		t.Fatalf("read back seeded item: %v", gErr)
+	}
+	var got SprintItem
+	if jErr := json.Unmarshal([]byte(raw), &got); jErr != nil {
+		t.Fatalf("unmarshal: %v", jErr)
+	}
+	if got.Status != "done" {
+		t.Fatalf("round-trip: expected status=done on successful mark, got %q", got.Status)
+	}
+
+	// Failure path — close the client so the next call's Redis ops error out.
+	// Against the pre-fix code this test file does not compile (wrong return
+	// arity). Against the post-fix code we assert: marked==0 (no over-count)
+	// and the function runs without panicking. Note Get may also error here,
+	// causing the loop to `continue`; that is acceptable — the contract under
+	// test is "do not claim success when Redis is unhealthy".
+	if cErr := s.rdb.Close(); cErr != nil {
+		t.Fatalf("close client: %v", cErr)
+	}
+	marked2, _ := s.markClosedItems(ctx, repo, []int{8})
+	if marked2 != 0 {
+		t.Fatalf("silent-loss: expected 0 marked with torn-down client, got %d", marked2)
 	}
 }
 


### PR DESCRIPTION
## Summary
- **Fix** `markClosedItems` in `internal/sprint/store.go` — the Redis `SET` return value was discarded and `marked++` ran unconditionally. On a Redis flap the caller logged "marked N closed issues as done" while the persisted state was still `open` / `pr_open`, causing repeat-marks each sync cycle and potential double- or missed-fires downstream.
- **Mirror** the sibling pattern in `tombstoneFromOpenSet` (same file, line 710 pre-fix) which already `.Err()`-checks its `SET`. Asymmetric handling was the tell.
- **Propagate** the first Redis error via a new `(int, error)` return. `Sync` logs it as best-effort so partial progress still counts, but callers can no longer mistake a flapped sync for a clean one.

## The lie
> "marked N closed issues as done" — when N items were mutated in memory but zero were persisted.

## Regression test — `TestMarkClosedItems_SilentLossRegression`
Mirrors PR #245 style.
- **Structural guard**: test file calls `marked, err := s.markClosedItems(...)`. Pre-fix signature is `int`, so this test does not compile against the parent commit — i.e. applying the test alone is a build-break proving the regression is caught.
- **Behavioral guard**: happy path asserts `marked==1` and round-trips the persisted item to confirm `Status=="done"` (counter/state agree). Failure path tears down the client and asserts `marked==0` (counter cannot over-report under a Redis failure).
- Existing `TestMarkClosedItems_*` tests updated for the new signature; all three still green.

## Test plan
- [x] `go test ./internal/sprint/...` — all green locally
- [x] `go build ./...` — clean
- [ ] CI green on push
- [ ] Manual: trigger a Sync with a stopped Redis; confirm log surfaces `markClosedItems ...: redis set ...: ...` instead of a phantom "marked N" claim.

Refs: #244, #245, workspace#408

🤖 Generated with [Claude Code](https://claude.com/claude-code)