### PR TITLE
fix(dispatcher): replay PR #245 honest-dispatch hunk + add go test CI (fixes #252)

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -1,0 +1,24 @@
+name: go-test
+
+# Repo had no Go CI workflow before this PR — which is exactly how PR #245's
+# dispatcher.go honest-dispatch hunk was dropped on merge without anyone
+# noticing the build broke. See chitinhq/octi#252.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.22'
+          cache: true
+      - name: go build
+        run: go build ./...
+      - name: go test
+        run: go test ./...

--- a/internal/dispatch/dispatcher.go
+++ b/internal/dispatch/dispatcher.go
@@ -79,17 +79,29 @@ type Dispatcher struct {
 	presUser  string                // user ID for presence checks
 	queueFile string                // ~/.chitin/queue.txt (compatibility bridge)
 	namespace string
-	adapters  []Adapter // execution-surface adapters (registered via SetAdapters)
+	adapters  []Adapter // execution-surface adapters; picked by Name() against routed driver
 }
 
 // SetAdapters registers adapters that execute a dispatched task on a real
-// surface. Restored after merge #226 clobbered the wiring from #245 —
-// tests in this package still reference it. The dispatcher does not yet
-// invoke these adapters in DispatchBudget (the #245 adapter-gating was lost
-// in the same merge); that invocation is tracked separately. For this PR's
-// scope (chitinhq/octi#241, adapter-level honest-dispatch for claude_code),
-// the adapter's own Status="failed" semantics carry the contract.
+// surface (HTTP repository_dispatch, Anthropic API, Claude Code CLI, etc.).
+// After route selection, Dispatch() invokes the adapter whose Name() matches
+// the routed driver. This is what makes result.Action="dispatched" mean "an
+// execution surface was actually called" rather than "we enqueued to Redis
+// and hoped." See workspace#408 (silent-loss regression) and chitinhq/octi#252
+// (replay of dropped PR #245 hunk).
 func (d *Dispatcher) SetAdapters(adapters ...Adapter) { d.adapters = adapters }
