### PR TITLE
feat(sprint): gate sprint_complete on validate/check_ci_passed

### DIFF
--- a/internal/mcp/gate_runner.go
+++ b/internal/mcp/gate_runner.go
@@ -1,0 +1,61 @@
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"time"
+)
+
+// GateRunner runs a named chitin gate against a target ref (PR number as string,
+// branch name, or empty for cwd). Returns nil on pass, error on fail. The error
+// message is surfaced back through sprint_complete so the agent can retry.
+//
+// Implementations shell out to `chitin gate run <name>` by default; tests inject
+// a mock to avoid a real chitin dependency.
+type GateRunner interface {
+	Run(ctx context.Context, gate string, ref string) error
+}
+
+// execGateRunner is the production GateRunner: it shells out to `chitin`.
+type execGateRunner struct{}
+
+func (execGateRunner) Run(ctx context.Context, gate string, ref string) error {
+	ctx, cancel := context.WithTimeout(ctx, 60*time.Second)
+	defer cancel()
+	args := []string{"gate", "run", gate}
+	if ref != "" {
+		args = append(args, "--ref", ref)
+	}
+	cmd := exec.CommandContext(ctx, "chitin", args...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("gate %s failed: %v: %s", gate, err, string(out))
+	}
+	return nil
+}
+
+// SetGateRunner overrides the default gate runner. Used by tests and to wire a
+// real chitin binary at startup. If never called, the shell-out implementation
+// is used.
+func (s *Server) SetGateRunner(gr GateRunner) { s.gateRunner = gr }
+
+// runSprintCompleteGates executes the gate chain required to mark a sprint item
+// done. Returns the first failing gate name and its error, or ("", nil) on pass.
+// When prNumber == 0 the ref is empty (gates run against cwd / default).
+func (s *Server) runSprintCompleteGates(ctx context.Context, repo string, prNumber int) (string, error) {
+	if s.gateRunner == nil {
+		s.gateRunner = execGateRunner{}
+	}
+	ref := ""
+	if prNumber > 0 {
+		ref = fmt.Sprintf("%s#%d", repo, prNumber)
+	}
+	gates := []string{"validate/check_ci_passed"}
+	for _, g := range gates {
+		if err := s.gateRunner.Run(ctx, g, ref); err != nil {
+			return g, err
+		}
+	}
+	return "", nil
+}

--- a/internal/mcp/gate_runner.go
+++ b/internal/mcp/gate_runner.go
@@ -30,9 +30,19 @@ func (execGateRunner) Run(ctx context.Context, gate string, ref string) error {
 	cmd := exec.CommandContext(ctx, "chitin", args...)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("gate %s failed: %v: %s", gate, err, string(out))
+		return fmt.Errorf("gate %s failed: %v: %s", gate, err, truncateOutput(out, 2048))
 	}
 	return nil
+}
+
+// truncateOutput returns the last `max` bytes of `out`, prefixed with a marker
+// when truncation occurred. Keeps JSON-RPC error payloads bounded and avoids
+// leaking large env/path dumps from chatty gate scripts.
+func truncateOutput(out []byte, max int) string {
+	if len(out) <= max {
+		return string(out)
+	}
+	return fmt.Sprintf("...[truncated %d bytes]...%s", len(out)-max, string(out[len(out)-max:]))
 }
 
 // SetGateRunner overrides the default gate runner. Used by tests and to wire a

