### PR TITLE
feat(dispatch): subscribe to circuit.tripped events + reset MCP

### DIFF
--- a/cmd/octi-pulpo/main.go
+++ b/cmd/octi-pulpo/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"log"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -14,6 +15,7 @@ import (
 	"github.com/chitinhq/octi-pulpo/internal/budget"
 	"github.com/chitinhq/octi-pulpo/internal/coordination"
 	"github.com/chitinhq/octi-pulpo/internal/dispatch"
+	"github.com/chitinhq/octi-pulpo/internal/dispatch/swarmcircuit"
 	"github.com/chitinhq/octi-pulpo/internal/learner"
 	"github.com/chitinhq/octi-pulpo/internal/mcp"
 	"github.com/chitinhq/octi-pulpo/internal/memory"
@@ -123,6 +125,20 @@ func main() {
 		return float64(closed) / float64(len(health))
 	})
 	dispatcher.SetProfiles(profiles)
+
+	// Wire swarm-circuit subscriber: tails the chitin events.jsonl stream
+	// for circuit.<signal> events emitted by sentinel's patrol (chitinhq/
+	// sentinel internal/circuit) and pauses dispatch when any signal
+	// trips. See internal/dispatch/swarmcircuit. Background goroutine —
+	// stops when the process exits; SIGTERM-driven shutdown elsewhere
+	// handles graceful drain.
+	swarmCircuit := swarmcircuit.New("", log.New(os.Stderr, "swarm-circuit ", log.LstdFlags))
+	go func() {
+		if err := swarmCircuit.Run(context.Background()); err != nil && err != context.Canceled {
+			log.Printf("swarm-circuit subscriber exited: %v", err)
+		}
+	}()
+	dispatcher.SetSwarmCircuit(swarmCircuit)
 
 	// Set up sprint store
 	sprintStore := sprint.NewStore(rdb, namespace)

--- a/internal/dispatch/dispatcher.go
+++ b/internal/dispatch/dispatcher.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/chitinhq/octi-pulpo/internal/budget"
 	"github.com/chitinhq/octi-pulpo/internal/coordination"
+	"github.com/chitinhq/octi-pulpo/internal/dispatch/swarmcircuit"
 	"github.com/chitinhq/octi-pulpo/internal/flow"
 	"github.com/chitinhq/octi-pulpo/internal/presence"
 	"github.com/chitinhq/octi-pulpo/internal/routing"
@@ -102,7 +103,21 @@ type Dispatcher struct {
 	queueFile string                // ~/.chitin/queue.txt (compatibility bridge)
 	namespace string
 	adapters  []Adapter // execution-surface adapters; picked by Name() against routed driver
+
+	// swarmCircuit reflects the swarm-wide pause flag driven by sentinel's
+	// circuit-breaker patrol (chitinhq/sentinel internal/circuit). When
+	// non-nil and Paused()=true, Dispatch short-circuits with action="paused".
+	// Distinct from the per-driver health circuit in routing.Router.
+	swarmCircuit *swarmcircuit.Subscriber
 }
+
+// SetSwarmCircuit installs the swarm-circuit subscriber on the dispatcher.
+// nil disables the gate.
+func (d *Dispatcher) SetSwarmCircuit(s *swarmcircuit.Subscriber) { d.swarmCircuit = s }
+
+// SwarmCircuit returns the installed subscriber (may be nil). Surfaced
+// so the MCP layer can read snapshot state into dispatch_status.
+func (d *Dispatcher) SwarmCircuit() *swarmcircuit.Subscriber { return d.swarmCircuit }
 
 // SetAdapters registers adapters that execute a dispatched task on a real
 // surface (HTTP repository_dispatch, Anthropic API, Claude Code CLI, etc.).
