### PR TITLE
feat(dispatch): T2b Copilot agent telemetry via webhooks

### DIFF
--- a/internal/dispatch/copilot_agent.go
+++ b/internal/dispatch/copilot_agent.go
@@ -1,0 +1,267 @@
+package dispatch
+
+// T2b Copilot Agent telemetry (agentguardhq Enterprise Copilot).
+//
+// There is no programmatic session-create API and no copilot_session.*
+// webhook. Invocation happens via POST /repos/{owner}/{repo}/issues/
+// {issue_number}/assignees with assignee "Copilot"; the agent later
+// opens/updates a PR from actor "copilot-swe-agent[bot]". We observe
+// that flow via the standard GitHub webhook events and synthesize
+// dispatch-log rows so the session is counted in swarm_today's
+// tiers.copilot column.
+//
+// Detection is a pure function over the webhook payload so it is
+// replayable against fixtures. See copilot_agent_test.go.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// CopilotAgentBot is the login GitHub uses for the Copilot coding agent
+// when it authors PRs / commits.
+const CopilotAgentBot = "copilot-swe-agent[bot]"
+
+// CopilotAgentDriver is the driver string we persist on synthesized
+// DispatchRecords. ClassifyTier and swarm_today.tierFor both map this
+// to the "copilot" tier.
+const CopilotAgentDriver = "copilot-agent"
+
+// CopilotAgentKind classifies what the webhook tells us happened.
+type CopilotAgentKind string
+
+const (
+	CopilotAgentDispatched CopilotAgentKind = "dispatched" // Copilot assigned to an issue
+	CopilotAgentCompleted  CopilotAgentKind = "completed"  // Copilot opened/updated a PR
+	CopilotAgentCanceled   CopilotAgentKind = "canceled"   // Copilot unassigned
+)
+
+// CopilotAgentEvent is the minimal record extracted from a webhook
+// payload. Org/Repo/Issue/PR form the join key — there is no
+// agent_session_id on webhooks (only in the Enterprise audit log),
+// so we correlate dispatch → completion via (repo, issue) pairs.
+type CopilotAgentEvent struct {
+	Kind  CopilotAgentKind
+	Org   string
+	Repo  string // full_name e.g. "agentguardhq/widget"
+	Issue int    // 0 if not applicable
+	PR    int    // 0 if not applicable
+	Actor string // who triggered (for dispatch, the assigner)
+}
+
+// DetectCopilotAgentEvent is the pure detection rule. It returns nil
+// when the payload is not a Copilot-agent signal. Fixture-replayable.
+//
+// Rules:
+//  1. issues.assigned  where assignee.login == "Copilot"            -> dispatched
+//  2. issues.unassigned where assignee.login == "Copilot"           -> canceled
+//  3. pull_request.opened|reopened|synchronize where
+//     pull_request.user.login == "copilot-swe-agent[bot]"           -> completed
+//     (synchronize is kept so we log every push from the bot; the
+//     aggregator de-dupes by (repo, pr) when counting completions.)
+func DetectCopilotAgentEvent(githubEvent, action string, payload map[string]interface{}) *CopilotAgentEvent {
+	repo := getNestedString(payload, "repository", "full_name")
+	org := getNestedString(payload, "repository", "owner", "login")
+	if repo == "" {
+		return nil
+	}
+
+	switch githubEvent {
+	case "issues":
+		if action != "assigned" && action != "unassigned" {
+			return nil
+		}
+		// GitHub sends the specific assignee that changed on `assignee`,
+		// not the full list.
+		assignee := getNestedString(payload, "assignee", "login")
+		if !isCopilotLogin(assignee) {
+			return nil
+		}
+		kind := CopilotAgentDispatched
+		if action == "unassigned" {
+			kind = CopilotAgentCanceled
+		}
+		return &CopilotAgentEvent{
+			Kind:  kind,
+			Org:   org,
+			Repo:  repo,
+			Issue: int(getNestedNumber(payload, "issue", "number")),
+			Actor: getNestedString(payload, "sender", "login"),
+		}
+
+	case "pull_request":
+		if action != "opened" && action != "reopened" && action != "synchronize" {
+			return nil
+		}
+		author := getNestedString(payload, "pull_request", "user", "login")
+		if !isCopilotSWEBot(author) {
+			return nil
+		}
+		return &CopilotAgentEvent{
+			Kind:  CopilotAgentCompleted,
+			Org:   org,
+			Repo:  repo,
+			PR:    int(getNestedNumber(payload, "pull_request", "number")),
+			Issue: copilotLinkedIssue(payload),
+			Actor: author,
+		}
+	}
+	return nil
+}
+
+func isCopilotLogin(login string) bool {
+	l := strings.ToLower(login)
+	// The assignee login is literally "Copilot" on the issues.assigned
+	// event for the Enterprise coding agent.
+	return l == "copilot" || l == "copilot-swe-agent[bot]" || l == "copilot-swe-agent"
+}
+
+func isCopilotSWEBot(login string) bool {
+	return strings.EqualFold(login, CopilotAgentBot) ||
+		strings.EqualFold(login, "copilot-swe-agent")
+}
+
+// copilotLinkedIssue best-effort extracts a "Fixes #N" / "Closes #N" /
+// "Resolves #N" issue number from the PR body so completions can be
+// joined back to the original dispatch. Returns 0 if none found.
+func copilotLinkedIssue(payload map[string]interface{}) int {
+	body := getNestedString(payload, "pull_request", "body")
+	if body == "" {
+		return 0
+	}
+	keywords := []string{"fixes", "closes", "resolves", "fix", "close", "resolve"}
+	lower := strings.ToLower(body)
+	for _, kw := range keywords {
+		idx := strings.Index(lower, kw+" #")
+		if idx < 0 {
+			continue
+		}
+		rest := lower[idx+len(kw)+2:]
+		var n int
+		for i := 0; i < len(rest); i++ {
+			c := rest[i]
+			if c < '0' || c > '9' {
+				break
+			}
+			n = n*10 + int(c-'0')
+		}
+		if n > 0 {
+			return n
+		}
+	}
+	return 0
+}
+
+// ToDispatchRecord synthesizes a DispatchRecord so the Copilot session
+// is counted in swarm_today and visible to Sentinel. dispatchID is
+// supplied by the caller — for `completed` events the caller should
+// reuse the id minted on the earlier `dispatched` record (joined by
+// repo+issue) to keep the correlation chain intact; if none is known,
+// pass a fresh id.
+func (e *CopilotAgentEvent) ToDispatchRecord(dispatchID string, now time.Time) DispatchRecord {
+	evt := Event{
+		Source: "github",
+		Repo:   e.Repo,
+		Payload: map[string]string{
+			"org":   e.Org,
+			"actor": e.Actor,
+		},
+	}
+	if e.Issue > 0 {
+		evt.Payload["issue"] = fmt.Sprintf("%d", e.Issue)
+	}
+	if e.PR > 0 {
+		evt.Payload["pr"] = fmt.Sprintf("%d", e.PR)
+	}
+
+	var result string
+	switch e.Kind {
+	case CopilotAgentDispatched:
+		evt.Type = EventIssueLabeled // nearest fit; the label key carries "copilot-assigned"
+		evt.Payload["label"] = "copilot-assigned"
+		result = "dispatched"
+	case CopilotAgentCompleted:
+		evt.Type = EventCompletion
+		result = "completed"
+	case CopilotAgentCanceled:
+		evt.Type = EventIssueLabeled
+		evt.Payload["label"] = "copilot-unassigned"
+		result = "canceled"
+	}
+
+	return DispatchRecord{
+		Agent:      "copilot-agent",
+		Event:      evt,
+		Result:     result,
+		Reason:     fmt.Sprintf("copilot-agent %s: %s#%d", e.Kind, e.Repo, maxInt(e.Issue, e.PR)),
+		Driver:     CopilotAgentDriver,
+		Tier:       "copilot",
+		DispatchID: dispatchID,
+		Timestamp:  now.UTC().Format(time.RFC3339),
+	}
+}
+
+func maxInt(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+// RecordCopilotAgentEvent persists the synthesized DispatchRecord to
+// Redis on the same dispatch-log key the regular dispatcher uses, so
+// classifyTiers() in swarm_today picks it up with no extra plumbing.
+//
+// Correlation: for `completed` we look up the most recent
+// `dispatched` row for (repo, issue) in the last 500 records and reuse
+// its DispatchID. Fall back to a fresh id if none is found (e.g.
+// webhook delivery out of order, or the dispatch row rolled off the
+// trim window).
+func (d *Dispatcher) RecordCopilotAgentEvent(ctx context.Context, ev *CopilotAgentEvent) error {
+	if ev == nil || d == nil || d.rdb == nil {
+		return nil
+	}
+	dispatchID := ""
+	if ev.Kind == CopilotAgentCompleted && ev.Issue > 0 {
+		dispatchID = d.findCopilotDispatchID(ctx, ev.Repo, ev.Issue)
+	}
+	if dispatchID == "" {
+		dispatchID = newDispatchID()
+	}
+	rec := ev.ToDispatchRecord(dispatchID, time.Now())
+	data, err := json.Marshal(rec)
+	if err != nil {
+		return err
+	}
+	pipe := d.rdb.Pipeline()
+	pipe.LPush(ctx, d.key("dispatch-log"), data)
+	pipe.LTrim(ctx, d.key("dispatch-log"), 0, 499)
+	_, err = pipe.Exec(ctx)
+	return err
+}
+
+// findCopilotDispatchID scans recent records for a Copilot dispatch
+// on the same (repo, issue). Best-effort — empty string on miss.
+func (d *Dispatcher) findCopilotDispatchID(ctx context.Context, repo string, issue int) string {
+	recs, err := d.RecentDispatches(ctx, 500)
+	if err != nil {
+		return ""
+	}
+	target := fmt.Sprintf("%d", issue)
+	for _, r := range recs {
+		if r.Driver != CopilotAgentDriver || r.Result != "dispatched" {
+			continue
+		}
+		if r.Event.Repo != repo {
+			continue
+		}
+		if r.Event.Payload["issue"] != target {
+			continue
+		}
+		return r.DispatchID
+	}
+	return ""
+}

--- a/internal/dispatch/copilot_agent_test.go
+++ b/internal/dispatch/copilot_agent_test.go
@@ -1,0 +1,135 @@
+package dispatch
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// loadFixture unmarshals a testdata JSON payload into the generic
+// map shape the webhook handler receives.
+func loadFixture(t *testing.T, name string) map[string]interface{} {
+	t.Helper()
+	path := filepath.Join("testdata", name)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read fixture %s: %v", name, err)
+	}
+	var out map[string]interface{}
+	if err := json.Unmarshal(data, &out); err != nil {
+		t.Fatalf("unmarshal %s: %v", name, err)
+	}
+	return out
+}
+
+func TestDetectCopilotAgentEvent_IssueAssigned(t *testing.T) {
+	payload := loadFixture(t, "copilot_issue_assigned.json")
+	ev := DetectCopilotAgentEvent("issues", "assigned", payload)
+	if ev == nil {
+		t.Fatal("expected a dispatched event, got nil")
+	}
+	if ev.Kind != CopilotAgentDispatched {
+		t.Errorf("kind = %q, want dispatched", ev.Kind)
+	}
+	if ev.Org != "agentguardhq" {
+		t.Errorf("org = %q, want agentguardhq", ev.Org)
+	}
+	if ev.Repo != "agentguardhq/widget" {
+		t.Errorf("repo = %q", ev.Repo)
+	}
+	if ev.Issue != 42 {
+		t.Errorf("issue = %d, want 42", ev.Issue)
+	}
+}
+
+func TestDetectCopilotAgentEvent_IssueUnassigned(t *testing.T) {
+	payload := loadFixture(t, "copilot_issue_assigned.json")
+	ev := DetectCopilotAgentEvent("issues", "unassigned", payload)
+	if ev == nil || ev.Kind != CopilotAgentCanceled {
+		t.Fatalf("expected canceled, got %+v", ev)
+	}
+}
+
+func TestDetectCopilotAgentEvent_PROpenedByBot(t *testing.T) {
+	payload := loadFixture(t, "copilot_pr_opened.json")
+	ev := DetectCopilotAgentEvent("pull_request", "opened", payload)
+	if ev == nil {
+		t.Fatal("expected completed event, got nil")
+	}
+	if ev.Kind != CopilotAgentCompleted {
+		t.Errorf("kind = %q, want completed", ev.Kind)
+	}
+	if ev.PR != 137 {
+		t.Errorf("pr = %d, want 137", ev.PR)
+	}
+	if ev.Issue != 42 {
+		t.Errorf("linked issue = %d, want 42 (from 'Fixes #42' in body)", ev.Issue)
+	}
+	if ev.Actor != CopilotAgentBot {
+		t.Errorf("actor = %q, want %q", ev.Actor, CopilotAgentBot)
+	}
+}
+
+func TestDetectCopilotAgentEvent_IgnoresHumanPR(t *testing.T) {
+	payload := map[string]interface{}{
+		"repository": map[string]interface{}{
+			"full_name": "chitinhq/octi",
+			"owner":     map[string]interface{}{"login": "chitinhq"},
+		},
+		"pull_request": map[string]interface{}{
+			"number": float64(1),
+			"user":   map[string]interface{}{"login": "jaredpleva"},
+			"body":   "Fixes #1",
+		},
+	}
+	if ev := DetectCopilotAgentEvent("pull_request", "opened", payload); ev != nil {
+		t.Fatalf("expected nil for human-authored PR, got %+v", ev)
+	}
+}
+
+func TestDetectCopilotAgentEvent_IgnoresNonAssigneeLabeled(t *testing.T) {
+	payload := map[string]interface{}{
+		"repository": map[string]interface{}{
+			"full_name": "agentguardhq/widget",
+			"owner":     map[string]interface{}{"login": "agentguardhq"},
+		},
+		"issue": map[string]interface{}{"number": float64(7)},
+		"assignee": map[string]interface{}{"login": "some-human"},
+	}
+	if ev := DetectCopilotAgentEvent("issues", "assigned", payload); ev != nil {
+		t.Fatalf("expected nil for non-Copilot assignee, got %+v", ev)
+	}
+}
+
+func TestCopilotAgentEvent_ToDispatchRecord_Tier(t *testing.T) {
+	ev := &CopilotAgentEvent{
+		Kind:  CopilotAgentDispatched,
+		Org:   "agentguardhq",
+		Repo:  "agentguardhq/widget",
+		Issue: 42,
+	}
+	now, _ := time.Parse(time.RFC3339, "2026-04-15T19:30:00Z")
+	rec := ev.ToDispatchRecord("did_abc", now)
+	if rec.Driver != CopilotAgentDriver {
+		t.Errorf("driver = %q", rec.Driver)
+	}
+	if rec.Tier != "copilot" {
+		t.Errorf("tier = %q, want copilot", rec.Tier)
+	}
+	if rec.Result != "dispatched" {
+		t.Errorf("result = %q", rec.Result)
+	}
+	if rec.DispatchID != "did_abc" {
+		t.Errorf("dispatch_id = %q", rec.DispatchID)
+	}
+	if rec.Event.Payload["issue"] != "42" {
+		t.Errorf("payload.issue = %q", rec.Event.Payload["issue"])
+	}
+	// Sanity: ClassifyTier on the persisted driver also gives "copilot".
+	if got := ClassifyTier(rec.Driver, rec.Event); got != "copilot" {
+		t.Errorf("ClassifyTier = %q, want copilot", got)
+	}
+}
+

