### PR TITLE
chore(octi): retire cloud tier + drop deepseek from clawta + phantom-silent-loss fix

### DIFF
--- a/internal/dispatch/clawta_adapter.go
+++ b/internal/dispatch/clawta_adapter.go
@@ -14,16 +14,17 @@ import (
 )
 
 const (
-	defaultClawtaModel    = "deepseek-chat"
 	clawtaTimeout         = 10 * time.Minute
 	defaultClawtaBinary   = "clawta"
-	defaultClawtaProvider = "deepseek"
+	defaultClawtaProvider = "ollama-cloud"
 
 	// Ollama Cloud (OpenAI-compatible) — flat $20/mo, wired in openclaw.
 	ollamaCloudBaseURL      = "https://ollama.com/v1"
 	defaultOllamaCloudModel = "gpt-oss:20b"
+	defaultClawtaModel      = defaultOllamaCloudModel
 
-	// Local Ollama — zero-cost fallback.
+	// Local Ollama — zero-cost path. Used when the local daemon is
+	// reachable (e.g. on the dedicated GPU box).
 	localOllamaHost         = "127.0.0.1:11434"
 	defaultLocalOllamaModel = "qwen2.5-coder:7b"
 )
@@ -40,10 +41,11 @@ type ClawtaAdapter struct {
 }
 
 // NewClawtaAdapter creates a ClawtaAdapter. Zero-value strings fall back to
-// defaults: binary="clawta", model="deepseek-chat", provider="deepseek",
+// defaults: binary="clawta", model="gpt-oss:20b", provider="ollama-cloud",
 // workspace="$HOME/workspace". At dispatch time the adapter auto-selects an
