### PR TITLE
fix(dispatcher): honest-dispatch for clawta adapter (silent-loss #243)

### DIFF
--- a/internal/dispatch/clawta_adapter.go
+++ b/internal/dispatch/clawta_adapter.go
@@ -152,11 +152,16 @@ func (a *ClawtaAdapter) Dispatch(ctx context.Context, task *Task) (*AdapterResul
 	}
 
 	// Adapter-side git plumbing: push branch and open PR if Clawta produced commits.
+	// Honest-dispatch: Status="completed" requires push + PR create to actually succeed.
+	// If either side-effect fails, downgrade Status so the outer dispatcher reports
+	// Action="failed" and the learner does not ingest a false-positive success.
+	// See: chitinhq/octi#243, chitinhq/octi#245 (sibling fix).
 	if result.Status == "completed" {
 		if hasNewCommits(worktreePath, "origin/"+defaultBranch) {
 			pushCmd := exec.CommandContext(ctx, "git", "push", "-u", "origin", branchName)
 			pushCmd.Dir = worktreePath
 			if pushOut, pushErr := pushCmd.CombinedOutput(); pushErr != nil {
+				result.Status = "failed"
 				result.Error = fmt.Sprintf("push failed: %s: %s", pushErr, string(pushOut))
 			} else {
 				prTitle := truncate(task.Prompt, 60)
@@ -169,6 +174,7 @@ func (a *ClawtaAdapter) Dispatch(ctx context.Context, task *Task) (*AdapterResul
 				)
 				prCmd.Dir = worktreePath
 				if prOut, prErr := prCmd.CombinedOutput(); prErr != nil {
+					result.Status = "failed"
 					result.Error = fmt.Sprintf("pr create failed: %s: %s", prErr, string(prOut))
 				} else {
 					result.Output = string(prOut)

--- a/internal/dispatch/clawta_adapter_test.go
+++ b/internal/dispatch/clawta_adapter_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -241,6 +242,91 @@ func TestClawtaAdapterDispatchFailsGracefully(t *testing.T) {
 	}
 	if result.TaskID != "test-task-001" {
 		t.Errorf("TaskID: want test-task-001, got %s", result.TaskID)
+	}
+}
+
+// TestClawtaAdapterDispatch_HonestDispatch_SilentLossRegression asserts that
+// when the clawta subprocess succeeds (Status transitions to "completed") but
+// the adapter-side git push fails, result.Status is downgraded to "failed".
+// Mirrors PR #245 style (chitinhq/octi#243) — gates success claim on the real
+// side-effect actually landing. Build-fails against the pre-fix shape where
+// push failure only populated result.Error and Status stayed "completed".
+func TestClawtaAdapterDispatch_HonestDispatch_SilentLossRegression(t *testing.T) {
+	t.Setenv("DEEPSEEK_API_KEY", "test-key")
+
+	// Build a shim PATH with a fake `clawta` that always exits 0 after
+	// creating a commit in cwd. The real `git` is inherited from the system
+	// PATH so push actually runs — it will fail because the remote is a
+	// dangling path (deleted after clone).
+	shimDir := t.TempDir()
+	clawtaShim := filepath.Join(shimDir, "clawta")
+	shim := "#!/bin/sh\n" +
+		"echo 'fake clawta run' > file.txt\n" +
+		"git -c user.email=fake@test -c user.name=Fake add file.txt\n" +
+		"git -c user.email=fake@test -c user.name=Fake commit -m 'fake clawta commit'\n" +
+		"exit 0\n"
+	if err := os.WriteFile(clawtaShim, []byte(shim), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Workspace layout: workspace/<repo-name> is a real git repo with a
+	// remote pointing at a bare repo we will delete, forcing push to fail.
+	ws := t.TempDir()
+	repoName := "silentloss-target"
+	repoPath := filepath.Join(ws, repoName)
+	if err := os.MkdirAll(repoPath, 0755); err != nil {
+		t.Fatal(err)
+	}
+	remoteDir := filepath.Join(ws, "remote.git")
+	if err := os.MkdirAll(remoteDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	mustGit(t, remoteDir, "init", "--bare")
+
+	// Init local repo with one commit on main and a remote tracking main.
+	mustGit(t, repoPath, "init")
+	mustGit(t, repoPath, "remote", "add", "origin", remoteDir)
+	if err := os.WriteFile(filepath.Join(repoPath, "README"), []byte("init"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	mustGit(t, repoPath, "-c", "user.email=t@t.com", "-c", "user.name=T", "add", "README")
+	mustGit(t, repoPath, "-c", "user.email=t@t.com", "-c", "user.name=T", "commit", "-m", "init")
+	mustGit(t, repoPath, "branch", "-M", "main")
+	mustGit(t, repoPath, "push", "origin", "main")
+
+	// Nuke the remote so the adapter-side `git push` fails with a real error.
+	if err := os.RemoveAll(remoteDir); err != nil {
+		t.Fatal(err)
+	}
+
+	a := NewClawtaAdapter(clawtaShim, "", "", ws)
+	task := &Task{
+		ID:     "silent-loss-regression-243",
+		Type:   "code-gen",
+		Repo:   "chitinhq/" + repoName,
+		Prompt: "Write hello world",
+	}
+
+	result, err := a.Dispatch(context.Background(), task)
+	if err != nil {
+		t.Fatalf("Dispatch returned unexpected error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("Dispatch returned nil result")
+	}
+
+	// The lie: pre-fix, push failure only set result.Error and Status stayed
+	// "completed". The honest-dispatch fix must downgrade to "failed".
+	if result.Status != "failed" {
+		t.Errorf("silent-loss regression: push failed but Status=%q (want \"failed\"). "+
+			"Adapter claimed success for work that never reached origin. "+
+			"result.Error=%q", result.Status, result.Error)
+	}
+	if result.Error == "" {
+		t.Error("result.Error: want non-empty push-failure reason, got empty")
+	}
+	if !strings.Contains(result.Error, "push failed") {
+		t.Errorf("result.Error: want contains \"push failed\", got %q", result.Error)
 	}
 }
 


### PR DESCRIPTION
## Summary

- **Fix** `ClawtaAdapter.Dispatch` so `result.Status = \"completed\"` requires the adapter-side `git push` AND `gh pr create` to actually succeed. Before: if the `clawta run` subprocess exited 0 but push or PR create failed, only `result.Error` was populated — `result.Status` stayed `\"completed\"`. Downstream the outer dispatcher reported `Action=\"dispatched\"` for work that never reached origin.
- **Learner contamination angle** (unique to clawta per #243): `a.learner.RecordOutcome(...)` at line 194 was ingesting `Status=\"completed\"` into episodic memory for failed dispatches, teaching the learner \"this prompt shape succeeds\" when the output was silently dropped. Fix downgrades Status to `\"failed\"` before RecordOutcome fires.
- **Regression test** `TestClawtaAdapterDispatch_HonestDispatch_SilentLossRegression` — spins a real temp git repo with a bare remote, deletes the remote before `Dispatch` runs so the push fails with a genuine git error (a fake `clawta` binary on PATH supplies the success exit code and a dummy commit). Asserts `result.Status == \"failed\"` with a non-empty `\"push failed\"` reason. Build-fails against the pre-fix shape, passes against the fix.

## Sibling to #245

This is the clawta half of the silent-loss sweep. PR #245 fixed the outer `Dispatcher.DispatchBudget` gate; this PR fixes the same claim-without-execution shape in the clawta adapter's adapter-side git plumbing. Copilot CLI (#242) and claude_code (#241) adapters are sibling follow-ups.

## Scope note

`go test ./...` is currently red on `origin/main` for unrelated reasons — `dispatcher_test.go` and `e2e_silent_loss_test.go` reference `Dispatcher.SetAdapters` which was removed in the PR #245 squash. That breakage is pre-existing and out of scope for this PR. The new regression test itself compiles and passes in isolation (verified by temporarily side-pocketing the broken files during development).

Refs: workspace#408 · chitinhq/octi#243 · chitinhq/octi#245

## Test plan

- [x] New regression test passes against this fix
- [x] New regression test fails against pre-fix shape (stash + rerun verified)
- [ ] CI green once pre-existing master breakage is addressed separately

🤖 Generated with [Claude Code](https://claude.com/claude-code)