### PR TITLE
feat(ci): wire chitin-gate + semantic-advisory reusable workflows

### DIFF
--- a/.github/workflows/chitin-gate-build-pr.yml
+++ b/.github/workflows/chitin-gate-build-pr.yml
@@ -11,4 +11,4 @@ jobs:
   validate:
     uses: chitinhq/chitin/.github/workflows/chitin-gate.yml@main
     with:
-      stage: validate
+      stage: build

--- a/.github/workflows/chitin-gate-build.yml
+++ b/.github/workflows/chitin-gate-build.yml
@@ -1,0 +1,14 @@
+name: chitin-gate build
+
+# Calls the reusable chitin-gate workflow at stage=build on push to main.
+# Pinned to @main for now; tag-pin in a follow-up once chitin cuts a release.
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  build:
+    uses: chitinhq/chitin/.github/workflows/chitin-gate.yml@main
+    with:
+      stage: build

--- a/.github/workflows/chitin-gate-validate.yml
+++ b/.github/workflows/chitin-gate-validate.yml
@@ -1,0 +1,14 @@
+name: chitin-gate validate
+
+# Calls the reusable chitin-gate workflow at stage=validate on every PR.
+# Pinned to @main for now; tag-pin in a follow-up once chitin cuts a release.
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  validate:
+    uses: chitinhq/chitin/.github/workflows/chitin-gate.yml@main
+    with:
+      stage: validate

--- a/.github/workflows/semantic-advisory.yml
+++ b/.github/workflows/semantic-advisory.yml
@@ -15,3 +15,5 @@ permissions:
 jobs:
   advisory:
     uses: chitinhq/chitin/.github/workflows/semantic-advisory.yml@main
+    # Advisory-only: never block merge even if the reusable workflow errors.
+    continue-on-error: true

--- a/.github/workflows/semantic-advisory.yml
+++ b/.github/workflows/semantic-advisory.yml
@@ -1,0 +1,17 @@
+name: semantic-advisory
+
+# Calls the reusable semantic-advisory workflow on PR open/sync.
+# Advisory only — never blocks merge. Reusable defaults to ci_mock=1 so
+# GH-hosted runners produce a heuristic verdict instead of needing ollama.
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  advisory:
+    uses: chitinhq/chitin/.github/workflows/semantic-advisory.yml@main


### PR DESCRIPTION
Wires the new reusable workflows from chitinhq/chitin into this repo:

- `chitin-gate-validate.yml` — calls reusable `chitin-gate.yml` with `stage: validate` on every PR.
- `chitin-gate-build.yml` — calls reusable `chitin-gate.yml` with `stage: build` on push to main.
- `semantic-advisory.yml` — calls reusable `semantic-advisory.yml` on PR open/synchronize. Advisory only, never blocks merge (mocked verdict on GH-hosted runners).

All three are pinned to `chitinhq/chitin@main` for now; follow-up will move to tag-pin once chitin cuts a release.

Draft until the user reviews. No app-code changes.

Soul: hopper · Agent: hopper-wire-20260416-0050