### PR TITLE
fix(dispatch): mint dispatch_id correlation key (octi#257)

### DIFF
--- a/internal/dispatch/adapter.go
+++ b/internal/dispatch/adapter.go
@@ -20,6 +20,12 @@ type Task struct {
 	Budget   int      `json:"budget"`   // max cost in cents
 	Context  string   `json:"context"`  // pre-assembled context
 	System   string   `json:"system"`   // system prompt
+	// DispatchID is the correlation id minted by the dispatcher; adapters
+	// that surface tasks to remote runtimes (gh-actions repository_dispatch,
+	// etc.) must include it in the downstream payload so Sentinel can join
+	// Redis dispatch-log ↔ gh run events ↔ Neon execution_events. See
+	// octi#257 / sentinel#70.
+	DispatchID string `json:"dispatch_id,omitempty"`
 }
 
 // AdapterResult is the outcome of a dispatched task.

--- a/internal/dispatch/dispatch_id_test.go
+++ b/internal/dispatch/dispatch_id_test.go
@@ -1,0 +1,107 @@
+package dispatch
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestDispatchID_MintedAndRecorded asserts that every recordDispatch call
+// produces a DispatchRecord with a non-empty dispatch_id, and that the id
+// on the DispatchResult matches the id persisted to Redis. This is the
+// join key Sentinel's DetectDispatchOrphans pass (sentinel#70) relies on.
+// See octi#257.
+func TestDispatchID_MintedAndRecorded(t *testing.T) {
+	d, ctx := testSetup(t)
+
+	event := Event{Type: EventManual, Source: "test"}
+	result, err := d.Dispatch(ctx, event, "test-agent-id", 2)
+	if err != nil {
+		t.Fatalf("dispatch error: %v", err)
+	}
+	if result.DispatchID == "" {
+		t.Fatal("expected DispatchResult.DispatchID to be minted, got empty")
+	}
+	if len(result.DispatchID) < 16 {
+		t.Fatalf("expected DispatchID to have >=16 chars of entropy, got %q", result.DispatchID)
+	}
+
+	recent, err := d.RecentDispatches(ctx, 10)
+	if err != nil {
+		t.Fatalf("recent: %v", err)
+	}
+	if len(recent) == 0 {
+		t.Fatal("expected at least one DispatchRecord in redis")
+	}
+	var match bool
+	for _, r := range recent {
+		if r.DispatchID == "" {
+			t.Errorf("DispatchRecord persisted with empty dispatch_id (agent=%s result=%s)", r.Agent, r.Result)
+		}
+		if r.DispatchID == result.DispatchID {
+			match = true
+		}
+	}
+	if !match {
+		t.Fatalf("DispatchResult.DispatchID=%q not found in persisted records", result.DispatchID)
+	}
+}
+
+// TestDispatchID_UniquePerDispatch guards against any accidental
+// deterministic/reused id (e.g. fallback time-based path firing under load).
+func TestDispatchID_UniquePerDispatch(t *testing.T) {
+	seen := make(map[string]struct{}, 64)
+	for i := 0; i < 64; i++ {
+		id := newDispatchID()
+		if id == "" {
+			t.Fatal("newDispatchID returned empty")
+		}
+		if _, dup := seen[id]; dup {
+			t.Fatalf("newDispatchID collision at iteration %d: %q", i, id)
+		}
+		seen[id] = struct{}{}
+	}
+}
+
+// TestGHActionsAdapter_PropagatesDispatchID asserts the gh-actions adapter
+// serialises Task.DispatchID into client_payload.dispatch_id on the
+// repository_dispatch POST body. Without this, downstream `gh run` events
+// carry no join key and Sentinel falls back to brittle (agent, repo, ts)
+// joins — the exact regression tracked by octi#257 / workspace#408.
+func TestGHActionsAdapter_PropagatesDispatchID(t *testing.T) {
+	var captured ghDispatchPayload
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+			t.Errorf("decode body: %v", err)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	adapter := &GHActionsAdapter{token: "fake", baseURL: srv.URL}
+	task := &Task{
+		ID:         "test-task-1",
+		Type:       "code-gen",
+		Repo:       "chitinhq/octi",
+		Priority:   "NORMAL",
+		DispatchID: "abc123def456abc123def456abc12345",
+	}
+
+	res, err := adapter.Dispatch(context.Background(), task)
+	if err != nil {
+		t.Fatalf("dispatch: %v", err)
+	}
+	if res.Status != "queued" {
+		t.Fatalf("expected status=queued, got %s", res.Status)
+	}
+	if captured.ClientPayload.DispatchID != task.DispatchID {
+		t.Fatalf("client_payload.dispatch_id mismatch: got %q want %q",
+			captured.ClientPayload.DispatchID, task.DispatchID)
+	}
+	if captured.ClientPayload.TaskID != task.ID {
+		t.Fatalf("client_payload.task_id mismatch: got %q want %q",
+			captured.ClientPayload.TaskID, task.ID)
+	}
+}

--- a/internal/dispatch/dispatcher.go
+++ b/internal/dispatch/dispatcher.go
@@ -2,6 +2,8 @@ package dispatch
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -17,25 +19,42 @@ import (
 
 // DispatchResult is the outcome of a dispatch decision.
 type DispatchResult struct {
-	Action    string `json:"action"`     // "dispatched", "skipped", "queued"
-	Agent     string `json:"agent"`      // agent name
-	Reason    string `json:"reason"`     // human-readable explanation
-	Driver    string `json:"driver"`     // chosen driver (empty if skipped)
-	Budget    string `json:"budget"`     // effective budget level: "low", "medium", "high"
-	QueuePos  int64  `json:"queue_pos"`  // position in queue (0 if not queued)
-	ClaimID   string `json:"claim_id"`   // coordination claim ID (empty if skipped)
-	Timestamp string `json:"timestamp"`
+	Action     string `json:"action"`      // "dispatched", "skipped", "queued"
+	Agent      string `json:"agent"`       // agent name
+	Reason     string `json:"reason"`      // human-readable explanation
+	Driver     string `json:"driver"`      // chosen driver (empty if skipped)
+	Budget     string `json:"budget"`      // effective budget level: "low", "medium", "high"
+	QueuePos   int64  `json:"queue_pos"`   // position in queue (0 if not queued)
+	ClaimID    string `json:"claim_id"`    // coordination claim ID (empty if skipped)
+	DispatchID string `json:"dispatch_id"` // correlation id for cross-sink reconcile (octi#257)
+	Timestamp  string `json:"timestamp"`
+}
+
+// newDispatchID mints a 16-byte hex correlation id that is threaded through
+// DispatchRecord (Redis) and repository_dispatch.client_payload.dispatch_id
+// (GitHub Actions) so Sentinel's DetectDispatchOrphans pass (sentinel#70) can
+// join the three truth sinks. Deliberately crypto/rand over a new ulid/uuid
+// dep — 128 bits of entropy, zero supply chain surface. See octi#257.
+func newDispatchID() string {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		// rand.Read on linux is infallible in practice; fall back to a
+		// time-based id so a dispatch is never un-joinable.
+		return fmt.Sprintf("t%x", time.Now().UnixNano())
+	}
+	return hex.EncodeToString(b[:])
 }
 
 // DispatchRecord is persisted to Redis for observability.
 type DispatchRecord struct {
-	Agent     string `json:"agent"`
-	Event     Event  `json:"event"`
-	Result    string `json:"result"` // action taken
-	Reason    string `json:"reason"`
-	Driver    string `json:"driver"`
-	Tier      string `json:"tier,omitempty"` // Ladder Forge tier: local|actions|cloud|desktop|human|unknown
-	Timestamp string `json:"timestamp"`
+	Agent      string `json:"agent"`
+	Event      Event  `json:"event"`
+	Result     string `json:"result"` // action taken
+	Reason     string `json:"reason"`
+	Driver     string `json:"driver"`
+	Tier       string `json:"tier,omitempty"`        // Ladder Forge tier: local|actions|cloud|desktop|human|unknown
+	DispatchID string `json:"dispatch_id,omitempty"` // correlation id joining Redis / gh runs / Neon (octi#257)
+	Timestamp  string `json:"timestamp"`
 }
 
 // ClassifyTier maps a driver (and event context) to a Ladder Forge tier.
@@ -139,9 +158,10 @@ func (d *Dispatcher) DispatchBudget(ctx context.Context, event Event, agentName 
 
 	now := time.Now().UTC()
 	result := DispatchResult{
-		Agent:     agentName,
-		Budget:    budget,
-		Timestamp: now.Format(time.RFC3339),
+		Agent:      agentName,
+		Budget:     budget,
+		DispatchID: newDispatchID(),
+		Timestamp:  now.Format(time.RFC3339),
 	}
 
 	// 0. Validate: repo-scoped events must carry a non-empty Repo.
@@ -296,10 +316,11 @@ func (d *Dispatcher) DispatchBudget(ctx context.Context, event Event, agentName 
 	}
 
 	task := &Task{
-		ID:       fmt.Sprintf("%s-%d", agentName, now.UnixNano()),
-		Type:     string(event.Type),
-		Repo:     event.Repo,
-		Priority: priorityStr(priority),
+		ID:         fmt.Sprintf("%s-%d", agentName, now.UnixNano()),
+		Type:       string(event.Type),
+		Repo:       event.Repo,
+		Priority:   priorityStr(priority),
+		DispatchID: result.DispatchID,
 	}
 
 	adapterResult, adapterErr := adapter.Dispatch(ctx, task)
@@ -502,14 +523,22 @@ func (d *Dispatcher) Coord() *coordination.Engine {
 }
 
 func (d *Dispatcher) recordDispatch(ctx context.Context, agentName string, event Event, result DispatchResult) {
+	// Defense-in-depth: every record persisted must carry a dispatch_id so
+	// Sentinel's DetectDispatchOrphans (sentinel#70) join key is never empty,
+	// even if a caller constructed DispatchResult outside DispatchBudget.
+	// See octi#257.
+	if result.DispatchID == "" {
+		result.DispatchID = newDispatchID()
+	}
 	record := DispatchRecord{
-		Agent:     agentName,
-		Event:     event,
-		Result:    result.Action,
-		Reason:    result.Reason,
-		Driver:    result.Driver,
-		Tier:      ClassifyTier(result.Driver, event),
-		Timestamp: result.Timestamp,
+		Agent:      agentName,
+		Event:      event,
+		Result:     result.Action,
+		Reason:     result.Reason,
+		Driver:     result.Driver,
+		Tier:       ClassifyTier(result.Driver, event),
+		DispatchID: result.DispatchID,
+		Timestamp:  result.Timestamp,
 	}
 	data, err := json.Marshal(record)
 	if err != nil {

--- a/internal/dispatch/ghactions_adapter.go
+++ b/internal/dispatch/ghactions_adapter.go
@@ -48,11 +48,12 @@ type ghDispatchPayload struct {
 }
 
 type ghClientPayload struct {
-	TaskID   string   `json:"task_id"`
-	Type     string   `json:"type"`
-	Prompt   string   `json:"prompt"`
-	Toolset  []string `json:"toolset"`
-	Priority string   `json:"priority"`
+	TaskID     string   `json:"task_id"`
+	DispatchID string   `json:"dispatch_id,omitempty"` // octi#257 correlation id
+	Type       string   `json:"type"`
+	Prompt     string   `json:"prompt"`
+	Toolset    []string `json:"toolset"`
+	Priority   string   `json:"priority"`
 }
 
 // Dispatch POSTs a repository_dispatch event to GitHub. On 204 the task is
@@ -65,11 +66,12 @@ func (g *GHActionsAdapter) Dispatch(ctx context.Context, task *Task) (retResult 
 	payload := ghDispatchPayload{
 		EventType: "octi-pulpo-dispatch",
 		ClientPayload: ghClientPayload{
-			TaskID:   task.ID,
-			Type:     task.Type,
-			Prompt:   task.Prompt,
-			Toolset:  task.Toolset,
-			Priority: task.Priority,
+			TaskID:     task.ID,
+			DispatchID: task.DispatchID,
+			Type:       task.Type,
+			Prompt:     task.Prompt,
+			Toolset:    task.Toolset,
+			Priority:   task.Priority,
 		},
 	}
 


### PR DESCRIPTION
## Summary

- Mints a 16-byte hex `dispatch_id` in `DispatchBudget` (dispatcher.go) and persists it on `DispatchRecord` in Redis `octi:dispatch-log`.
- Propagates through `Task.DispatchID` -> `repository_dispatch.client_payload.dispatch_id` for the gh-actions adapter, so downstream `gh run` events carry the same id.
- `recordDispatch` has defense-in-depth: mints a fallback id if any caller constructs a `DispatchResult` outside `DispatchBudget`.
- Uses `crypto/rand` (128 bits of entropy) — no new deps (ulid/uuid avoided intentionally).

Closes #257. Unblocks sentinel#70 (`DetectDispatchOrphans`) and workspace#408 Phase-1 (Telemetry Truth).

## Why this matters

Today `octi:dispatch-log` has 500 entries, 0 with any join key. Sentinel's reconciler falls back to `(agent, repo, ts ± window)` — brittle on fan-out timer events and useless on `brain.*` events with empty repo. 458 human-tier silent dispatches/day bleed through unjoined.

## Changes (4 files)

- `internal/dispatch/dispatcher.go` — `newDispatchID()`, `DispatchResult.DispatchID`, `DispatchRecord.DispatchID`, mint in `DispatchBudget`, belt-and-suspenders in `recordDispatch`.
- `internal/dispatch/adapter.go` — `Task.DispatchID` field.
- `internal/dispatch/ghactions_adapter.go` — `ghClientPayload.DispatchID` wired from `task.DispatchID`.
- `internal/dispatch/dispatch_id_test.go` — 3 new tests (see below).

## Test plan

- [x] `TestDispatchID_MintedAndRecorded` — every `Dispatch` produces non-empty `DispatchID`, same id appears in Redis record.
- [x] `TestDispatchID_UniquePerDispatch` — 64 consecutive mints have no collisions.
- [x] `TestGHActionsAdapter_PropagatesDispatchID` — httptest server asserts the POST body's `client_payload.dispatch_id` matches `task.DispatchID`.
- [x] Full `internal/dispatch` + `internal/mcp` suite: 478 passed.

## Follow-ups (not inline, per scope)

- Record `run_id` back to Redis keyed by `dispatch_id` once workflow run is created (optional, enables full 3-way reconcile). Will file as a separate issue.
- `octi/workflows/octi-triage.yml` shell-level dispatch (line 42-43) also lacks a dispatch_id; separate fix since that path doesn't go through the Go dispatcher.

🤖 Generated with [Claude Code](https://claude.com/claude-code)