### PR TITLE
feat(dispatch): wire adapters on Dispatcher — unblock T1 local routing

### DIFF
--- a/cmd/octi-pulpo/main.go
+++ b/cmd/octi-pulpo/main.go
@@ -271,6 +271,15 @@ func main() {
 			clawtaAdapter := dispatch.NewClawtaAdapter(clawtaBinary, "", "", "")
 			clawtaAdapter.SetLearner(taskLearner)
 			brain.SetAdapters(clawtaAdapter, ghActionsAdapter, copilotAdapter, openclawAdapter)
+			// T1 local enablement (turing, 2026-04-15): also register adapters on
+			// the Dispatcher itself so non-brain dispatch paths (timer, webhook,
+			// signal-watcher) invoke a real execution surface for the routed
+			// driver rather than falling through to the legacy queue-only path
+			// that logs Action="dispatched" with "no adapter registered" reason.
+			// Without this, router.Recommend() can pick clawta (tier=local) but
+			// dispatcher.selectAdapter() returns nil and nothing actually runs.
+			// See chitinhq/octi#243 (silent-loss) and the T1 local=0 tracker.
+			dispatcher.SetAdapters(clawtaAdapter, ghActionsAdapter, copilotAdapter, openclawAdapter, anthropicAdapter)
 			if ghToken := os.Getenv("GITHUB_TOKEN"); ghToken != "" {
 				brain.SetGitHubToken(ghToken)
 			}

--- a/internal/dispatch/dispatcher_test.go
+++ b/internal/dispatch/dispatcher_test.go
@@ -743,3 +743,86 @@ func TestDispatchBudget_CallsAdapter_SilentLossRegression(t *testing.T) {
 	})
 }
 
+// TestDispatchBudget_T1LocalEndToEnd locks in T1-local routing correctness
+// end-to-end: agent name without code keywords → router picks the TierLocal
+// driver (clawta) → Dispatcher invokes the registered adapter → dispatch-log
+// record carries tier="local" and a non-empty dispatch_id join key.
+//
+// Regression guard for the "local=0" telemetry gap (turing, 2026-04-15): the
+// production dispatcher in main.go previously had no adapters registered, so
+// even when routing correctly picked clawta, the legacy queue-only fallback
+// fired and no real execution surface was invoked. This test is the proof
+// that (a) the router picks local when it should, (b) the adapter is called,
+// and (c) ClassifyTier emits "local" so swarm_today counts the dispatch.
+func TestDispatchBudget_T1LocalEndToEnd(t *testing.T) {
+	d, ctx := testSetup(t)
+
+	// Override the router so clawta is the only TierLocal driver and
+	// the default gh-actions/anthropic entries don't leak in from the
+	// global driverTiers map. Write a healthy file so CircuitState=CLOSED.
+	healthDir := t.TempDir()
+	writeHealthFile(t, healthDir, "clawta", "CLOSED")
+	d.router = routing.NewRouterWithTiers(healthDir, map[string]routing.CostTier{
+		"clawta": routing.TierLocal,
+	})
+
+	fake := &silentLossFakeAdapter{
+		name:      "clawta",
+		returnRes: &AdapterResult{Status: "completed", Adapter: "clawta"},
+	}
+	d.SetAdapters(fake)
+
+	// Agent name deliberately has no code/review/implement keyword so
+	// taskMinTier() returns TierLocal. "kernel-em" matches the real
+	// production event rules (see events.go DefaultRules).
+	event := Event{Type: EventManual, Source: "test", Repo: "chitinhq/octi"}
+	result, err := d.DispatchBudget(ctx, event, "kernel-em", 2, "medium")
+	if err != nil {
+		t.Fatalf("dispatch error: %v", err)
+	}
+
+	// Router should have picked clawta (cheapest local driver, healthy).
+	if result.Driver != "clawta" {
+		t.Fatalf("expected driver=clawta, got %q (reason: %s)", result.Driver, result.Reason)
+	}
+	if result.Action != "dispatched" {
+		t.Fatalf("expected action=dispatched, got %s (reason: %s)", result.Action, result.Reason)
+	}
+	// Adapter actually invoked — no silent-loss on the local path.
+	if fake.calls != 1 {
+		t.Fatalf("expected clawta adapter called once, got %d", fake.calls)
+	}
+	// dispatch_id correlation key populated (octi#257).
+	if result.DispatchID == "" {
+		t.Fatal("expected non-empty DispatchID for cross-sink reconcile")
+	}
+	if fake.lastTask == nil || fake.lastTask.DispatchID != result.DispatchID {
+		t.Fatalf("expected task.DispatchID=%q to match result, got task=%+v",
+			result.DispatchID, fake.lastTask)
+	}
+
+	// Verify the dispatch-log record in Redis carries tier="local" + the
+	// join key — this is what swarm_today/tier_activity consume.
+	records, err := d.RecentDispatches(ctx, 1)
+	if err != nil {
+		t.Fatalf("read dispatch log: %v", err)
+	}
+	if len(records) != 1 {
+		t.Fatalf("expected 1 dispatch-log record, got %d", len(records))
+	}
+	rec := records[0]
+	if rec.Tier != "local" {
+		t.Fatalf("expected tier=local in dispatch-log, got %q", rec.Tier)
+	}
+	if rec.Driver != "clawta" {
+		t.Fatalf("expected driver=clawta in dispatch-log, got %q", rec.Driver)
+	}
+	if rec.DispatchID == "" || rec.DispatchID != result.DispatchID {
+		t.Fatalf("expected dispatch_id=%q in record, got %q",
+			result.DispatchID, rec.DispatchID)
+	}
+	if rec.Result != "dispatched" {
+		t.Fatalf("expected result=dispatched in record, got %q", rec.Result)
+	}
+}
+