--- a/internal/mcp/gate_runner_test.go
+++ b/internal/mcp/gate_runner_test.go
@@ -1,0 +1,75 @@
+package mcp
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+// mockGateRunner records calls and returns a scripted error per gate name.
+type mockGateRunner struct {
+	errs  map[string]error
+	calls []string
+}
+
+func (m *mockGateRunner) Run(ctx context.Context, gate, ref string) error {
+	m.calls = append(m.calls, gate+"@"+ref)
+	if err, ok := m.errs[gate]; ok {
+		return err
+	}
+	return nil
+}
+
+func TestRunSprintCompleteGates_CIFailBlocks(t *testing.T) {
+	s := &Server{}
+	m := &mockGateRunner{errs: map[string]error{
+		"validate/check_ci_passed": errors.New("CI red on last commit"),
+	}}
+	s.SetGateRunner(m)
+
+	failed, err := s.runSprintCompleteGates(context.Background(), "chitinhq/octi", 42)
+	if err == nil {
+		t.Fatal("expected error when CI gate fails, got nil")
+	}
+	if failed != "validate/check_ci_passed" {
+		t.Errorf("failed gate name: got %q, want validate/check_ci_passed", failed)
+	}
+	if !strings.Contains(err.Error(), "CI red") {
+		t.Errorf("error should surface underlying cause, got: %v", err)
+	}
+	if len(m.calls) != 1 {
+		t.Errorf("expected 1 gate call, got %d: %v", len(m.calls), m.calls)
+	}
+	if !strings.Contains(m.calls[0], "chitinhq/octi#42") {
+		t.Errorf("gate should receive repo#PR ref, got: %s", m.calls[0])
+	}
+}
+
+func TestRunSprintCompleteGates_CIGreenPasses(t *testing.T) {
+	s := &Server{}
+	m := &mockGateRunner{errs: map[string]error{}}
+	s.SetGateRunner(m)
+
+	failed, err := s.runSprintCompleteGates(context.Background(), "chitinhq/octi", 99)
+	if err != nil {
+		t.Fatalf("expected nil error on green CI, got: %v", err)
+	}
+	if failed != "" {
+		t.Errorf("expected empty failed gate, got %q", failed)
+	}
+}
+
+func TestRunSprintCompleteGates_NoPRNumberEmptyRef(t *testing.T) {
+	s := &Server{}
+	m := &mockGateRunner{}
+	s.SetGateRunner(m)
+
+	_, err := s.runSprintCompleteGates(context.Background(), "chitinhq/octi", 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(m.calls) != 1 || !strings.HasSuffix(m.calls[0], "@") {
+		t.Errorf("expected empty ref when no PR, got: %v", m.calls)
+	}
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -74,6 +74,7 @@ type Server struct {
 	rdb              *redis.Client
 	redisNS          string
 	bootcheckCache   *bootcheck.Cache
+	gateRunner       GateRunner
 }
 
 // SetBootcheckCache enables the bootcheck_status MCP tool.
@@ -548,16 +549,49 @@ func (s *Server) handleToolCall(req Request) (resp Response) {
 			return errorResp(req.ID, -32000, "sprint store not initialized")
 		}
 		var args struct {
-			Repo     string `json:"repo"`
-			IssueNum int    `json:"issue_num"`
-			Summary  string `json:"summary"`
+			Repo       string `json:"repo"`
+			IssueNum   int    `json:"issue_num"`
+			Summary    string `json:"summary"`
+			SkipGates  bool   `json:"skip_gates"`
 		}
 		json.Unmarshal(params.Arguments, &args)
 		if args.IssueNum == 0 {
 			return errorResp(req.ID, -32602, "issue_num is required")
 		}
+		// Resolve PR number (if any) so gates can target the linked PR.
+		resolvePR := func(repo string) int {
+			items, err := s.sprintStore.GetAll(ctx)
+			if err != nil {
+				return 0
+			}
+			for _, it := range items {
+				if it.Repo == repo && it.IssueNum == args.IssueNum {
+					return it.PRNumber
+				}
+			}
+			return 0
+		}
+		// Run gate chain unless explicitly skipped (migration escape hatch).
+		runGates := func(repo string) (Response, bool) {
+			if args.SkipGates {
+				return Response{}, false
+			}
+			failed, err := s.runSprintCompleteGates(ctx, repo, resolvePR(repo))
+			if err != nil {
+				return errorResp(req.ID, -32000,
+					fmt.Sprintf("sprint_complete blocked: gate %s failed: %v", failed, err)), true
+			}
+			return Response{}, false
+		}
 		if args.Repo == "" {
 			for _, repo := range sprint.DefaultRepos {
+				// Peek: only run gates if the item exists in this repo.
+				if pr := resolvePR(repo); pr == 0 {
+					// No match in this repo — skip to next without running gates.
+					// (Complete will still error and we move on.)
+				} else if resp, block := runGates(repo); block {
+					return resp
+				}
 				unblocked, err := s.sprintStore.Complete(ctx, repo, args.IssueNum)
 				if err == nil {
 					args.Repo = repo
@@ -580,6 +614,9 @@ func (s *Server) handleToolCall(req Request) (resp Response) {
 				}
 			}
 			return errorResp(req.ID, -32000, fmt.Sprintf("issue #%d not found in any sprint repo", args.IssueNum))
+		}
+		if resp, block := runGates(args.Repo); block {
+			return resp
 		}
 		unblocked, err := s.sprintStore.Complete(ctx, args.Repo, args.IssueNum)
 		if err != nil {
@@ -1331,6 +1368,7 @@ func toolDefs() []ToolDef {
 					"issue_num": map[string]interface{}{"type": "number", "description": "GitHub issue number to mark done"},
 					"repo":      map[string]string{"type": "string", "description": "Repo (e.g. chitinhq/octi-pulpo). If omitted, all tracked repos are searched."},
 					"summary":   map[string]string{"type": "string", "description": "Optional run summary. When provided, closes the GitHub issue and posts this text as a comment. Leave empty to only update Redis without touching GitHub."},
+					"skip_gates": map[string]string{"type": "boolean", "description": "Migration escape hatch — skip the chitin gate chain (validate/check_ci_passed). Default false; gates block completion on failure."},
 				},
 				"required": []string{"issue_num"},
 			},

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -558,25 +558,28 @@ func (s *Server) handleToolCall(req Request) (resp Response) {
 		if args.IssueNum == 0 {
 			return errorResp(req.ID, -32602, "issue_num is required")
 		}
-		// Resolve PR number (if any) so gates can target the linked PR.
-		resolvePR := func(repo string) int {
-			items, err := s.sprintStore.GetAll(ctx)
-			if err != nil {
-				return 0
-			}
-			for _, it := range items {
+		// Fetch sprint items once and reuse for all repo lookups (avoids repeated
+		// Redis O(n) scans across DefaultRepos).
+		allItems, _ := s.sprintStore.GetAll(ctx)
+		// Resolve sprint item for a repo. Returns (found, prNumber). prNumber may
+		// legitimately be 0 for an existing item with no linked PR — callers must
+		// branch on `found`, not on prNumber, to decide whether the item exists.
+		resolveItem := func(repo string) (bool, int) {
+			for _, it := range allItems {
 				if it.Repo == repo && it.IssueNum == args.IssueNum {
-					return it.PRNumber
+					return true, it.PRNumber
 				}
 			}
-			return 0
+			return false, 0
 		}
 		// Run gate chain unless explicitly skipped (migration escape hatch).
-		runGates := func(repo string) (Response, bool) {
+		// Caller is responsible for confirming the item exists before invoking,
+		// so gates always run against a real sprint item (possibly with empty ref).
+		runGates := func(repo string, prNumber int) (Response, bool) {
 			if args.SkipGates {
 				return Response{}, false
 			}
-			failed, err := s.runSprintCompleteGates(ctx, repo, resolvePR(repo))
+			failed, err := s.runSprintCompleteGates(ctx, repo, prNumber)
 			if err != nil {
 				return errorResp(req.ID, -32000,
 					fmt.Sprintf("sprint_complete blocked: gate %s failed: %v", failed, err)), true
@@ -585,11 +588,13 @@ func (s *Server) handleToolCall(req Request) (resp Response) {
 		}
 		if args.Repo == "" {
 			for _, repo := range sprint.DefaultRepos {
-				// Peek: only run gates if the item exists in this repo.
-				if pr := resolvePR(repo); pr == 0 {
-					// No match in this repo — skip to next without running gates.
-					// (Complete will still error and we move on.)
-				} else if resp, block := runGates(repo); block {
+				// Only run gates if the item exists in this repo. Use `found` —
+				// not prNumber == 0 — so items without a linked PR still gate.
+				found, prNumber := resolveItem(repo)
+				if !found {
+					continue
+				}
+				if resp, block := runGates(repo, prNumber); block {
 					return resp
 				}
 				unblocked, err := s.sprintStore.Complete(ctx, repo, args.IssueNum)
@@ -615,7 +620,15 @@ func (s *Server) handleToolCall(req Request) (resp Response) {
 			}
 			return errorResp(req.ID, -32000, fmt.Sprintf("issue #%d not found in any sprint repo", args.IssueNum))
 		}
-		if resp, block := runGates(args.Repo); block {
+		// Resolve item before running gates so a missing sprint item surfaces as
+		// "not found" rather than a misleading gate failure (e.g., empty-ref CI
+		// check against cwd).
+		found, prNumber := resolveItem(args.Repo)
+		if !found {
+			return errorResp(req.ID, -32000,
+				fmt.Sprintf("issue #%d not found in sprint repo %s", args.IssueNum, args.Repo))
+		}
+		if resp, block := runGates(args.Repo, prNumber); block {
 			return resp
 		}
 		unblocked, err := s.sprintStore.Complete(ctx, args.Repo, args.IssueNum)


### PR DESCRIPTION
## Summary

Wires a result gate into `mcp__octi__sprint_complete` so completion is deterministic rather than agent self-report. Before marking a sprint item done, the handler now:

- Resolves the linked PR number from the sprint store (by repo + issue_num)
- Runs a chitin gate chain — currently `validate/check_ci_passed`
- On any gate failure: returns `-32000` error surfacing the failing gate name; the item is NOT marked done (agent must fix + retry)
- `skip_gates: true` escape hatch (default false) for migration only

New `GateRunner` interface (internal/mcp/gate_runner.go) decouples the shell-out so tests can mock. Default `execGateRunner` shells out to `chitin gate run <gate> --ref <repo>#<pr>`.

## Test plan

- [x] Unit: `TestRunSprintCompleteGates_CIFailBlocks` — gate error surfaces failing gate name + cause
- [x] Unit: `TestRunSprintCompleteGates_CIGreenPasses` — green CI returns nil
- [x] Unit: `TestRunSprintCompleteGates_NoPRNumberEmptyRef` — empty ref when no linked PR
- [x] `go build ./...` clean
- [x] `go test ./internal/mcp/` all pass
- [ ] Integration test against real `chitin gate run` binary (follow-up — needs CI harness with chitin installed)
- [ ] Wire stage-appropriate gates beyond `check_ci_passed` (e.g. `groom/has_subtasks` for grooming tasks) — scaffolding in place, add in follow-up