### PR TITLE
cleanup(dispatch): excise squad-era fossils (#271 Phase 1)

### DIFF
--- a/internal/dispatch/brain.go
+++ b/internal/dispatch/brain.go
@@ -1277,7 +1277,7 @@ func (b *Brain) leverageForP0(ctx context.Context) *LeverageAction {
 			if b.skipList != nil && b.skipList.IsSkipped(issueKey) {
 				continue
 			}
-			agent := b.srForSquad(item.Squad)
+			agent := b.srForRepo(item.Squad)
 			if agent == "" {
 				continue
 			}
@@ -1310,7 +1310,7 @@ func (b *Brain) leverageForIdleAgents(ctx context.Context) *LeverageAction {
 		if b.skipList != nil && b.skipList.IsSkipped(issueKey) {
 			continue
 		}
-		agent := b.srForSquad(item.Squad)
+		agent := b.srForRepo(item.Squad)
 		if agent == "" {
 			continue
 		}
@@ -1374,7 +1374,7 @@ func (b *Brain) leverageForNextSprint(ctx context.Context) *LeverageAction {
 		if b.skipList != nil && b.skipList.IsSkipped(issueKey) {
 			continue
 		}
-		agent := b.srForSquad(item.Squad)
+		agent := b.srForRepo(item.Squad)
 		if agent == "" {
 			continue
 		}
@@ -1485,8 +1485,12 @@ func (b *Brain) findIdleAgents(ctx context.Context) []string {
 		return nil
 	}
 
-	// Check known SR agents
-	srAgents := []string{"kernel-sr", "cloud-sr", "shellforge-sr", "octi-pulpo-sr", "studio-sr"}
+	// Check known SR agents (one per live repo — see LiveRepos in
+	// fossil_regression_test.go; post-octi#271 squad-collapse).
+	srAgents := []string{
+		"kernel-sr", "shellforge-sr", "clawta-sr", "sentinel-sr",
+		"llmint-sr", "octi-sr", "workspace-sr", "ganglia-sr",
+	}
 	var idle []string
 
 	for _, agent := range srAgents {
@@ -1540,21 +1544,22 @@ func (b *Brain) notifyAdapterResult(adapter, repo string, issueNum int, status, 
 	}
 }
 
-// srForSquad returns the SR agent name for a given squad.
-func (b *Brain) srForSquad(squad string) string {
+// srForRepo returns the SR agent name for a given repo. Returns "" for
+// unknown repos so callers can skip dispatch. The sprint-item field is
+// still named `Squad` (Phase 3 rename — see octi#271) but semantically
+// holds a repo name.
+func (b *Brain) srForRepo(repo string) string {
 	mapping := map[string]string{
 		"kernel":     "kernel-sr",
-		"cloud":      "cloud-sr",
 		"shellforge": "shellforge-sr",
-		"octi-pulpo": "octi-pulpo-sr",
-		"studio":     "studio-sr",
-		"analytics":  "analytics-sr",
 		"clawta":     "clawta-sr",
 		"sentinel":   "sentinel-sr",
 		"llmint":     "llmint-sr",
-		"ops":        "kernel-sr",
+		"octi":       "octi-sr",
+		"workspace":  "workspace-sr",
+		"ganglia":    "ganglia-sr",
 	}
-	return mapping[squad]
+	return mapping[repo]
 }
 
 // checkBackpressureRecovery looks for agents that were queued due to

--- a/internal/dispatch/chains.go
+++ b/internal/dispatch/chains.go
@@ -26,35 +26,26 @@ type ChainConfig map[string]CompletionAction
 //	SR finishes coding -> QA reviews
 //	QA passes -> PR review
 //	PR review done -> merger
-//	Conductor/Director -> broadcast to EMs
+//
+// Squad-era fan-outs (jared-conductor, director, *-em) were excised in
+// octi#271 Phase 1 when the org collapsed to per-repo routing. Fossil
+// regrowth is prevented by TestNoFossilAgentsInChains in
+// fossil_regression_test.go, keyed to LiveRepos.
 func DefaultChains() ChainConfig {
 	return ChainConfig{
 		// SR finishes coding -> QA reviews, triage on failure
 		"kernel-sr":     {OnCommit: []string{"kernel-qa"}, OnFailure: []string{"triage-failing-ci-agent"}},
-		"cloud-sr":      {OnCommit: []string{"cloud-qa"}, OnFailure: []string{"ci-triage-agent-cloud"}},
 		"shellforge-sr": {OnCommit: []string{"shellforge-qa"}},
-		"octi-pulpo-sr": {OnCommit: []string{"octi-pulpo-qa"}},
-		"studio-sr":     {OnCommit: []string{"studio-qa"}},
-		"office-sim-sr": {OnCommit: []string{"office-sim-qa"}},
 
 		// QA passes -> PR review
-		"kernel-qa":    {OnSuccess: []string{"workspace-pr-review-agent"}},
-		"cloud-qa":     {OnSuccess: []string{"code-review-agent-cloud"}},
+		"kernel-qa":     {OnSuccess: []string{"workspace-pr-review-agent"}},
 		"shellforge-qa": {OnSuccess: []string{"shellforge-reviewer"}},
 
 		// PR review done -> merger
 		"workspace-pr-review-agent": {OnSuccess: []string{"pr-merger-agent"}},
-		"code-review-agent-cloud":   {OnSuccess: []string{"pr-merger-agent-cloud"}},
 
-		// EM reports -> director reads
-		"kernel-em": {OnSuccess: []string{"hq-em"}},
-		"cloud-em":  {OnSuccess: []string{"hq-em"}},
-
-		// Conductor finishes -> dispatch EMs
-		"jared-conductor": {OnSuccess: []string{"kernel-em", "cloud-em", "shellforge-em", "octi-pulpo-em", "studio-em"}},
-
-		// Director finishes -> broadcast to all EMs
-		"director": {OnSuccess: []string{"kernel-em", "cloud-em", "shellforge-em", "octi-pulpo-em", "studio-em", "marketing-em", "design-em", "site-em", "qa-em"}},
+		// Analytics PR review is still live; analytics webhooks may fire.
+		"analytics-pr-review-agent": {OnSuccess: []string{"pr-merger-agent"}},
 	}
 }
 

--- a/internal/dispatch/chains_test.go
+++ b/internal/dispatch/chains_test.go
@@ -10,12 +10,15 @@ import (
 func TestDefaultChains_KeyAgentsExist(t *testing.T) {
 	chains := DefaultChains()
 
-	// Verify key chain entries exist
+	// Verify key chain entries exist. Squad-era fan-outs
+	// (jared-conductor, director, *-em) and dead-repo chains
+	// (cloud-sr/qa, octi-pulpo-sr, studio-sr, office-sim-sr) were
+	// excised in octi#271 Phase 1; absence is enforced by
+	// TestNoFossilAgentsInChains.
 	required := []string{
-		"kernel-sr", "cloud-sr", "shellforge-sr",
-		"kernel-qa", "cloud-qa",
-		"workspace-pr-review-agent", "code-review-agent-cloud",
-		"jared-conductor", "director",
+		"kernel-sr", "shellforge-sr",
+		"kernel-qa", "shellforge-qa",
+		"workspace-pr-review-agent",
 	}
 	for _, name := range required {
 		if _, ok := chains[name]; !ok {

--- a/internal/dispatch/dispatcher_test.go
+++ b/internal/dispatch/dispatcher_test.go
@@ -773,10 +773,11 @@ func TestDispatchBudget_T1LocalEndToEnd(t *testing.T) {
 	d.SetAdapters(fake)
 
 	// Agent name deliberately has no code/review/implement keyword so
-	// taskMinTier() returns TierLocal. "kernel-em" matches the real
-	// production event rules (see events.go DefaultRules).
+	// taskMinTier() returns TierLocal. The squad-era "kernel-em" timer
+	// was excised in octi#271 Phase 1; use "kernel-sr" which is the
+	// surviving live timer agent (see events.go DefaultRules).
 	event := Event{Type: EventManual, Source: "test", Repo: "chitinhq/octi"}
-	result, err := d.DispatchBudget(ctx, event, "kernel-em", 2, "medium")
+	result, err := d.DispatchBudget(ctx, event, "kernel-sr", 2, "medium")
 	if err != nil {
 		t.Fatalf("dispatch error: %v", err)
 	}

--- a/internal/dispatch/events.go
+++ b/internal/dispatch/events.go
@@ -180,41 +180,17 @@ func DefaultRules() []EventRule {
 			Cooldown:  10 * time.Minute,
 		},
 
-		// Timer-based agents (replacing blind cron)
+		// Timer-based agents (replacing blind cron).
+		// Squad-era *-em timers (kernel/cloud/platform/analytics) were
+		// excised in octi#271 Phase 1 when the org collapsed to per-repo
+		// routing. Fossil regrowth is blocked by TestNoFossilTimersInRules
+		// in fossil_regression_test.go, keyed to LiveRepos.
 		{
 			EventType: EventTimer,
 			RepoMatch: "",
 			AgentName: "kernel-sr",
 			Priority:  2,
 			Cooldown:  3 * time.Hour,
-		},
-		{
-			EventType: EventTimer,
-			RepoMatch: "",
-			AgentName: "kernel-em",
-			Priority:  1,
-			Cooldown:  6 * time.Hour,
-		},
-		{
-			EventType: EventTimer,
-			RepoMatch: "",
-			AgentName: "cloud-em",
-			Priority:  1,
-			Cooldown:  6 * time.Hour,
-		},
-		{
-			EventType: EventTimer,
-			RepoMatch: "",
-			AgentName: "platform-em",
-			Priority:  1,
-			Cooldown:  6 * time.Hour,
-		},
-		{
-			EventType: EventTimer,
-			RepoMatch: "",
-			AgentName: "analytics-em",
-			Priority:  1,
-			Cooldown:  6 * time.Hour,
 		},
 
 		// Manual and Slack triggers (no cooldown -- explicit human action)

--- a/internal/dispatch/fossil_regression_test.go
+++ b/internal/dispatch/fossil_regression_test.go
@@ -1,0 +1,94 @@
+package dispatch
+
+import (
+	"strings"
+	"testing"
+)
+
+// deadAgents are squad-era agent names excised in octi#271 Phase 1.
+// Any of these reappearing in DefaultChains, DefaultRules, or the
+// signal-watcher fixtures means the fossil regrew.
+var deadAgents = []string{
+	"kernel-em", "cloud-em", "platform-em", "analytics-em",
+	"shellforge-em", "octi-pulpo-em", "studio-em",
+	"marketing-em", "design-em", "site-em", "qa-em",
+	"jared-conductor", "director", "hq-em",
+	"octi-pulpo-sr", "studio-sr", "office-sim-sr", "cloud-sr",
+	"octi-pulpo-qa", "studio-qa", "office-sim-qa", "cloud-qa",
+}
+
+// TestNoFossilAgentsInChains asserts DefaultChains has no entries for
+// squad-era agents and no chain edge dispatches one. See octi#271.
+func TestNoFossilAgentsInChains(t *testing.T) {
+	chains := DefaultChains()
+	deadSet := make(map[string]bool, len(deadAgents))
+	for _, a := range deadAgents {
+		deadSet[a] = true
+	}
+
+	for _, dead := range deadAgents {
+		if _, ok := chains[dead]; ok {
+			t.Errorf("fossil agent %q found as DefaultChains key — squads are dead (see octi#271)", dead)
+		}
+	}
+
+	for src, action := range chains {
+		for _, bucket := range [][]string{action.OnSuccess, action.OnFailure, action.OnCommit} {
+			for _, target := range bucket {
+				if deadSet[target] {
+					t.Errorf("chain %q -> fossil %q (see octi#271)", src, target)
+				}
+			}
+		}
+	}
+}
+
+// TestNoFossilTimersInRules asserts DefaultRules registers no timer
+// for a squad-era agent, and that every timer rule's agent has a
+// prefix matching a live repo. See octi#271.
+func TestNoFossilTimersInRules(t *testing.T) {
+	rules := DefaultRules()
+	deadSet := make(map[string]bool, len(deadAgents))
+	for _, a := range deadAgents {
+		deadSet[a] = true
+	}
+
+	for _, rule := range rules {
+		if rule.EventType != EventTimer {
+			continue
+		}
+		if deadSet[rule.AgentName] {
+			t.Errorf("timer rule registers fossil agent %q (see octi#271)", rule.AgentName)
+		}
+
+		// Every timer agent name must start with a live-repo prefix.
+		// Wildcards and wildcard-like non-repo rules should not be
+		// timer-registered.
+		matched := false
+		for _, repo := range LiveRepos {
+			if strings.HasPrefix(rule.AgentName, repo+"-") {
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			t.Errorf("timer rule for %q has no LiveRepos prefix — timers must bind to a real repo (see octi#271)", rule.AgentName)
+		}
+	}
+}
+
+// TestSrForRepo_UnknownReturnsEmpty locks the contract that Brain
+// callers rely on: an unknown repo returns "" so the dispatch is
+// skipped. Exercised by brain.go:1280 (P0), :1313 (idle), :1377 (next).
+func TestSrForRepo_UnknownReturnsEmpty(t *testing.T) {
+	b := &Brain{}
+	if got := b.srForRepo("not-a-repo"); got != "" {
+		t.Errorf("srForRepo(unknown) = %q, want empty string", got)
+	}
+	// Spot-check every live repo has a mapping.
+	for _, repo := range LiveRepos {
+		if got := b.srForRepo(repo); got == "" {
+			t.Errorf("srForRepo(%q) is empty — live repo must map to an SR", repo)
+		}
+	}
+}

--- a/internal/dispatch/live_repos.go
+++ b/internal/dispatch/live_repos.go
@@ -1,0 +1,26 @@
+package dispatch
+
+// LiveRepos is the authoritative list of repos that the dispatch layer
+// routes to. Every agent name referenced in DefaultChains, DefaultRules,
+// NewSignalWatcher.repoSeniors, and Brain.srForRepo must derive its
+// prefix from this list.
+//
+// Squad-era entries (cloud, octi-pulpo, studio, office-sim, analytics,
+// platform, marketing, design, site, qa, ops) were excised in octi#271
+// Phase 1 when the org collapsed to per-repo routing. Regrowth is
+// blocked by TestNoFossilAgentsInChains + TestNoFossilTimersInRules in
+// fossil_regression_test.go — both keyed to this const.
+//
+// Adding a new repo: update this slice, add the SR mapping in
+// Brain.srForRepo and NewSignalWatcher.repoSeniors, and re-run the
+// regression tests.
+var LiveRepos = []string{
+	"kernel",
+	"shellforge",
+	"clawta",
+	"sentinel",
+	"llmint",
+	"octi",
+	"workspace",
+	"ganglia",
+}

--- a/internal/dispatch/signals.go
+++ b/internal/dispatch/signals.go
@@ -22,16 +22,14 @@ type SignalWatcher struct {
 	namespace  string
 	log        *log.Logger
 
-	// squadSeniors maps squad prefixes to senior/architect agents
-	// that should be dispatched on "need-help" signals.
-	squadSeniors map[string]string
+	// repoSeniors maps live repo names to senior/architect agents
+	// that should be dispatched on "need-help" signals. Keyed to
+	// LiveRepos (see fossil_regression_test.go).
+	repoSeniors map[string]string
 
-	// triageAgents maps squad prefixes to triage agents
+	// triageAgents maps repo names to triage agents
 	// that should be dispatched on "blocked" signals.
 	triageAgents map[string]string
-
-	// allEMs is the list of all EM agents that receive director broadcasts.
-	allEMs []string
 }
 
 // NewSignalWatcher creates a signal watcher connected to Redis pub/sub.
@@ -41,22 +39,18 @@ func NewSignalWatcher(dispatcher *Dispatcher, rdb *redis.Client, namespace strin
 		rdb:        rdb,
 		namespace:  namespace,
 		log:        log.New(os.Stderr, "signal-watcher: ", log.LstdFlags),
-		squadSeniors: map[string]string{
+		repoSeniors: map[string]string{
 			"kernel":     "kernel-sr",
-			"cloud":      "cloud-sr",
 			"shellforge": "shellforge-sr",
-			"octi-pulpo": "octi-pulpo-sr",
-			"studio":     "studio-sr",
-			"office-sim": "office-sim-sr",
+			"clawta":     "clawta-sr",
+			"sentinel":   "sentinel-sr",
+			"llmint":     "llmint-sr",
+			"octi":       "octi-sr",
+			"workspace":  "workspace-sr",
+			"ganglia":    "ganglia-sr",
 		},
 		triageAgents: map[string]string{
 			"kernel": "triage-failing-ci-agent",
-			"cloud":  "ci-triage-agent-cloud",
-		},
-		allEMs: []string{
-			"kernel-em", "cloud-em", "shellforge-em",
-			"octi-pulpo-em", "studio-em", "marketing-em",
-			"design-em", "site-em", "qa-em",
 		},
 	}
 }
@@ -115,7 +109,11 @@ func (sw *SignalWatcher) handleSignal(ctx context.Context, raw string) {
 	case "blocked":
 		sw.handleBlocked(ctx, sig)
 	case "directive":
-		sw.handleDirective(ctx, sig)
+		// Squad-era director broadcast was excised in octi#271 Phase 1
+		// (all 9 *-em agents targeted by allEMs were dead). Directive
+		// signals now log for observability only; re-introduce a
+		// handler here if a live EM role is ever restored.
+		sw.log.Printf("directive signal from %s (ignored; squad fan-out removed in octi#271)", sig.AgentID)
 	case "completed":
 		// Completion signals are handled by the chain system in the worker,
 		// but we log them for observability.
@@ -125,12 +123,12 @@ func (sw *SignalWatcher) handleSignal(ctx context.Context, raw string) {
 	}
 }
 
-// handleNeedHelp dispatches the squad's senior developer to assist.
+// handleNeedHelp dispatches the repo's senior developer to assist.
 func (sw *SignalWatcher) handleNeedHelp(ctx context.Context, sig signalPayload) {
-	squad := inferSquad(sig.AgentID)
-	senior, ok := sw.squadSeniors[squad]
+	repo := inferSquad(sig.AgentID)
+	senior, ok := sw.repoSeniors[repo]
 	if !ok {
-		sw.log.Printf("no senior mapped for squad %q (agent: %s)", squad, sig.AgentID)
+		sw.log.Printf("no senior mapped for repo %q (agent: %s)", repo, sig.AgentID)
 		return
 	}
 
@@ -154,12 +152,12 @@ func (sw *SignalWatcher) handleNeedHelp(ctx context.Context, sig signalPayload) 
 	sw.log.Printf("need-help -> dispatched %s (%s)", senior, result.Action)
 }
 
-// handleBlocked dispatches the squad's triage agent.
+// handleBlocked dispatches the repo's triage agent.
 func (sw *SignalWatcher) handleBlocked(ctx context.Context, sig signalPayload) {
-	squad := inferSquad(sig.AgentID)
-	triage, ok := sw.triageAgents[squad]
+	repo := inferSquad(sig.AgentID)
+	triage, ok := sw.triageAgents[repo]
 	if !ok {
-		sw.log.Printf("no triage agent for squad %q (agent: %s)", squad, sig.AgentID)
+		sw.log.Printf("no triage agent for repo %q (agent: %s)", repo, sig.AgentID)
 		return
 	}
 
@@ -183,56 +181,27 @@ func (sw *SignalWatcher) handleBlocked(ctx context.Context, sig signalPayload) {
 	sw.log.Printf("blocked -> dispatched %s (%s)", triage, result.Action)
 }
 
-// handleDirective broadcasts to all EM agents when a directive is published.
-func (sw *SignalWatcher) handleDirective(ctx context.Context, sig signalPayload) {
-	event := Event{
-		Type:   EventSignal,
-		Source: sig.AgentID,
-		Payload: map[string]string{
-			"signal_type": "directive",
-			"from_agent":  sig.AgentID,
-			"directive":   sig.Payload,
-		},
-		Priority: 1,
-	}
-
-	var dispatched int
-	for _, em := range sw.allEMs {
-		result, err := sw.dispatcher.Dispatch(ctx, event, em, 1)
-		if err != nil {
-			sw.log.Printf("dispatch %s for directive: %v", em, err)
-			continue
-		}
-		if result.Action == "dispatched" {
-			dispatched++
-		}
-	}
-	sw.log.Printf("directive -> dispatched %d/%d EMs", dispatched, len(sw.allEMs))
-}
-
-// inferSquad extracts the squad name from an agent ID.
-// e.g., "kernel-qa" -> "kernel", "cloud-sr" -> "cloud",
-// "ci-triage-agent-cloud" -> "cloud"
+// inferSquad extracts the repo name from an agent ID.
+// e.g., "kernel-qa" -> "kernel", "octi-sr" -> "octi".
+// The function name is retained for call-site compatibility; the term
+// "squad" is historical and now synonymous with "repo" after the
+// org collapse (see octi#271).
 func inferSquad(agentID string) string {
-	// Direct prefix match for standard naming
-	knownSquads := []string{
-		"kernel", "cloud", "shellforge", "octi-pulpo",
-		"studio", "office-sim", "marketing", "design", "site", "qa",
-	}
-	for _, squad := range knownSquads {
-		if strings.HasPrefix(agentID, squad+"-") {
-			return squad
+	// Direct prefix match against live repos.
+	for _, repo := range LiveRepos {
+		if strings.HasPrefix(agentID, repo+"-") {
+			return repo
 		}
 	}
 
-	// Check suffix for agents like "ci-triage-agent-cloud"
-	for _, squad := range knownSquads {
-		if strings.HasSuffix(agentID, "-"+squad) {
-			return squad
+	// Check suffix for agents like "ci-triage-agent-kernel".
+	for _, repo := range LiveRepos {
+		if strings.HasSuffix(agentID, "-"+repo) {
+			return repo
 		}
 	}
 
-	// Fallback: first segment
+	// Fallback: first segment.
 	parts := strings.SplitN(agentID, "-", 2)
 	return parts[0]
 }

--- a/internal/dispatch/signals_test.go
+++ b/internal/dispatch/signals_test.go
@@ -5,23 +5,32 @@ import (
 )
 
 func TestInferSquad(t *testing.T) {
+	// Dead squad names (cloud, octi-pulpo, studio, office-sim) were
+	// removed from the knownSquads list in octi#271 Phase 1. They now
+	// fall through to the first-segment fallback.
 	tests := []struct {
 		agentID string
 		want    string
 	}{
 		{"kernel-sr", "kernel"},
 		{"kernel-qa", "kernel"},
-		{"kernel-em", "kernel"},
-		{"cloud-sr", "cloud"},
-		{"cloud-qa", "cloud"},
+		{"kernel-em", "kernel"}, // prefix "kernel-" still matches even though em is a fossil role
 		{"shellforge-sr", "shellforge"},
-		{"octi-pulpo-sr", "octi-pulpo"},
-		{"studio-sr", "studio"},
-		{"office-sim-sr", "office-sim"},
+		{"clawta-sr", "clawta"},
+		{"sentinel-sr", "sentinel"},
+		{"llmint-sr", "llmint"},
+		{"octi-sr", "octi"},
+		{"workspace-sr", "workspace"},
+		{"ganglia-sr", "ganglia"},
 
-		// Suffix matching for agents like "ci-triage-agent-cloud"
-		{"ci-triage-agent-cloud", "cloud"},
-		{"triage-failing-ci-agent", "triage"}, // no known squad match, falls through to first segment
+		// Suffix matching for agents like "ci-triage-agent-kernel"
+		{"ci-triage-agent-kernel", "kernel"},
+		{"triage-failing-ci-agent", "triage"}, // no known repo match, falls through to first segment
+
+		// Dead-squad names fall through to first-segment fallback now.
+		{"cloud-sr", "cloud"},
+		{"studio-sr", "studio"},
+		{"office-sim-sr", "office"}, // "office" is first segment; "office-sim" no longer recognised
 
 		// Fallback to first segment
 		{"unknown-agent", "unknown"},
@@ -49,13 +58,17 @@ func TestNewSignalWatcher_Defaults(t *testing.T) {
 	if sw.namespace != "octi-test" {
 		t.Fatalf("namespace mismatch: got %s", sw.namespace)
 	}
-	if len(sw.squadSeniors) == 0 {
-		t.Fatal("expected squad seniors to be populated")
+	if len(sw.repoSeniors) == 0 {
+		t.Fatal("expected repo seniors to be populated")
 	}
-	if len(sw.allEMs) == 0 {
-		t.Fatal("expected allEMs to be populated")
+	// Every LiveRepos entry must be mapped; otherwise a squad-era
+	// senior silently drops need-help signals for a real repo.
+	for _, repo := range LiveRepos {
+		if sw.repoSeniors[repo] == "" {
+			t.Errorf("expected senior mapping for live repo %q", repo)
+		}
 	}
-	if sw.squadSeniors["kernel"] != "kernel-sr" {
-		t.Fatalf("expected kernel senior to be kernel-sr, got %s", sw.squadSeniors["kernel"])
+	if sw.repoSeniors["kernel"] != "kernel-sr" {
+		t.Fatalf("expected kernel senior to be kernel-sr, got %s", sw.repoSeniors["kernel"])
 	}
 }

--- a/internal/dispatch/webhook.go
+++ b/internal/dispatch/webhook.go
@@ -896,7 +896,7 @@ func (ws *WebhookServer) routeSlackAction(ctx context.Context, actionID, value, 
 			Source:  "slack",
 			Payload: map[string]string{"action": "switch_tier", "driver": value, "actor": actor},
 		}
-		_, err := ws.dispatcher.Dispatch(ctx, event, "octi-pulpo-sr", 1)
+		_, err := ws.dispatcher.Dispatch(ctx, event, "octi-sr", 1)
 		if err != nil {
 			return "", fmt.Errorf("dispatch switch-tier: %w", err)
 		}


### PR DESCRIPTION
## Summary

Phase 1 of chitinhq/octi#271: mechanical deletion of pre-rebrand AgentGuard-SaaS squad routing from the Go dispatch layer. The org collapsed to per-repo routing months ago; the Go internals never got the memo, which is why `tier_activity` shows 8 `unknown` dispatches every cycle and `agent_leaderboard` verdicts every squad-era agent "fire" (0 commits, 0.10 score). This is dead code burning real DeepSeek tokens every 6h.

## What was deleted

- **Timer registrations** (`events.go`): `kernel-em`, `cloud-em`, `platform-em`, `analytics-em` (kept `kernel-sr` — it feeds the live chain)
- **Chain entries** (`chains.go`): `cloud-sr`, `octi-pulpo-sr`, `studio-sr`, `office-sim-sr`, `cloud-qa`, `code-review-agent-cloud`, `kernel-em`, `cloud-em`, `jared-conductor`, `director`
- **Signal fan-out** (`signals.go`): deleted `allEMs` slice + `handleDirective` entirely (all 9 targets were dead agents — `directive` signals now log and no-op)
- **Dead-squad aliases** in `inferSquad`'s `knownSquads` list: `cloud`, `octi-pulpo`, `studio`, `office-sim`, `marketing`, `design`, `site`, `qa`

## What was renamed

- `Brain.srForSquad` → `Brain.srForRepo` (3 call sites in `brain.go` at 1280/1313/1377 updated). The sprint-store `item.Squad` field rename is deferred to Phase 3 to avoid cross-package churn in this PR.
- `SignalWatcher.squadSeniors` → `repoSeniors`

## What was fixed

- `webhook.go:899`: `switch_tier` Slack action was dispatching the nonexistent `octi-pulpo-sr`; changed to `octi-sr` (the real repo is `octi`).

## Regression infrastructure

Added `internal/dispatch/live_repos.go` with a single authoritative `LiveRepos` const (8 repos: kernel, shellforge, clawta, sentinel, llmint, octi, workspace, ganglia). Added `fossil_regression_test.go` with three tests:

1. `TestNoFossilAgentsInChains` — fails if any dead agent reappears in `DefaultChains` as a key or target.
2. `TestNoFossilTimersInRules` — fails if any timer rule registers a dead agent or an agent with no `LiveRepos` prefix.
3. `TestSrForRepo_UnknownReturnsEmpty` — pins the contract that the three `brain.go` callers rely on: unknown repo returns `""` so dispatch is skipped.

Together these close the monitoring gap flagged by shannon in the planning thread: fossils can no longer regrow silently.

## Test updates (turing's catch)

Without these, a pure delete would red CI:

- `chains_test.go:18` — `required` list no longer demands `jared-conductor`, `director`, or dead-repo `*-sr/*-qa` entries
- `dispatcher_test.go:776-779` — swapped `kernel-em` dispatch target to `kernel-sr` (live timer agent); updated the stale comment
- `signals_test.go` — `TestInferSquad` updated to reflect dead squads falling through to first-segment fallback; `TestNewSignalWatcher_Defaults` now iterates `LiveRepos` to assert every live repo has a senior mapping

## Out of scope

- `item.Squad` field rename on sprint items — Phase 3 (separate PR, cross-package churn)
- `internal/org/import.go:133` naming-convention parser — out of scope (parses agent role suffixes, not a routing fossil)
- Semantic-advisory CI failures — to be filed as a follow-up issue

## Test plan

- [x] `go build ./...` (clean)
- [x] `go test ./internal/dispatch/...` (pass — includes new regression tests)
- [x] `go test ./internal/org/...` (pass)
- [x] `go test ./...` (full suite green)
- [ ] Post-merge: confirm `tier_activity.unknown` drops to 0 within one cooldown cycle (6h)
- [ ] Post-merge: confirm `agent_leaderboard` stops listing fire-verdict no-op agents

## Planning thread

`/home/jared/workspace/wiki/ganglia/go-2026-04-16-1246/thread.md` — contains hopper's file:line plan, turing's correctness review (three tests that would red a naive delete), and shannon's post-strike telemetry expectations.

Refs chitinhq/octi#271.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>