-// inference provider (local Ollama → Ollama Cloud → DeepSeek) unless the
-// caller constructed it with an explicit non-default provider override.
+// inference provider (local Ollama → Ollama Cloud) unless the caller
+// constructed it with an explicit non-default provider override. DeepSeek
+// was retired from the T1 worker path — Ollama Cloud + local GPU only.
 func NewClawtaAdapter(binary, model, provider, workspace string) *ClawtaAdapter {
 	if binary == "" {
 		binary = defaultClawtaBinary
@@ -73,7 +75,7 @@ func (a *ClawtaAdapter) SetLearner(l *learner.Learner) { a.learner = l }
 
 // providerChoice describes the concrete provider/model/auth passed to clawta.
 type providerChoice struct {
-	name    string // telemetry label: "ollama-local", "ollama-cloud", "deepseek"
+	name    string // telemetry label: "ollama-local", "ollama-cloud"
 	flag    string // clawta --provider value
 	model   string
 	baseURL string // empty = provider default
@@ -82,11 +84,12 @@ type providerChoice struct {
 }
 
 // selectProvider picks an inference provider in preference order:
-//  1. local Ollama reachable at 127.0.0.1:11434 (free)
+//  1. local Ollama reachable at 127.0.0.1:11434 (free, dedicated GPU box)
 //  2. OLLAMA_CLOUD_API_KEY set (flat $20/mo)
-//  3. DEEPSEEK_API_KEY set (legacy, kept for when wallet refills)
 //
-// Returns nil if none are available.
+// Returns nil if none are available. DeepSeek was retired from this path
+// on 2026-04-15 — provider policy locks T1 workers to Ollama Cloud +
+// local GPU only.
 func selectProvider() *providerChoice {
 	if localOllamaReachable() {
 		return &providerChoice{
@@ -104,15 +107,6 @@ func selectProvider() *providerChoice {
 			baseURL: ollamaCloudBaseURL,
 			envKey:  "OPENAI_API_KEY",
 			envVal:  key,
-		}
-	}
-	if key := os.Getenv("DEEPSEEK_API_KEY"); key != "" {
-		return &providerChoice{
-			name:   "deepseek",
-			flag:   "deepseek",
-			model:  defaultClawtaModel,
-			envKey: "DEEPSEEK_API_KEY",
-			envVal: key,
 		}
 	}
 	return nil
@@ -142,8 +136,8 @@ func envOr(key, fallback string) string {
 }
 
 // CanAccept returns true for code-gen, bugfix, config, and evolve task types
-// when at least one inference provider is available (local Ollama, Ollama
-// Cloud, or DeepSeek).
+// when at least one inference provider is available (local Ollama or
+// Ollama Cloud).
 func (a *ClawtaAdapter) CanAccept(task *Task) bool {
 	if selectProvider() == nil {
 		return false
@@ -171,7 +165,7 @@ func (a *ClawtaAdapter) Dispatch(ctx context.Context, task *Task) (*AdapterResul
 	choice := selectProvider()
 	if choice == nil {
 		result.Status = "failed"
-		result.Error = "no inference provider available (need OLLAMA_CLOUD_API_KEY, DEEPSEEK_API_KEY, or local Ollama at 127.0.0.1:11434)"
+		result.Error = "no inference provider available (need OLLAMA_CLOUD_API_KEY or local Ollama at 127.0.0.1:11434)"
 		return result, nil
 	}
 

--- a/internal/dispatch/clawta_adapter_test.go
+++ b/internal/dispatch/clawta_adapter_test.go
@@ -11,7 +11,9 @@ import (
 // isolateProviderEnv clears all provider-selection inputs so a test case can
 // re-assert exactly one. Local-Ollama is skipped by default via
 // CLAWTA_SKIP_LOCAL_OLLAMA=1 — tests that want to exercise the local-Ollama
-// branch must override that explicitly.
+// branch must override that explicitly. DEEPSEEK_API_KEY is also cleared
+// defensively so stray env state on the test host cannot smuggle the
+// retired DeepSeek provider into any assertion.
 func isolateProviderEnv(t *testing.T) {
 	t.Helper()
 	t.Setenv("DEEPSEEK_API_KEY", "")
@@ -33,59 +35,59 @@ func TestClawtaAdapterName(t *testing.T) {
 
 func TestClawtaAdapterCanAcceptCodeGen(t *testing.T) {
 	isolateProviderEnv(t)
-	t.Setenv("DEEPSEEK_API_KEY", "test-key")
+	t.Setenv("OLLAMA_CLOUD_API_KEY", "test-key")
 	a := NewClawtaAdapter("", "", "", "")
 	task := &Task{Type: "code-gen"}
 	if !a.CanAccept(task) {
-		t.Error("CanAccept(code-gen) with deepseek key: want true, got false")
+		t.Error("CanAccept(code-gen) with ollama-cloud key: want true, got false")
 	}
 }
 
 func TestClawtaAdapterCanAcceptBugfix(t *testing.T) {
 	isolateProviderEnv(t)
-	t.Setenv("DEEPSEEK_API_KEY", "test-key")
+	t.Setenv("OLLAMA_CLOUD_API_KEY", "test-key")
 	a := NewClawtaAdapter("", "", "", "")
 	task := &Task{Type: "bugfix"}
 	if !a.CanAccept(task) {
-		t.Error("CanAccept(bugfix) with deepseek key: want true, got false")
+		t.Error("CanAccept(bugfix) with ollama-cloud key: want true, got false")
 	}
 }
 
 func TestClawtaAdapterCanAcceptConfig(t *testing.T) {
 	isolateProviderEnv(t)
-	t.Setenv("DEEPSEEK_API_KEY", "test-key")
+	t.Setenv("OLLAMA_CLOUD_API_KEY", "test-key")
 	a := NewClawtaAdapter("", "", "", "")
 	task := &Task{Type: "config"}
 	if !a.CanAccept(task) {
-		t.Error("CanAccept(config) with deepseek key: want true, got false")
+		t.Error("CanAccept(config) with ollama-cloud key: want true, got false")
 	}
 }
 
 func TestClawtaAdapterCanAcceptEvolve(t *testing.T) {
 	isolateProviderEnv(t)
-	t.Setenv("DEEPSEEK_API_KEY", "test-key")
+	t.Setenv("OLLAMA_CLOUD_API_KEY", "test-key")
 	a := NewClawtaAdapter("", "", "", "")
 	task := &Task{Type: "evolve"}
 	if !a.CanAccept(task) {
-		t.Error("CanAccept(evolve) with deepseek key: want true, got false")
+		t.Error("CanAccept(evolve) with ollama-cloud key: want true, got false")
 	}
 }
 
 func TestClawtaAdapterCanAcceptEvolveSubTypes(t *testing.T) {
 	isolateProviderEnv(t)
-	t.Setenv("DEEPSEEK_API_KEY", "test-key")
+	t.Setenv("OLLAMA_CLOUD_API_KEY", "test-key")
 	a := NewClawtaAdapter("", "", "", "")
 	for _, typ := range []string{"prompt_config", "tool_addition", "config_change"} {
 		task := &Task{Type: typ}
 		if !a.CanAccept(task) {
-			t.Errorf("CanAccept(%s) with deepseek key: want true, got false", typ)
+			t.Errorf("CanAccept(%s) with ollama-cloud key: want true, got false", typ)
 		}
 	}
 }
 
 func TestClawtaAdapterRejectsPRReview(t *testing.T) {
 	isolateProviderEnv(t)
-	t.Setenv("DEEPSEEK_API_KEY", "test-key")
+	t.Setenv("OLLAMA_CLOUD_API_KEY", "test-key")
 	a := NewClawtaAdapter("", "", "", "")
 	task := &Task{Type: "pr-review"}
 	if a.CanAccept(task) {
@@ -95,7 +97,7 @@ func TestClawtaAdapterRejectsPRReview(t *testing.T) {
 
 func TestClawtaAdapterRejectsTriage(t *testing.T) {
 	isolateProviderEnv(t)
-	t.Setenv("DEEPSEEK_API_KEY", "test-key")
+	t.Setenv("OLLAMA_CLOUD_API_KEY", "test-key")
 	a := NewClawtaAdapter("", "", "", "")
 	task := &Task{Type: "triage"}
 	if a.CanAccept(task) {
@@ -115,33 +117,24 @@ func TestClawtaAdapterRejectsWithoutAnyProvider(t *testing.T) {
 	}
 }
 
-// ---- Provider selection (3-way) ----
+// ---- Provider selection (2-way: local Ollama → Ollama Cloud) ----
 
-func TestSelectProviderDeepSeekOnly(t *testing.T) {
+// TestSelectProviderDeepSeekRetired verifies that DEEPSEEK_API_KEY alone is
+// NOT sufficient to select a provider — DeepSeek was removed from the T1
+// cascade on 2026-04-15 (provider policy: Ollama Cloud + local GPU only).
+func TestSelectProviderDeepSeekRetired(t *testing.T) {
 	isolateProviderEnv(t)
 	t.Setenv("DEEPSEEK_API_KEY", "ds-key")
-	c := selectProvider()
-	if c == nil {
-		t.Fatal("selectProvider: want non-nil, got nil")
-	}
-	if c.name != "deepseek" {
-		t.Errorf("provider: want deepseek, got %s", c.name)
-	}
-	if c.flag != "deepseek" {
-		t.Errorf("flag: want deepseek, got %s", c.flag)
-	}
-	if c.envKey != "DEEPSEEK_API_KEY" || c.envVal != "ds-key" {
-		t.Errorf("env: want DEEPSEEK_API_KEY=ds-key, got %s=%s", c.envKey, c.envVal)
+	if c := selectProvider(); c != nil {
+		t.Errorf("selectProvider with only DEEPSEEK_API_KEY: want nil (retired), got %+v", c)
 	}
 }
 
-// TestSelectProviderOllamaCloudPreferredOverDeepSeek verifies preference:
-// when both OLLAMA_CLOUD_API_KEY and DEEPSEEK_API_KEY are set (and local
-// ollama is skipped), ollama-cloud wins.
-func TestSelectProviderOllamaCloudPreferredOverDeepSeek(t *testing.T) {
+// TestSelectProviderOllamaCloud verifies selection when OLLAMA_CLOUD_API_KEY
+// is set and local Ollama is unreachable.
+func TestSelectProviderOllamaCloud(t *testing.T) {
 	isolateProviderEnv(t)
 	t.Setenv("OLLAMA_CLOUD_API_KEY", "oc-key")
-	t.Setenv("DEEPSEEK_API_KEY", "ds-key")
 	c := selectProvider()
 	if c == nil {
 		t.Fatal("selectProvider: want non-nil, got nil")
@@ -288,7 +281,7 @@ func TestDetectDefaultBranchMain(t *testing.T) {
 
 func TestClawtaAdapterDispatchFailsGracefully(t *testing.T) {
 	isolateProviderEnv(t)
-	t.Setenv("DEEPSEEK_API_KEY", "test-key")
+	t.Setenv("OLLAMA_CLOUD_API_KEY", "test-key")
 
 	ws := t.TempDir()
 	a := NewClawtaAdapter("clawta-does-not-exist", "", "", ws)

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -1184,7 +1184,7 @@ func toolDefs() []ToolDef {
 		},
 		{
 			Name:        "tier_activity",
-			Description: "Summarize dispatch activity by Ladder Forge tier (local/actions/cloud/desktop/human/unknown) over the last N hours. v0 telemetry — T1 local and T4 desktop report 0 until those tiers come online; legacy entries without a tier field are counted as unknown.",
+			Description: "Summarize dispatch activity by Ladder Forge tier (local/actions/copilot/desktop/human/unknown) over the last N hours. v0 telemetry — T1 local reports 0 until the dedicated GPU box is online; legacy entries without a tier field are counted as unknown. The old T3 'cloud-scheduled' bucket was retired 2026-04-15.",
 			InputSchema: map[string]interface{}{
 				"type": "object",
 				"properties": map[string]interface{}{

--- a/internal/mcp/swarm_today.go
+++ b/internal/mcp/swarm_today.go
@@ -225,13 +225,20 @@ func classifyTiers(recent []dispatch.DispatchRecord, since time.Time) map[string
 		"local":   {},
 		"actions": {},
 		"copilot": {},
-		"cloud":   {},
 		"desktop": {},
 		"human":   {},
 	}
 	for _, r := range recent {
 		ts, err := time.Parse(time.RFC3339, r.Timestamp)
 		if err != nil || ts.Before(since) {
+			continue
+		}
+		// Phantom-silent-loss fix (octi#243): dispatch-log entries with
+		// Result=="skipped" are router no-ops (e.g. workspace-pr-review-agent
+		// retries), not real dispatches. Counting them via the driver=""
+		// fallback inflated the `human` bucket by ~450/day and falsely
+		// triggered silent-loss alerts.
+		if r.Result == "skipped" {
 			continue
 		}
 		tier := tierFor(r.Driver, r.Agent)
@@ -260,8 +267,6 @@ func tierFor(driver, agent string) string {
 		return "copilot"
 	case strings.Contains(d, "gh-actions"), strings.Contains(d, "actions"):
 		return "actions"
-	case strings.Contains(d, "anthropic"), strings.Contains(d, "claude-api"), strings.Contains(d, "cloud"):
-		return "cloud"
 	case strings.Contains(d, "clawta"), strings.Contains(d, "ollama"), strings.Contains(d, "local"):
 		return "local"
 	case strings.Contains(d, "copilot"), strings.Contains(d, "desktop"), strings.Contains(d, "prompt-cli"), strings.Contains(d, "openclaw"):
@@ -292,7 +297,7 @@ func renderSwarmTodayText(r *SwarmTodayReport) string {
 	}
 	b.WriteString(issLine + "\n")
 
-	tierOrder := []string{"local", "actions", "copilot", "cloud", "desktop", "human"}
+	tierOrder := []string{"local", "actions", "copilot", "desktop", "human"}
 	parts := []string{}
 	var silentNote string
 	for _, t := range tierOrder {

--- a/internal/mcp/swarm_today_test.go
+++ b/internal/mcp/swarm_today_test.go
@@ -59,7 +59,9 @@ func TestSwarmToday_Active(t *testing.T) {
 			{Name: "copilot", CircuitState: "CLOSED", LastSuccess: lastSuccess},
 		},
 		recent: []dispatch.DispatchRecord{
-			{Agent: "kernel-01", Driver: "anthropic", Result: "dispatched", Timestamp: now.Add(-10 * time.Minute).Format(time.RFC3339)},
+			// T2b Copilot agent (see #263). Replaces the retired T3
+			// anthropic/cloud record that previously seeded this test.
+			{Agent: "kernel-01", Driver: "copilot-agent", Result: "dispatched", Timestamp: now.Add(-10 * time.Minute).Format(time.RFC3339)},
 			{Agent: "kernel-02", Driver: "gh-actions", Result: "dispatched", Timestamp: now.Add(-20 * time.Minute).Format(time.RFC3339)},
 		},
 		budgetTodayC: 47,
@@ -82,8 +84,11 @@ func TestSwarmToday_Active(t *testing.T) {
 	if r.Swarm.LastRunWorkflow != "chitin-swarm-worker" || r.Swarm.RunsToday != 1 {
 		t.Fatalf("swarm mismatch: %+v", r.Swarm)
 	}
-	if r.Tiers["cloud"].Dispatches != 1 {
-		t.Fatalf("expected 1 cloud dispatch, got %+v", r.Tiers)
+	if r.Tiers["copilot"].Dispatches != 1 {
+		t.Fatalf("expected 1 copilot dispatch, got %+v", r.Tiers)
+	}
+	if _, hasCloud := r.Tiers["cloud"]; hasCloud {
+		t.Fatalf("cloud bucket should be retired post-2026-04-15, got %+v", r.Tiers)
 	}
 	if r.Tiers["actions"].Dispatches != 1 {
 		t.Fatalf("expected 1 actions dispatch, got %+v", r.Tiers)
@@ -136,6 +141,40 @@ func TestSwarmToday_StuckAndSilentLoss(t *testing.T) {
 	}
 	if r.Alerts.SilentDispatches != 5 || r.Alerts.StuckAgents != 1 || r.Alerts.StaleDrivers != 1 {
 		t.Fatalf("alerts mismatch: %+v", r.Alerts)
+	}
+}
+
+// TestClassifyTiers_SkippedNotCountedAsHuman pins the phantom-silent-loss fix.
+// The workspace-pr-review-agent fast-path writes dispatch-log entries with
+// driver="" + result="skipped" when the router no-ops. Before the fix,
+// classifyTiers would bucket those into `human` via the driver="" fallback
+// and falsely flag silent-loss once the count crossed 5. The fix skips
+// result=="skipped" records outright.
+func TestClassifyTiers_SkippedNotCountedAsHuman(t *testing.T) {
+	now := fixedNow()
+	since := now.Add(-24 * time.Hour)
+	var recent []dispatch.DispatchRecord
+	for i := 0; i < 100; i++ {
+		recent = append(recent, dispatch.DispatchRecord{
+			Agent:     "workspace-pr-review-agent",
+			Driver:    "",
+			Result:    "skipped",
+			Timestamp: now.Add(-time.Duration(i) * time.Minute).Format(time.RFC3339),
+		})
+	}
+	// One legitimate human escalation, to prove the bucket still works.
+	recent = append(recent, dispatch.DispatchRecord{
+		Agent: "needs-human", Driver: "human", Result: "dispatched",
+		Timestamp: now.Add(-5 * time.Minute).Format(time.RFC3339),
+	})
+
+	tiers := classifyTiers(recent, since)
+
+	if got := tiers["human"].Dispatches; got != 1 {
+		t.Fatalf("human dispatches: want 1 (skipped records excluded), got %d", got)
+	}
+	if tiers["human"].SilentLoss {
+		t.Fatalf("human tier should not flag silent-loss when skipped records are excluded")
 	}
 }
 

--- a/internal/mcp/tier_activity.go
+++ b/internal/mcp/tier_activity.go
@@ -24,7 +24,12 @@ type TierActivitySummary struct {
 
 // knownTiers is the canonical tier set reported by v0. Buckets are always
 // present (dispatches=0) so clients get a stable shape.
-var knownTiers = []string{"local", "actions", "cloud", "desktop", "human", "unknown"}
+// knownTiers covers the active Ladder Forge surfaces after the 2026-04-15
+// retirement of the old T3 "cloud-scheduled" (RemoteTrigger) bucket. Any
+// legacy records still carrying Tier="cloud" in Redis will be surfaced
+// dynamically in the output (see bucket creation below) but are no longer
+// pre-initialized.
+var knownTiers = []string{"local", "actions", "copilot", "desktop", "human", "unknown"}
 
 // tierActivitySummary scans the last `limit` entries of the dispatch log in
 // Redis namespace `ns` and groups them by tier over the last `windowHours`.

--- a/internal/mcp/tier_activity_test.go
+++ b/internal/mcp/tier_activity_test.go
@@ -70,8 +70,8 @@ func TestTierActivitySummary_GroupsByTier(t *testing.T) {
 	if got := sum.Tiers["unknown"].Dispatches; got != 1 {
 		t.Errorf("unknown=%d, want 1", got)
 	}
-	if got := sum.Tiers["cloud"].Dispatches; got != 0 {
-		t.Errorf("cloud=%d, want 0 (T3 not online)", got)
+	if _, present := sum.Tiers["cloud"]; present {
+		t.Errorf("cloud bucket should not be pre-initialized after T3 retirement (2026-04-15)")
 	}
 	if sum.Scanned != 4 {
 		t.Errorf("scanned=%d, want 4", sum.Scanned)


### PR DESCRIPTION
## Summary

Three bundled swarm-hygiene cleanups, one PR. The octi-pulpo binary rebuild + systemd restart is a post-merge step.

1. **Phantom silent-loss fix** (`internal/mcp/swarm_today.go`). `classifyTiers` was bucketing `workspace-pr-review-agent` retries (driver="", result="skipped") into `human` via the empty-driver fallback. ~450/day inflation; false silent-loss alert once count crossed 5. Fix: skip `result=="skipped"` records before bucketing. New test `TestClassifyTiers_SkippedNotCountedAsHuman` fails pre-fix.

2. **Retire T3 cloud tier.** Drop the `cloud` bucket from `swarm_today.classifyTiers`, drop the `anthropic/claude-api/cloud` case from `tierFor`, drop `cloud` from the render tierOrder. In `tier_activity.go` drop `cloud` from `knownTiers` and update the MCP tool description. Semantic keys (`local`, `actions`, `copilot`, `desktop`, `human`) unchanged — no renaming. `dispatch.ClassifyTier` left alone (driver→tier classification; out of scope).

3. **DeepSeek retired from ClawtaAdapter cascade.** Provider policy locks T1 workers to Ollama Cloud + local GPU only. Removed `DEEPSEEK_API_KEY` branch from `selectProvider`, default provider/model flipped to `ollama-cloud` + `gpt-oss:20b`. Local Ollama path preserved (will pass CanAccept once the dedicated GPU box is online). The standalone `DeepSeekAdapter` (triage/pr-review cascade) is untouched — separate adapter, separate retirement.

Also: `~/.openclaw/openclaw.json` DeepSeek provider block removed on the host (not in this diff — config is gitignored; backup at `~/.openclaw/openclaw.json.bak.pre-deepseek-removal`).

## Before (swarm_today snapshot pre-fix)

```
Tiers:  local=0 actions=45 cloud=0 desktop=0 human=455/0*
        *silent-loss suspected
Alerts: silent_dispatches=455 stuck_agents=0 stale_drivers=0
```

## After (expected post-merge + binary restart)

- `cloud` key absent from Tiers output.
- `human` drops dramatically (phantom 455 gone; real human escalations only).
- `silent_dispatches` drops to ~0 on a quiet swarm.
- A fresh dispatch-log entry post-restart carries a populated `dispatch_id` (via #258 which is now compiled in).

Final after-snapshot will be appended to this PR description after the binary rebuild + systemctl restart.

## Verification

- `go build ./...` clean
- `go vet ./...` clean
- `go test ./...` green (all 27 packages)
- New test `TestClassifyTiers_SkippedNotCountedAsHuman` fails pre-fix, passes post-fix (manually verified by reasoning — 100 skipped records with driver:"" would bucket 100→human via fallback and trip silent-loss).

## Out of scope (intentionally)

- 4-tier rename refactor (latent socrates flag — separate PR).
- #263 Copilot webhook semantics (untouched).
- T3→T1 handoff protocol (lovelace's future spec).
- Standalone `DeepSeekAdapter` for triage/pr-review (separate retirement decision).

## Test plan

- [ ] Merge this PR.
- [ ] `cd /home/jared/workspace/octi && git pull && make build` (or `go build -o bin/octi-pulpo ./cmd/octi-pulpo`).
- [ ] `systemctl --user restart octi-pulpo`.
- [ ] Confirm new PID + binary mtime match build time.
- [ ] Call `mcp__octi__swarm_today` → confirm `cloud` key absent, `human` drops, fresh dispatch-log entry carries `dispatch_id`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)