@@ -165,6 +180,19 @@ func (d *Dispatcher) DispatchBudget(ctx context.Context, event Event, agentName 
 		Budget:     budget,
 		DispatchID: newDispatchID(),
 		Timestamp:  now.Format(time.RFC3339),
+	}
+
+	// 0a. Swarm-circuit gate: if sentinel's patrol has tripped any of the
+	// four signals (retry_storm / resource_burn / repo_health /
+	// telemetry_integrity), pause new dispatches until an operator
+	// resets the breaker. This is fleet-wide, distinct from per-driver
+	// health in routing.Router.
+	if d.swarmCircuit != nil && d.swarmCircuit.Paused() {
+		st := d.swarmCircuit.Snapshot()
+		result.Action = "paused"
+		result.Reason = fmt.Sprintf("swarm circuit open (%s): %s", st.Signal, st.Reason)
+		d.recordDispatch(ctx, agentName, event, result)
+		return result, nil
 	}
 
 	// 0. Validate: repo-scoped events must carry a non-empty Repo.

--- a/internal/dispatch/swarmcircuit/swarmcircuit.go
+++ b/internal/dispatch/swarmcircuit/swarmcircuit.go
@@ -1,0 +1,263 @@
+// Package swarmcircuit subscribes to circuit.<signal> events on the
+// shared chitin events.jsonl stream and exposes a paused/resumed state
+// to the dispatcher. The patrol that produces these events lives in
+// chitinhq/sentinel (internal/circuit) — this package is the consumer.
+//
+// Architecture: orthogonal patrol, never inline. Sentinel's patrol
+// detects a swarm-wide condition and emits a flow_failed event named
+// `circuit.<signal>` (e.g. `circuit.retry_storm`). Octi's dispatcher
+// tails events.jsonl, sees the event, sets a pause flag, and stops
+// admitting new dispatches until a `circuit.reset` event clears it.
+//
+// Distinct from the per-driver health circuit in internal/routing —
+// that one fails individual drivers based on Octi's own dispatch
+// outcomes. This swarm circuit reflects fleet-wide conditions read
+// from sentinel telemetry.
+package swarmcircuit
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"io"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// State is a snapshot of the swarm circuit. Safe to JSON-marshal into
+// the dispatch_status response.
+type State struct {
+	Paused      bool   `json:"paused"`
+	Signal      string `json:"signal,omitempty"`       // e.g. "retry_storm"
+	Reason      string `json:"reason,omitempty"`       // human-readable threshold + sample
+	Since       string `json:"paused_since,omitempty"` // RFC3339
+	LastEvent   string `json:"last_event,omitempty"`   // last circuit.* tool name observed
+	LastEventAt string `json:"last_event_at,omitempty"`
+}
+
+// Subscriber tails a JSONL stream and maintains pause state. The zero
+// value is unusable — build with New.
+type Subscriber struct {
+	path   string
+	logger *log.Logger
+
+	state atomic.Value // *State, never nil after construction
+	mu    sync.Mutex   // serializes apply()
+}
+
+// New returns a subscriber bound to path. If path is empty,
+// DefaultPath() is consulted. Logger may be nil.
+func New(path string, logger *log.Logger) *Subscriber {
+	if path == "" {
+		path = DefaultPath()
+	}
+	s := &Subscriber{path: path, logger: logger}
+	s.state.Store(&State{})
+	return s
+}
+
+// DefaultPath mirrors octi/internal/flow.destination() so the
+// subscriber reads the same file the producer writes:
+//  1. $MCPTRACE_FILE
+//  2. $CHITIN_WORKSPACE/.chitin/events.jsonl
+//  3. $HOME/.chitin/flow_events.jsonl
+func DefaultPath() string {
+	if p := os.Getenv("MCPTRACE_FILE"); p != "" {
+		return p
+	}
+	if ws := os.Getenv("CHITIN_WORKSPACE"); ws != "" {
+		return filepath.Join(ws, ".chitin", "events.jsonl")
+	}
+	if home, err := os.UserHomeDir(); err == nil && home != "" {
+		return filepath.Join(home, ".chitin", "flow_events.jsonl")
+	}
+	return ""
+}
+
+// Snapshot returns the current state by value.
+func (s *Subscriber) Snapshot() State {
+	if s == nil {
+		return State{}
+	}
+	st := s.state.Load().(*State)
+	return *st
+}
+
+// Paused is the hot-path check used by the dispatcher.
+func (s *Subscriber) Paused() bool {
+	if s == nil {
+		return false
+	}
+	return s.state.Load().(*State).Paused
+}
+
+// Reset clears pause state. Idempotent. Used by mcp__octi__circuit_reset
+// (when scope=="swarm") and by an observed `circuit.reset` event.
+func (s *Subscriber) Reset(reason string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	prev := s.state.Load().(*State)
+	next := &State{
+		LastEvent:   "circuit.reset",
+		LastEventAt: time.Now().UTC().Format(time.RFC3339),
+	}
+	s.state.Store(next)
+	if s.logger != nil && prev.Paused {
+		s.logger.Printf("swarm-circuit: RESET (was %s) reason=%q", prev.Signal, reason)
+	}
+}
+
+// Run tails the JSONL file and applies events. It blocks until ctx is
+// done. A missing file is not an error — Run polls for it to appear.
+// Truncation/rotation is handled by re-opening on EOF when size shrinks.
+func (s *Subscriber) Run(ctx context.Context) error {
+	if s.path == "" {
+		if s.logger != nil {
+			s.logger.Println("swarm-circuit: no events path resolved; subscriber idle")
+		}
+		<-ctx.Done()
+		return ctx.Err()
+	}
+	if s.logger != nil {
+		s.logger.Printf("swarm-circuit: tailing %s", s.path)
+	}
+
+	var (
+		f      *os.File
+		reader *bufio.Reader
+		offset int64
+	)
+	openFile := func() error {
+		if f != nil {
+			f.Close()
+		}
+		var err error
+		f, err = os.Open(s.path)
+		if err != nil {
+			return err
+		}
+		// Start from the end so we don't replay history at startup —
+		// historical trips are stale by definition (operator already
+		// reset, or the situation has cleared).
+		end, err := f.Seek(0, io.SeekEnd)
+		if err != nil {
+			return err
+		}
+		offset = end
+		reader = bufio.NewReader(f)
+		return nil
+	}
+
+	for {
+		if reader == nil {
+			if err := openFile(); err != nil {
+				select {
+				case <-ctx.Done():
+					return ctx.Err()
+				case <-time.After(2 * time.Second):
+					continue
+				}
+			}
+		}
+		line, err := reader.ReadString('\n')
+		if len(line) > 0 {
+			s.handleLine(line)
+		}
+		if err == io.EOF {
+			// Detect rotation/truncation: if the file is shorter than
+			// our offset, re-open from end.
+			if fi, statErr := os.Stat(s.path); statErr == nil && fi.Size() < offset {
+				reader = nil
+				continue
+			}
+			if pos, posErr := f.Seek(0, io.SeekCurrent); posErr == nil {
+				offset = pos
+			}
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(500 * time.Millisecond):
+			}
+			continue
+		}
+		if err != nil {
+			// Read error — close, sleep, retry.
+			reader = nil
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(2 * time.Second):
+			}
+		}
+	}
+}
+
+// handleLine parses a single JSONL line and applies it. Best-effort:
+// malformed lines are ignored.
+func (s *Subscriber) handleLine(line string) {
+	line = strings.TrimSpace(line)
+	if line == "" {
+		return
+	}
+	var ev struct {
+		Tool   string                 `json:"tool"`
+		Action string                 `json:"action"`
+		Fields map[string]interface{} `json:"fields"`
+		Ts     string                 `json:"ts"`
+	}
+	if err := json.Unmarshal([]byte(line), &ev); err != nil {
+		return
+	}
+	tool := strings.TrimPrefix(ev.Tool, "flow.")
+	if !strings.HasPrefix(tool, "circuit.") {
+		return
+	}
+	signal := strings.TrimPrefix(tool, "circuit.")
+
+	if signal == "reset" {
+		s.Reset("event circuit.reset")
+		return
+	}
+
+	// Anything else under circuit.* is a trip. The producer uses
+	// flow_failed for trips, but we don't gate on action — any
+	// circuit.<signal> we see is treated as a trip.
+	s.applyTrip(signal, ev.Fields, ev.Ts)
+}
+
+func (s *Subscriber) applyTrip(signal string, fields map[string]interface{}, ts string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	prev := s.state.Load().(*State)
+	if prev.Paused && prev.Signal == signal {
+		// Already paused on this signal — refresh last-event timestamp
+		// but don't re-log.
+		prev.LastEvent = "circuit." + signal
+		prev.LastEventAt = ts
+		return
+	}
+	reason := signal
+	if t, ok := fields["threshold"].(string); ok && t != "" {
+		reason = signal + ": " + t
+	}
+	if ts == "" {
+		ts = time.Now().UTC().Format(time.RFC3339)
+	}
+	next := &State{
+		Paused:      true,
+		Signal:      signal,
+		Reason:      reason,
+		Since:       ts,
+		LastEvent:   "circuit." + signal,
+		LastEventAt: ts,
+	}
+	s.state.Store(next)
+	if s.logger != nil {
+		s.logger.Printf("swarm-circuit: PAUSED signal=%s reason=%q", signal, reason)
+	}
+}

