### PR TITLE
feat(dispatch): T2 Copilot iteration loop — auto-mention on COMMENTED auto-reviews

### DIFF
--- a/cmd/octi-pulpo/main.go
+++ b/cmd/octi-pulpo/main.go
@@ -224,6 +224,13 @@ func main() {
 		cascadeHandler := dispatch.NewCascadeHandler("", "", "")
 		ws.SetCascadeHandler(cascadeHandler)
 
+		// Wire Copilot fix loop + iteration loop — keep Copilot PRs moving
+		// without human intervention. Both require a GitHub token.
+		if ghToken := os.Getenv("GITHUB_TOKEN"); ghToken != "" {
+			ws.SetCopilotFixLoop(dispatch.NewCopilotFixLoop(ghToken, rdb))
+			ws.SetCopilotIterationLoop(dispatch.NewCopilotIterationLoop(ghToken, rdb, dispatcher))
+		}
+
 		// Wire Slack Events API command handler when credentials are set.
 		if slackSecret := os.Getenv("SLACK_SIGNING_SECRET"); slackSecret != "" {
 			slackBotToken := os.Getenv("SLACK_BOT_TOKEN")

--- a/internal/dispatch/copilot_iteration.go
+++ b/internal/dispatch/copilot_iteration.go
@@ -1,0 +1,288 @@
+package dispatch
+
+// T2 internal-iteration loop (bridge).
+//
+// Copilot's auto-reviewer (`copilot-pull-request-reviewer`) leaves
+// COMMENTED reviews on PRs the Copilot coding agent (`copilot-swe-agent`)
+// authors, but NOTHING automatic happens after that — the PR stalls. To
+// continue iterating we must @-mention @copilot to re-trigger the coding
+// agent. This loop does that mechanically, with safety caps.
+//
+// Scope is deliberately narrow:
+//   - trigger only on pull_request_review.submitted
+//   - reviewer == copilot-pull-request-reviewer (auto-review bot)
+//   - review state == COMMENTED
+//   - PR author == copilot-swe-agent (NOT human-authored)
+//   - PR is not draft
+// Caps:
+//   - max 3 iterations per PR (Redis counter, 7d TTL)
+//   - 60s debounce between fires (SetNX)
+//   - skip when review body has zero `Suggested change:` blocks AND zero
+//     `## ` section headings (best-effort "looks good" heuristic; when
+//     in doubt, iterate).
+//
+// On cap-hit we label the PR `tier:human` and emit a dispatch-log record
+// with event=iteration_max_reached. On successful trigger we emit
+// event=iteration_triggered.
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+const (
+	// CopilotIterationMention is the comment body that re-triggers the
+	// Copilot coding agent on the PR.
+	CopilotIterationMention = "@copilot please address the review feedback above"
+
+	// CopilotAutoReviewerBot is the login of the auto-review bot that
+	// leaves COMMENTED reviews on Copilot-authored PRs.
+	CopilotAutoReviewerBot = "copilot-pull-request-reviewer"
+
+	// CopilotIterationMaxAttempts caps the number of @-mention triggers
+	// per PR before escalation to a human.
+	CopilotIterationMaxAttempts = 3
+
+	// CopilotIterationCounterTTL bounds stale counters when a PR is
+	// abandoned without a close event.
+	CopilotIterationCounterTTL = 7 * 24 * time.Hour
+
+	// CopilotIterationDebounce collapses bursts of quick-fire review
+	// events from the auto-reviewer into a single @-mention.
+	CopilotIterationDebounce = 60 * time.Second
+)
+
+// iterationRedis is the narrow Redis surface used by CopilotIterationLoop.
+// Kept separate from copilotRedis so tests can evolve independently.
+type iterationRedis interface {
+	Incr(ctx context.Context, key string) *redis.IntCmd
+	Expire(ctx context.Context, key string, ttl time.Duration) *redis.BoolCmd
+	SetNX(ctx context.Context, key string, value interface{}, ttl time.Duration) *redis.BoolCmd
+	Del(ctx context.Context, keys ...string) *redis.IntCmd
+}
+
+// CopilotIterationLoop auto-mentions @copilot on COMMENTED auto-reviews.
+type CopilotIterationLoop struct {
+	ghToken     string
+	rdb         iterationRedis
+	baseURL     string
+	maxAttempts int
+	dispatcher  *Dispatcher // optional — for dispatch-log telemetry
+}
+
+// NewCopilotIterationLoop wires a new loop using the shared Redis client.
+func NewCopilotIterationLoop(ghToken string, rdb redis.Cmdable, dispatcher *Dispatcher) *CopilotIterationLoop {
+	return &CopilotIterationLoop{
+		ghToken:     ghToken,
+		rdb:         rdb,
+		baseURL:     "https://api.github.com",
+		maxAttempts: CopilotIterationMaxAttempts,
+		dispatcher:  dispatcher,
+	}
+}
+
+// ReviewInput is the minimal slice of webhook fields the loop needs. The
+// webhook handler extracts these from `pull_request_review.submitted`
+// payloads and passes them in; keeping the signature typed (not a raw
+// map) makes the contract explicit and test-friendly.
+type ReviewInput struct {
+	Repo         string
+	PRNumber     int
+	ReviewerBot  string // review.user.login
+	ReviewState  string // review.state — "commented", "approved", ...
+	PRAuthor     string // pull_request.user.login
+	IsDraft      bool   // pull_request.draft
+	ReviewBody   string // review.body
+}
+
+// HandleReview is the single entry point. It returns (triggered, err).
+// `triggered` is true iff a new @-mention was posted this call (useful in
+// tests and for caller-side logging). All "skip" paths return
+// (false, nil) — they are routine, not errors.
+func (c *CopilotIterationLoop) HandleReview(ctx context.Context, in ReviewInput) (bool, error) {
+	if !c.shouldIterate(in) {
+		return false, nil
+	}
+
+	// Debounce: swallow a 2nd fire within the window.
+	debounceKey := c.debounceKey(in.Repo, in.PRNumber)
+	ok, err := c.rdb.SetNX(ctx, debounceKey, "1", CopilotIterationDebounce).Result()
+	if err != nil {
+		return false, fmt.Errorf("copilot-iter: debounce setnx: %w", err)
+	}
+	if !ok {
+		return false, nil
+	}
+
+	// Increment iteration counter atomically and refresh TTL.
+	counterKey := c.counterKey(in.Repo, in.PRNumber)
+	count, err := c.rdb.Incr(ctx, counterKey).Result()
+	if err != nil {
+		return false, fmt.Errorf("copilot-iter: incr counter: %w", err)
+	}
+	_ = c.rdb.Expire(ctx, counterKey, CopilotIterationCounterTTL).Err()
+
+	if count > int64(c.maxAttempts) {
+		// Cap exceeded — escalate to a human.
+		if labelErr := c.addLabel(ctx, in.Repo, in.PRNumber, "tier:human"); labelErr != nil {
+			return false, fmt.Errorf("copilot-iter: add tier:human: %w", labelErr)
+		}
+		c.emitDispatchLog(ctx, in.Repo, in.PRNumber, "iteration_max_reached", int(count))
+		return false, nil
+	}
+
+	if err := c.postComment(ctx, in.Repo, in.PRNumber, CopilotIterationMention); err != nil {
+		return false, err
+	}
+	c.emitDispatchLog(ctx, in.Repo, in.PRNumber, "iteration_triggered", int(count))
+	return true, nil
+}
+
+// shouldIterate gates on author / reviewer / state / draft / body heuristics.
+// Conservative: when in doubt, iterate.
+func (c *CopilotIterationLoop) shouldIterate(in ReviewInput) bool {
+	if !strings.EqualFold(in.ReviewState, "commented") {
+		return false
+	}
+	if !isCopilotAutoReviewer(in.ReviewerBot) {
+		return false
+	}
+	if !isCopilotSWEBot(in.PRAuthor) {
+		return false
+	}
+	if in.IsDraft {
+		return false
+	}
+	if looksLikeNoActionableFindings(in.ReviewBody) {
+		return false
+	}
+	return true
+}
+
+// isCopilotAutoReviewer matches the auto-review bot login. GitHub sometimes
+// suffixes `[bot]` and the handle is occasionally seen lowercased, so
+// compare case-insensitively against both forms.
+func isCopilotAutoReviewer(login string) bool {
+	l := strings.ToLower(strings.TrimSuffix(login, "[bot]"))
+	return l == CopilotAutoReviewerBot
+}
+
+// looksLikeNoActionableFindings is a conservative heuristic: return true
+// only when the review body has ZERO `Suggested change:` blocks AND
+// ZERO `## ` headings. Any structure => iterate.
+func looksLikeNoActionableFindings(body string) bool {
+	if body == "" {
+		return true
+	}
+	if strings.Contains(body, "Suggested change:") {
+		return false
+	}
+	// A `## ` section heading must start a line. Split and check each.
+	for _, line := range strings.Split(body, "\n") {
+		if strings.HasPrefix(line, "## ") {
+			return false
+		}
+	}
+	return true
+}
+
+// emitDispatchLog synthesizes a DispatchRecord so swarm_today and
+// Sentinel can observe iteration events. Best-effort; errors are logged
+// but not returned.
+func (c *CopilotIterationLoop) emitDispatchLog(ctx context.Context, repo string, prNumber int, eventName string, count int) {
+	if c.dispatcher == nil {
+		return
+	}
+	rec := DispatchRecord{
+		Agent: "copilot-iteration",
+		Event: Event{
+			Type:   EventSignal,
+			Source: "github",
+			Repo:   repo,
+			Payload: map[string]string{
+				"event":     eventName,
+				"pr":        strconv.Itoa(prNumber),
+				"iteration": strconv.Itoa(count),
+			},
+		},
+		Result:     eventName,
+		Reason:     fmt.Sprintf("copilot-iteration %s: %s#%d (iter=%d)", eventName, repo, prNumber, count),
+		Driver:     CopilotAgentDriver,
+		Tier:       "copilot",
+		DispatchID: newDispatchID(),
+		Timestamp:  time.Now().UTC().Format(time.RFC3339),
+	}
+	data, err := json.Marshal(rec)
+	if err != nil {
+		return
+	}
+	pipe := c.dispatcher.rdb.Pipeline()
+	pipe.LPush(ctx, c.dispatcher.key("dispatch-log"), data)
+	pipe.LTrim(ctx, c.dispatcher.key("dispatch-log"), 0, 499)
+	_, _ = pipe.Exec(ctx)
+}
+
+func (c *CopilotIterationLoop) counterKey(repo string, prNumber int) string {
+	return "octi:copilot_iterations:" + repo + ":" + strconv.Itoa(prNumber)
+}
+
+func (c *CopilotIterationLoop) debounceKey(repo string, prNumber int) string {
+	return "octi:copilot_iter_debounce:" + repo + ":" + strconv.Itoa(prNumber)
+}
+
+// postComment posts a comment on the PR via the GitHub issues-comments API.
+func (c *CopilotIterationLoop) postComment(ctx context.Context, repo string, prNumber int, body string) error {
+	url := fmt.Sprintf("%s/repos/%s/issues/%d/comments", c.baseURL, repo, prNumber)
+	payload, _ := json.Marshal(map[string]string{"body": body})
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(payload))
+	if err != nil {
+		return fmt.Errorf("copilot-iter: build request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+c.ghToken)
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("copilot-iter: post comment: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 300 {
+		respBody, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("copilot-iter: GitHub API %d: %s", resp.StatusCode, string(respBody))
+	}
+	return nil
+}
+
+// addLabel attaches a single label to the PR/issue.
+func (c *CopilotIterationLoop) addLabel(ctx context.Context, repo string, prNumber int, label string) error {
+	url := fmt.Sprintf("%s/repos/%s/issues/%d/labels", c.baseURL, repo, prNumber)
+	payload, _ := json.Marshal(map[string][]string{"labels": {label}})
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(payload))
+	if err != nil {
+		return fmt.Errorf("copilot-iter: build label request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+c.ghToken)
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("copilot-iter: label request: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 300 {
+		respBody, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("copilot-iter: GitHub API (label) %d: %s", resp.StatusCode, string(respBody))
+	}
+	return nil
+}

--- a/internal/dispatch/copilot_iteration_test.go
+++ b/internal/dispatch/copilot_iteration_test.go
@@ -1,0 +1,308 @@
+package dispatch
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+// --- minimal Redis mock implementing iterationRedis ---
+//
+// The iteration loop's surface is narrower than the fix loop's — Incr /
+// Expire / SetNX / Del. We keep a separate mock so the two tests evolve
+// independently (the fix-loop mock cannot grow SetNX without tangling).
+
+type mockIterRedis struct {
+	mu       sync.Mutex
+	counters map[string]int64
+	setnx    map[string]bool // simulates existence of debounce keys
+}
+
+func newMockIterRedis() *mockIterRedis {
+	return &mockIterRedis{
+		counters: make(map[string]int64),
+		setnx:    make(map[string]bool),
+	}
+}
+
+func (m *mockIterRedis) Incr(ctx context.Context, key string) *redis.IntCmd {
+	m.mu.Lock()
+	m.counters[key]++
+	val := m.counters[key]
+	m.mu.Unlock()
+	cmd := redis.NewIntCmd(ctx)
+	cmd.SetVal(val)
+	return cmd
+}
+
+func (m *mockIterRedis) Expire(ctx context.Context, key string, ttl time.Duration) *redis.BoolCmd {
+	cmd := redis.NewBoolCmd(ctx)
+	cmd.SetVal(true)
+	return cmd
+}
+
+// SetNX returns false on the second call for the same key within process
+// lifetime — simulates the debounce window being honored. A test that
+// wants to "expire" the window calls clearDebounce.
+func (m *mockIterRedis) SetNX(ctx context.Context, key string, value interface{}, ttl time.Duration) *redis.BoolCmd {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	cmd := redis.NewBoolCmd(ctx)
+	if m.setnx[key] {
+		cmd.SetVal(false)
+		return cmd
+	}
+	m.setnx[key] = true
+	cmd.SetVal(true)
+	return cmd
+}
+
+func (m *mockIterRedis) Del(ctx context.Context, keys ...string) *redis.IntCmd {
+	m.mu.Lock()
+	var n int64
+	for _, k := range keys {
+		if _, ok := m.counters[k]; ok {
+			delete(m.counters, k)
+			n++
+		}
+		if _, ok := m.setnx[k]; ok {
+			delete(m.setnx, k)
+			n++
+		}
+	}
+	m.mu.Unlock()
+	cmd := redis.NewIntCmd(ctx)
+	cmd.SetVal(n)
+	return cmd
+}
+
+func (m *mockIterRedis) clearDebounce() {
+	m.mu.Lock()
+	m.setnx = make(map[string]bool)
+	m.mu.Unlock()
+}
+
+// --- GH mock that records both comments AND label calls ---
+
+type ghCall struct {
+	Path string
+	Body string
+}
+
+func newIterGHMock(t *testing.T) (*httptest.Server, *[]ghCall) {
+	t.Helper()
+	var calls []ghCall
+	var mu sync.Mutex
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		mu.Lock()
+		calls = append(calls, ghCall{Path: r.URL.Path, Body: string(body)})
+		mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		w.Write([]byte(`{"id":1}`))
+	}))
+	t.Cleanup(srv.Close)
+	return srv, &calls
+}
+
+func newIterLoopForTest(rdb *mockIterRedis, baseURL string) *CopilotIterationLoop {
+	return &CopilotIterationLoop{
+		ghToken:     "tok",
+		rdb:         rdb,
+		baseURL:     baseURL,
+		maxAttempts: CopilotIterationMaxAttempts,
+	}
+}
+
+// An actionable review body — has a `## ` heading so the heuristic treats
+// it as worth iterating on.
+const actionableReview = "## Findings\nsome feedback"
+
+func validInput() ReviewInput {
+	return ReviewInput{
+		Repo:        "chitinhq/demo",
+		PRNumber:    7,
+		ReviewerBot: "copilot-pull-request-reviewer",
+		ReviewState: "commented",
+		PRAuthor:    "copilot-swe-agent[bot]",
+		IsDraft:     false,
+		ReviewBody:  actionableReview,
+	}
+}
+
+func ctx5s(t *testing.T) (context.Context, context.CancelFunc) {
+	t.Helper()
+	return context.WithTimeout(context.Background(), 5*time.Second)
+}
+
+// --- tests ---
+
+// TestCopilotIteration_TriggersOnCommentedReview confirms the happy path:
+// a COMMENTED review from the auto-reviewer on a Copilot-authored PR
+// produces exactly one @copilot mention.
+func TestCopilotIteration_TriggersOnCommentedReview(t *testing.T) {
+	srv, calls := newIterGHMock(t)
+	rdb := newMockIterRedis()
+	loop := newIterLoopForTest(rdb, srv.URL)
+
+	ctx, cancel := ctx5s(t)
+	defer cancel()
+
+	triggered, err := loop.HandleReview(ctx, validInput())
+	if err != nil {
+		t.Fatalf("HandleReview: %v", err)
+	}
+	if !triggered {
+		t.Fatalf("expected triggered=true")
+	}
+	if len(*calls) != 1 {
+		t.Fatalf("expected 1 GH call, got %d", len(*calls))
+	}
+	if !strings.Contains((*calls)[0].Body, "@copilot please address") {
+		t.Errorf("expected @copilot mention, got body=%q", (*calls)[0].Body)
+	}
+	if !strings.HasSuffix((*calls)[0].Path, "/issues/7/comments") {
+		t.Errorf("expected comments endpoint, got %s", (*calls)[0].Path)
+	}
+}
+
+// TestCopilotIteration_RespectsMaxCap confirms the 4th attempt labels
+// the PR tier:human instead of posting another mention.
+func TestCopilotIteration_RespectsMaxCap(t *testing.T) {
+	srv, calls := newIterGHMock(t)
+	rdb := newMockIterRedis()
+	loop := newIterLoopForTest(rdb, srv.URL)
+
+	ctx, cancel := ctx5s(t)
+	defer cancel()
+
+	// Fire 4 times, clearing the debounce between each so the cap — not
+	// the debounce — gates the last call.
+	for i := 0; i < 4; i++ {
+		if _, err := loop.HandleReview(ctx, validInput()); err != nil {
+			t.Fatalf("attempt %d: %v", i+1, err)
+		}
+		rdb.clearDebounce()
+	}
+
+	// Expect 3 comment posts + 1 label call.
+	var comments, labels int
+	for _, c := range *calls {
+		switch {
+		case strings.HasSuffix(c.Path, "/issues/7/comments"):
+			comments++
+		case strings.HasSuffix(c.Path, "/issues/7/labels"):
+			labels++
+		}
+	}
+	if comments != 3 {
+		t.Errorf("expected 3 comments, got %d", comments)
+	}
+	if labels != 1 {
+		t.Errorf("expected 1 label call, got %d", labels)
+	}
+	// Check label body has tier:human.
+	var sawTierHuman bool
+	for _, c := range *calls {
+		if strings.Contains(c.Body, `"tier:human"`) {
+			sawTierHuman = true
+		}
+	}
+	if !sawTierHuman {
+		t.Errorf("expected tier:human label in one call; calls=%+v", *calls)
+	}
+}
+
+// TestCopilotIteration_SkipsHumanAuthoredPR — author != copilot-swe-agent
+// must not fire the loop even on a COMMENTED auto-review.
+func TestCopilotIteration_SkipsHumanAuthoredPR(t *testing.T) {
+	srv, calls := newIterGHMock(t)
+	rdb := newMockIterRedis()
+	loop := newIterLoopForTest(rdb, srv.URL)
+
+	ctx, cancel := ctx5s(t)
+	defer cancel()
+
+	in := validInput()
+	in.PRAuthor = "jared" // human
+
+	triggered, err := loop.HandleReview(ctx, in)
+	if err != nil {
+		t.Fatalf("HandleReview: %v", err)
+	}
+	if triggered {
+		t.Errorf("expected triggered=false for human-authored PR")
+	}
+	if len(*calls) != 0 {
+		t.Errorf("expected 0 GH calls, got %d", len(*calls))
+	}
+}
+
+// TestCopilotIteration_SkipsDraft — draft PRs are considered in-progress
+// and must not be iterated.
+func TestCopilotIteration_SkipsDraft(t *testing.T) {
+	srv, calls := newIterGHMock(t)
+	rdb := newMockIterRedis()
+	loop := newIterLoopForTest(rdb, srv.URL)
+
+	ctx, cancel := ctx5s(t)
+	defer cancel()
+
+	in := validInput()
+	in.IsDraft = true
+
+	triggered, err := loop.HandleReview(ctx, in)
+	if err != nil {
+		t.Fatalf("HandleReview: %v", err)
+	}
+	if triggered {
+		t.Errorf("expected triggered=false for draft PR")
+	}
+	if len(*calls) != 0 {
+		t.Errorf("expected 0 GH calls, got %d", len(*calls))
+	}
+}
+
+// TestCopilotIteration_DebouncesQuickFires — two fires within the debounce
+// window produce only a single @copilot mention.
+func TestCopilotIteration_DebouncesQuickFires(t *testing.T) {
+	srv, calls := newIterGHMock(t)
+	rdb := newMockIterRedis()
+	loop := newIterLoopForTest(rdb, srv.URL)
+
+	ctx, cancel := ctx5s(t)
+	defer cancel()
+
+	if _, err := loop.HandleReview(ctx, validInput()); err != nil {
+		t.Fatalf("first HandleReview: %v", err)
+	}
+	triggered, err := loop.HandleReview(ctx, validInput())
+	if err != nil {
+		t.Fatalf("second HandleReview: %v", err)
+	}
+	if triggered {
+		t.Errorf("expected second fire to be debounced")
+	}
+	// Only one comment posted — debounce won.
+	var comments int
+	for _, c := range *calls {
+		if strings.HasSuffix(c.Path, "/issues/7/comments") {
+			comments++
+		}
+	}
+	if comments != 1 {
+		t.Errorf("expected 1 comment (debounced), got %d", comments)
+	}
+}
+
+// silence unused-import warnings if json is later dropped
+var _ = json.Marshal

--- a/internal/dispatch/webhook.go
+++ b/internal/dispatch/webhook.go
@@ -42,6 +42,7 @@ type WebhookServer struct {
 	cascadeHandler     *CascadeHandler
 	draftConverter     *DraftConverter
 	copilotFix         *CopilotFixLoop
+	copilotIteration   *CopilotIterationLoop
 	branchUpdater      *BranchUpdater
 }
 
@@ -79,6 +80,13 @@ func (ws *WebhookServer) SetDraftConverter(dc *DraftConverter) {
 // when PR reviews request changes.
 func (ws *WebhookServer) SetCopilotFixLoop(cf *CopilotFixLoop) {
 	ws.copilotFix = cf
+}
+
+// SetCopilotIterationLoop enables the T2 internal-iteration loop — auto-mentions
+// @copilot on COMMENTED auto-reviewer feedback so PRs keep moving without
+// human intervention (capped at 3 iterations per PR).
+func (ws *WebhookServer) SetCopilotIterationLoop(ci *CopilotIterationLoop) {
+	ws.copilotIteration = ci
 }
 
 // SetBranchUpdater enables automatic PR branch updates when the default
@@ -333,11 +341,24 @@ func (ws *WebhookServer) handleWebhook(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Copilot fix loop: auto-post @copilot comment when a review requests changes.
+	// Copilot iteration loop: auto-mention @copilot on COMMENTED auto-reviewer feedback.
 	if githubEvent == "pull_request_review" && action == "submitted" {
+		reviewState := getNestedString(payload, "review", "state")
+		prNumber := int(getNestedNumber(payload, "pull_request", "number"))
 		if ws.copilotFix != nil {
-			reviewState := getNestedString(payload, "review", "state")
-			prNumber := int(getNestedNumber(payload, "pull_request", "number"))
 			go ws.copilotFix.HandleReview(context.Background(), repo, prNumber, reviewState)
+		}
+		if ws.copilotIteration != nil {
+			in := ReviewInput{
+				Repo:        repo,
+				PRNumber:    prNumber,
+				ReviewerBot: getNestedString(payload, "review", "user", "login"),
+				ReviewState: reviewState,
+				PRAuthor:    getNestedString(payload, "pull_request", "user", "login"),
+				IsDraft:     getNestedBool(payload, "pull_request", "draft"),
+				ReviewBody:  getNestedString(payload, "review", "body"),
+			}
+			go ws.copilotIteration.HandleReview(context.Background(), in)
 		}
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)


### PR DESCRIPTION
## Summary

- New `CopilotIterationLoop` auto-mentions `@copilot` when the auto-reviewer leaves a COMMENTED review on a Copilot-authored PR — unblocks overnight PRs that would otherwise stall.
- Hard cap: 3 iterations per PR (Redis counter, 7d TTL). On the 4th trigger, label `tier:human` + emit `iteration_max_reached` dispatch-log row.
- 60s SetNX debounce collapses bursts of review events into a single mention.
- Complementary to existing `CopilotFixLoop` (which handles `changes_requested`) — wired side-by-side in the `pull_request_review.submitted` branch of the webhook handler.
- Wired into `cmd/octi-pulpo/main.go` when `GITHUB_TOKEN` is set.

## Why now

Tonight's campaign-dispatch strike is filing ~12 Copilot agent assignments. Each produces a PR that gets an auto-COMMENTED review and then stalls. Without this loop, all 12 sit static until morning.

## Test plan

- [x] `TestCopilotIteration_TriggersOnCommentedReview`
- [x] `TestCopilotIteration_RespectsMaxCap` (4th attempt → `tier:human` label)
- [x] `TestCopilotIteration_SkipsHumanAuthoredPR`
- [x] `TestCopilotIteration_SkipsDraft`
- [x] `TestCopilotIteration_DebouncesQuickFires`
- [x] Full `go test ./...` green

## Rollout

After merge: rebuild + `systemctl --user restart octi-pulpo.service`. Retroactively: already-COMMENTED PRs will NOT auto-iterate (only new review events trigger the webhook).

Strike: hopper-iter-loop-2026-04-15-2125

🤖 Generated with [Claude Code](https://claude.com/claude-code)