+
+// selectAdapter returns the registered adapter whose Name() matches driver,
+// or nil if none is registered. Gate between routing ("we picked claude-code")
+// and execution ("we actually called it").
+func (d *Dispatcher) selectAdapter(driver string) Adapter {
+	for _, a := range d.adapters {
+		if a != nil && a.Name() == driver {
+			return a
+		}
+	}
+	return nil
+}
 
 // NewDispatcher creates an event-driven dispatcher.
 func NewDispatcher(rdb *redis.Client, router *routing.Router, coord *coordination.Engine, events *EventRouter, queueFile, namespace string) *Dispatcher {
@@ -251,11 +263,65 @@ func (d *Dispatcher) DispatchBudget(ctx context.Context, event Event, agentName 
 	}
 
 	queueDepth, _ := d.PendingCount(ctx)
-	result.Action = "dispatched"
-	result.Reason = fmt.Sprintf("dispatched via %s (tier: %s, confidence: %.1f)", routeDecision.Driver, routeDecision.Tier, routeDecision.Confidence)
 	result.Driver = routeDecision.Driver
 	result.ClaimID = claim.ClaimID
 	result.QueuePos = queueDepth
+
+	// 5. Actually call the adapter for the routed driver. Until this returns
+	// successfully, we have only *routed* — we have not *dispatched*. Action
+	// "dispatched" must mean an execution surface was invoked and accepted
+	// the task (workspace#408 / chitinhq/octi#252: silent-loss fix replay).
+	adapter := d.selectAdapter(routeDecision.Driver)
+	if adapter == nil {
+		if len(d.adapters) == 0 {
+			// Legacy path: no adapters registered at all. Preserve the old
+			// queue-only behavior so callers that consume from the Redis
+			// queue directly don't regress. Reason string marks it as
+			// queue-only so observers can distinguish it from HTTP-confirmed
+			// dispatch.
+			result.Action = "dispatched"
+			result.Reason = fmt.Sprintf("queued via %s (tier: %s, confidence: %.1f; no adapter registered)", routeDecision.Driver, routeDecision.Tier, routeDecision.Confidence)
+			d.recordDispatch(ctx, agentName, event, result)
+			if d.profiles != nil {
+				_ = d.profiles.RecordDispatch(ctx, agentName)
+			}
+			return result, nil
+		}
+		// Adapters exist but none matches the routed driver: don't claim
+		// success with no execution surface attached.
+		result.Action = "unroutable"
+		result.Reason = fmt.Sprintf("no adapter registered for driver %q", routeDecision.Driver)
+		d.recordDispatch(ctx, agentName, event, result)
+		return result, nil
+	}
+
+	task := &Task{
+		ID:       fmt.Sprintf("%s-%d", agentName, now.UnixNano()),
+		Type:     string(event.Type),
+		Repo:     event.Repo,
+		Priority: priorityStr(priority),
+	}
+
+	adapterResult, adapterErr := adapter.Dispatch(ctx, task)
+	if adapterErr != nil {
+		result.Action = "failed"
+		result.Reason = fmt.Sprintf("adapter %s dispatch failed: %v", adapter.Name(), adapterErr)
+		d.recordDispatch(ctx, agentName, event, result)
+		return result, nil
+	}
+	if adapterResult != nil && adapterResult.Status == "failed" {
+		errMsg := adapterResult.Error
+		if errMsg == "" {
+			errMsg = "adapter reported failed status"
+		}
+		result.Action = "failed"
+		result.Reason = fmt.Sprintf("adapter %s: %s", adapter.Name(), errMsg)
+		d.recordDispatch(ctx, agentName, event, result)
+		return result, nil
+	}
+
+	result.Action = "dispatched"
+	result.Reason = fmt.Sprintf("dispatched via %s (tier: %s, confidence: %.1f)", routeDecision.Driver, routeDecision.Tier, routeDecision.Confidence)
 
 	d.recordDispatch(ctx, agentName, event, result)
 


### PR DESCRIPTION
## Summary

PR #245 introduced `SetAdapters`/`selectAdapter` and the adapter-gated `DispatchBudget` logic that makes `Action=\"dispatched\"` mean *an execution surface accepted the task*. On merge, the `internal/dispatch/dispatcher.go` hunk was dropped — leaving `dispatcher_test.go` and `e2e_silent_loss_test.go` referencing an undefined `Dispatcher.SetAdapters` and breaking the `internal/dispatch` build on `main`. See #252 for the full forensic.

Sibling silent-loss PRs (#248, #249, #250, #251) each ship a *local* `SetAdapters` stub in their own adapter file to keep their slice compiling. Once this PR lands those local stubs become redundant and can be removed in follow-ups.

## What this does

- Restores `adapters` field, `SetAdapters`, `selectAdapter` on `Dispatcher`.
- Restores the `dispatched | failed | unroutable` adapter gate in `DispatchBudget` after enqueue/claim — three honest outcomes.
- Preserves the explicit legacy fallback when no adapters are registered at all (callers consuming the Redis queue directly do not regress).
- Adds `.github/workflows/go-test.yml` so a dropped hunk like this can never reach `main` silently again. Repo previously had only `claude.yml` and `clawta-dispatch.yml` — no Go build/test gate.

## Verification

- `go test ./internal/dispatch/...` — **green**, no `SetAdapters` stub anywhere outside `dispatcher.go`.
- `go test ./...` — **green** across the repo.

## Why siblings carry stubs

#248–#251 each landed before this replay; without `Dispatcher.SetAdapters` defined, their adapter-level tests would not compile. Each chose to add a local 2-line stub rather than block on the dispatcher fix. Those stubs are safe to delete once this merges; tracked as a follow-up.

Fixes #252. Replays #245.

## Test plan

- [x] `go test ./internal/dispatch/...` green
- [x] `go test ./...` green
- [x] No `SetAdapters` stub remains in any `*_adapter.go` after this branch
- [ ] CI go-test workflow runs green on this PR

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>