### PR DESCRIPTION
## Summary
- **Root cause of T1 local=0**: `main.go` registered task adapters on `Brain` but never on `Dispatcher`. The router correctly routes `kernel-em`/`workspace-sr`/`pr-merger-agent` (non-code agent names) to `clawta` at `TierLocal`, but `dispatcher.selectAdapter()` returned `nil`, so the legacy queue-only fallback fired — logging `Action=\"dispatched … no adapter registered\"` with `tier=local` but executing nothing. That's why `swarm_today` reads `local=0` while the telemetry still feels like dispatches happen.
- **Fix**: additive — `dispatcher.SetAdapters(clawta, gh-actions, copilot, openclaw, anthropic)` next to the existing `brain.SetAdapters(...)`. No config schema change, no tier taxonomy change, no change to T2/T5 routing.
- **Test**: `TestDispatchBudget_T1LocalEndToEnd` locks in the local-path contract — clawta picked, adapter invoked, `tier=\"local\"` + non-empty `dispatch_id` in the Redis `dispatch-log` record (octi#257 join key preserved).

## Out of scope — follow-up needed
The openclaw gateway on `:18789` currently serves only the HTML control UI — no `/v1/chat/completions` endpoint for octi to POST against. A full T1-local path that routes lightweight tasks (triage, classify, label suggestion) to the local Ollama Cloud model still needs:
1. Server-side adapter wrapper on the openclaw gateway exposing an OpenAI-compatible (or simpler RPC) chat surface.
2. A new `OctiGatewayAdapter` here that POSTs to it, registers as `TierLocal`, and has `CanAccept` scoped to lightweight task classes only.

This PR is the pre-req that makes any such adapter honest — without `dispatcher.SetAdapters` it would silent-loss the same way clawta does today.

## Test plan
- [x] `go test ./internal/dispatch/ -run TestDispatchBudget_T1LocalEndToEnd -v` passes
- [x] Full `go test ./...` green
- [x] `go build ./...` clean
- [ ] Post-merge: rebuild production octi-pulpo binary; observe `swarm_today` local count grow as non-code agents route through the real clawta adapter (note: clawta itself still requires `DEEPSEEK_API_KEY` — see follow-up above for the gateway path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)