--- a/internal/dispatch/dispatcher.go
+++ b/internal/dispatch/dispatcher.go
@@ -74,6 +74,9 @@ func ClassifyTier(driver string, event Event) string {
 	switch driver {
 	case "gh-actions", "ghactions", "github-actions":
 		return "actions"
+	case "copilot-agent":
+		// T2b: Enterprise Copilot coding agent (org-level webhook).
+		return "copilot"
 	case "clawta", "openclaw", "claude-code", "copilot-cli":
 		return "local"
 	case "anthropic", "claude", "remote", "remote-trigger":

--- a/internal/dispatch/testdata/copilot_issue_assigned.json
+++ b/internal/dispatch/testdata/copilot_issue_assigned.json
@@ -1,0 +1,21 @@
+{
+  "action": "assigned",
+  "issue": {
+    "number": 42,
+    "title": "Widget crashes on empty input",
+    "state": "open"
+  },
+  "assignee": {
+    "login": "Copilot",
+    "type": "Bot"
+  },
+  "repository": {
+    "full_name": "agentguardhq/widget",
+    "owner": {
+      "login": "agentguardhq"
+    }
+  },
+  "sender": {
+    "login": "jaredpleva"
+  }
+}

--- a/internal/dispatch/testdata/copilot_pr_opened.json
+++ b/internal/dispatch/testdata/copilot_pr_opened.json
@@ -1,0 +1,22 @@
+{
+  "action": "opened",
+  "pull_request": {
+    "number": 137,
+    "title": "Guard against empty input in widget",
+    "user": {
+      "login": "copilot-swe-agent[bot]",
+      "type": "Bot"
+    },
+    "body": "Fixes #42\n\nAdds a nil-check before dereferencing the input.",
+    "draft": true
+  },
+  "repository": {
+    "full_name": "agentguardhq/widget",
+    "owner": {
+      "login": "agentguardhq"
+    }
+  },
+  "sender": {
+    "login": "copilot-swe-agent[bot]"
+  }
+}

--- a/internal/dispatch/webhook.go
+++ b/internal/dispatch/webhook.go
@@ -285,6 +285,23 @@ func (ws *WebhookServer) handleWebhook(w http.ResponseWriter, r *http.Request) {
 	action := getString(payload, "action")
 	repo := getNestedString(payload, "repository", "full_name")
 
+	// T2b: Enterprise Copilot coding agent telemetry (agentguardhq).
+	// Purely observational — synthesize a DispatchRecord so swarm_today's
+	// tiers.copilot column counts the session, then fall through so any
+	// other handlers (which mostly no-op for agentguardhq/*) still run.
+	if ev := DetectCopilotAgentEvent(githubEvent, action, payload); ev != nil && ws.dispatcher != nil {
+		cpCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		err := ws.dispatcher.RecordCopilotAgentEvent(cpCtx, ev)
+		cancel()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "[octi-pulpo] copilot-agent telemetry error %s#%d: %v\n",
+				ev.Repo, maxInt(ev.Issue, ev.PR), err)
+		} else {
+			fmt.Fprintf(os.Stderr, "[octi-pulpo] copilot-agent %s %s issue=%d pr=%d\n",
+				ev.Kind, ev.Repo, ev.Issue, ev.PR)
+		}
+	}
+
 	// Draft-to-ready gate: detect when Copilot signals review_requested on a draft PR
 	// and promote it to ready-for-review so normal CI and review pipelines can fire.
 	if githubEvent == "pull_request" && action == "review_requested" && ws.draftConverter != nil {

--- a/internal/mcp/swarm_today.go
+++ b/internal/mcp/swarm_today.go
@@ -224,6 +224,7 @@ func classifyTiers(recent []dispatch.DispatchRecord, since time.Time) map[string
 	out := map[string]TierCounts{
 		"local":   {},
 		"actions": {},
+		"copilot": {},
 		"cloud":   {},
 		"desktop": {},
 		"human":   {},
@@ -253,6 +254,10 @@ func classifyTiers(recent []dispatch.DispatchRecord, since time.Time) map[string
 func tierFor(driver, agent string) string {
 	d := strings.ToLower(driver)
 	switch {
+	// T2b: Enterprise Copilot coding agent — must precede the generic
+	// "copilot" substring branch below which routes copilot-cli to desktop.
+	case d == "copilot-agent", strings.Contains(d, "copilot-agent"):
+		return "copilot"
 	case strings.Contains(d, "gh-actions"), strings.Contains(d, "actions"):
 		return "actions"
 	case strings.Contains(d, "anthropic"), strings.Contains(d, "claude-api"), strings.Contains(d, "cloud"):
@@ -287,7 +292,7 @@ func renderSwarmTodayText(r *SwarmTodayReport) string {
 	}
 	b.WriteString(issLine + "\n")
 
-	tierOrder := []string{"local", "actions", "cloud", "desktop", "human"}
+	tierOrder := []string{"local", "actions", "copilot", "cloud", "desktop", "human"}
 	parts := []string{}
 	var silentNote string
 	for _, t := range tierOrder {


### PR DESCRIPTION
## Summary

Wire the agentguardhq Enterprise Copilot coding agent (\$40/mo seat) into octi's existing webhook receiver so every session is counted in swarm_today. Today Copilot is the largest unmeasured dispatch channel (curie telemetry audit P0, davinci G14).

## Detection rules

Pure function `DetectCopilotAgentEvent(event, action, payload)` — fixture-replayable, no network.

| Webhook | Rule | Synth row |
|---|---|---|
| `issues.assigned` | `assignee.login == "Copilot"` | `driver=copilot-agent, tier=copilot, result=dispatched` |
| `issues.unassigned` | same | `result=canceled` |
| `pull_request.opened/reopened/synchronize` | `user.login == "copilot-swe-agent[bot]"` | `result=completed`, joined to the dispatch by `(repo, issue)` via body `Fixes #N` |

Synthesized records land on the same Redis `dispatch-log` key the dispatcher uses, so `swarm_today.classifyTiers` picks them up with no extra plumbing. A new `tiers.copilot` column is added to the report; `ClassifyTier` maps `copilot-agent` → `copilot`; `tierFor` routes `copilot-agent` before the generic "copilot" substring branch (which still sends copilot-cli to desktop).

Purely additive — no existing chitinhq handler changes, and the new hook only logs then falls through.

## Constraints respected

- Worktree: `/home/jared/workspace-worktrees/octi-t2b-copilot-lovelace`
- No separate service needed — webhook receiver is already inside the `octi-pulpo` binary (`internal/dispatch/webhook.go`)
- No agentguardhq repo touched; no Copilot session invoked
- Org-level webhook is the recommended wiring (one URL, all repos)

## Wiring the agentguardhq webhook

Run once, replacing `<WEBHOOK_URL>` with your cloudflared tunnel target (e.g. `https://<tunnel>.trycloudflare.com/webhook`) and `<SECRET>` with the same value octi-pulpo already verifies:

\`\`\`
gh api -X POST /orgs/agentguardhq/hooks -f name=web -F active=true -f config[url]=<WEBHOOK_URL> -f config[content_type]=json -f config[secret]=<SECRET> -f events[]=issues -f events[]=pull_request
\`\`\`

## Expected swarm_today output once live

\`\`\`
Tiers:  local=3 actions=12 copilot=2 cloud=1 desktop=0 human=0
\`\`\`

## Test plan

- [x] `go test ./internal/dispatch/ -run CopilotAgent`
- [x] `go test ./internal/mcp/ -run SwarmToday`
- [x] Full `go test ./internal/...` green
- [ ] Once webhook URL is wired on agentguardhq, assign Copilot to any issue and confirm `mcp__octi__swarm_today` shows `tiers.copilot.dispatches=1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)