--- a/internal/dispatch/swarmcircuit/swarmcircuit.go
+++ b/internal/dispatch/swarmcircuit/swarmcircuit.go
@@ -234,19 +234,21 @@ func (s *Subscriber) applyTrip(signal string, fields map[string]interface{}, ts 
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	prev := s.state.Load().(*State)
+	if ts == "" {
+		ts = time.Now().UTC().Format(time.RFC3339)
+	}
 	if prev.Paused && prev.Signal == signal {
 		// Already paused on this signal — refresh last-event timestamp
-		// but don't re-log.
-		prev.LastEvent = "circuit." + signal
-		prev.LastEventAt = ts
+		// but don't re-log. Copy to avoid mutating the live snapshot.
+		next := *prev
+		next.LastEvent = "circuit." + signal
+		next.LastEventAt = ts
+		s.state.Store(&next)
 		return
 	}
 	reason := signal
 	if t, ok := fields["threshold"].(string); ok && t != "" {
 		reason = signal + ": " + t
-	}
-	if ts == "" {
-		ts = time.Now().UTC().Format(time.RFC3339)
 	}
 	next := &State{
 		Paused:      true,

--- a/internal/dispatch/swarmcircuit/swarmcircuit_test.go
+++ b/internal/dispatch/swarmcircuit/swarmcircuit_test.go
@@ -1,0 +1,105 @@
+package swarmcircuit
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func writeLine(t *testing.T, path, line string) {
+	t.Helper()
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0600)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer f.Close()
+	if _, err := f.WriteString(line + "\n"); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+}
+
+// TestSubscriberPausesOnTripAndResumesOnReset emits a synthetic
+// circuit.retry_storm event and then a circuit.reset, asserting the
+// subscriber transitions accordingly.
+func TestSubscriberPausesOnTripAndResumesOnReset(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "events.jsonl")
+	if err := os.WriteFile(path, nil, 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	sub := New(path, nil)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go sub.Run(ctx)
+
+	// Give Run() a beat to open + seek to end.
+	time.Sleep(50 * time.Millisecond)
+
+	if sub.Paused() {
+		t.Fatalf("subscriber paused before any trip event")
+	}
+
+	writeLine(t, path, `{"ts":"2026-04-15T20:00:00Z","tool":"flow.circuit.retry_storm","action":"flow_failed","fields":{"threshold":"retries>3 within 1h","signal":"retry_storm"}}`)
+
+	if !waitFor(func() bool { return sub.Paused() }, time.Second) {
+		t.Fatalf("subscriber did not pause within 1s; state=%+v", sub.Snapshot())
+	}
+	st := sub.Snapshot()
+	if st.Signal != "retry_storm" {
+		t.Fatalf("expected signal retry_storm, got %q", st.Signal)
+	}
+	if st.Reason == "" {
+		t.Fatalf("expected reason populated, got empty")
+	}
+
+	writeLine(t, path, `{"ts":"2026-04-15T20:01:00Z","tool":"flow.circuit.reset","action":"flow_completed"}`)
+
+	if !waitFor(func() bool { return !sub.Paused() }, time.Second) {
+		t.Fatalf("subscriber did not resume within 1s; state=%+v", sub.Snapshot())
+	}
+}
+
+func TestSubscriberIgnoresUnrelatedEvents(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "events.jsonl")
+	if err := os.WriteFile(path, nil, 0600); err != nil {
+		t.Fatal(err)
+	}
+	sub := New(path, nil)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go sub.Run(ctx)
+	time.Sleep(50 * time.Millisecond)
+
+	writeLine(t, path, `{"tool":"flow.swarm.dispatch","action":"flow_completed"}`)
+	writeLine(t, path, `garbage not json`)
+	writeLine(t, path, `{"tool":"flow.unrelated","action":"flow_failed"}`)
+
+	time.Sleep(150 * time.Millisecond)
+	if sub.Paused() {
+		t.Fatalf("subscriber paused on unrelated event: %+v", sub.Snapshot())
+	}
+}
+
+func TestResetIsIdempotent(t *testing.T) {
+	sub := New("/dev/null/missing", nil)
+	sub.Reset("test")
+	sub.Reset("test")
+	if sub.Paused() {
+		t.Fatalf("paused after reset")
+	}
+}
+
+func waitFor(cond func() bool, timeout time.Duration) bool {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return true
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	return cond()
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -388,6 +388,15 @@ func (s *Server) handleToolCall(req Request) (resp Response) {
 			"pending_agents":    agents,
 			"recent_dispatches": recent,
 		}
+		// Surface swarm-circuit pause state so /go can see at a glance
+		// whether sentinel's patrol has frozen the dispatcher (retry_storm
+		// / resource_burn / repo_health / telemetry_integrity). Always
+		// present so consumers can rely on the key.
+		if sc := s.dispatcher.SwarmCircuit(); sc != nil {
+			status["swarm_circuit"] = sc.Snapshot()
+		} else {
+			status["swarm_circuit"] = map[string]interface{}{"paused": false}
+		}
 		// Augment with chitin session state so callers see the active
 		// session id (for rating) and recent session history alongside
 		// dispatch info. Best-effort: if chitin isn't installed or the
@@ -825,10 +834,31 @@ func (s *Server) handleToolCall(req Request) (resp Response) {
 		var args struct {
 			Driver string `json:"driver"`
 			Note   string `json:"note"`
+			Scope  string `json:"scope"` // "driver" (default) or "swarm"
 		}
 		json.Unmarshal(params.Arguments, &args)
+
+		// Scope=swarm clears sentinel's swarm-wide circuit (the patrol-
+		// driven pause flag tailed from events.jsonl) without touching
+		// any per-driver routing health. The Driver field is ignored
+		// when scope=swarm.
+		if args.Scope == "swarm" {
+			if s.dispatcher == nil {
+				return errorResp(req.ID, -32000, "dispatcher not initialized")
+			}
+			sc := s.dispatcher.SwarmCircuit()
+			if sc == nil {
+				return errorResp(req.ID, -32000, "swarm circuit subscriber not wired")
+			}
+			prev := sc.Snapshot()
+			sc.Reset(args.Note)
+			msg := fmt.Sprintf("circuit_reset(swarm): paused=%v→false (was signal=%s)", prev.Paused, prev.Signal)
+			data, _ := json.Marshal(sc.Snapshot())
+			return textResult(req.ID, msg+"\n"+string(data))
+		}
+
 		if args.Driver == "" {
-			return errorResp(req.ID, -32602, "driver is required")
+			return errorResp(req.ID, -32602, "driver is required (or set scope=\"swarm\")")
 		}
 		// Capture previous state for the response message.
 		prev := routing.DriverHealth{Name: args.Driver}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -1521,14 +1521,18 @@ func toolDefs() []ToolDef {
 		},
 		{
 			Name:        "circuit_reset",
-			Description: "Manually reset a driver circuit breaker from OPEN to CLOSED. Use when you know a driver has recovered (e.g. budget refilled, rate-limit lifted, transient error resolved). Requires the driver to have an existing health file.",
+			Description: "Manually reset a circuit breaker. scope='driver' (default) resets a per-driver health circuit from OPEN to CLOSED and requires 'driver'. scope='swarm' clears the swarm-wide pause set by sentinel patrol events (no driver required).",
 			InputSchema: map[string]interface{}{
 				"type": "object",
 				"properties": map[string]interface{}{
-					"driver": map[string]string{"type": "string", "description": "Driver name to reset (e.g. 'openclaw', 'clawta', 'gh-actions', 'claude-api'). Must match an existing health file."},
+					"scope":  map[string]interface{}{"type": "string", "enum": []string{"driver", "swarm"}, "description": "Which circuit to reset. 'driver' (default) resets a per-driver health circuit; 'swarm' clears the fleet-wide pause."},
+					"driver": map[string]string{"type": "string", "description": "Driver name to reset (required when scope='driver'). Must match an existing health file (e.g. 'openclaw', 'clawta', 'gh-actions', 'claude-api')."},
 					"note":   map[string]string{"type": "string", "description": "Optional reason for the manual reset (logged in the response for audit purposes)."},
 				},
-				"required": []string{"driver"},
+				"oneOf": []interface{}{
+					map[string]interface{}{"properties": map[string]interface{}{"scope": map[string]interface{}{"const": "swarm"}}, "required": []string{"scope"}},
+					map[string]interface{}{"required": []string{"driver"}},
+				},
 			},
 		},
 		{


### PR DESCRIPTION
## Summary

Companion to chitinhq/sentinel#76. Wires Octi's dispatcher to the swarm-wide circuit-breaker patrol so a sentinel-detected trip actually freezes new dispatches.

## What lands

- **`internal/dispatch/swarmcircuit/`** — tail-and-state subscriber over the shared chitin `events.jsonl`. Recognizes `circuit.<signal>` (trip) and `circuit.reset` (clear). Starts at end-of-file (no replay of stale historical trips). Lock-free `Snapshot()` via `atomic.Value` for the dispatcher hot path.
- **`internal/dispatch/dispatcher.go`** — `SetSwarmCircuit` / `SwarmCircuit` accessors + a new gate at the top of `DispatchBudget`. When paused, returns `Action="paused"` carrying the tripped signal + threshold. Distinct from the per-driver `routing.Router` circuit.
- **`internal/mcp/server.go`** — `dispatch_status` now always returns a `swarm_circuit` field. `circuit_reset` gains `scope:"swarm"` to clear the swarm pause without touching per-driver health; `scope` defaults to per-driver behavior so existing callers are unaffected.
- **`cmd/octi-pulpo/main.go`** — instantiate subscriber, run in background goroutine, install on dispatcher.

## Test plan

- [x] `go test ./internal/dispatch/swarmcircuit/... ./internal/dispatch/... ./internal/mcp/...` — 501 tests pass across 3 packages
- [x] Synthetic trip event flips `Paused()` true; reset event flips it back
- [x] Garbage / unrelated events do not flip state
- [ ] End-to-end with sentinel patrol writing to the same `events.jsonl`

## Architecture

Orthogonal patrol, never inline. Sentinel patrols, emits `circuit.<signal>` to events.jsonl, Octi reads. Octi never calls into sentinel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)