### PR TITLE
fix(sprint): ignore zombie agent:claimed labels on closed issues

### DIFF
--- a/internal/sprint/label_status_test.go
+++ b/internal/sprint/label_status_test.go
@@ -1,0 +1,52 @@
+package sprint
+
+import "testing"
+
+// TestDispatchLabelStatus_ClosedSetSuppressesClaim is the guard proof for the
+// turing slice of /go session 2026-04-17-0006. Before the fix,
+// dispatchLabelStatus unconditionally promoted any "agent:claimed" label to
+// status="claimed" on every Sync — including issues GitHub had already closed,
+// whose labels are zombie locks. This test pins that a closed issue carrying a
+// stale "agent:claimed" label resolves to "" (no status override), so the
+// caller's downstream SyncClosed / tombstoneFromOpenSet path can mark the item
+// done instead of re-animating the zombie claim.
+func TestDispatchLabelStatus_ClosedSetSuppressesClaim(t *testing.T) {
+	closed := map[int]bool{62: true}
+
+	// Zombie: issue #62 is in the closed set AND carries agent:claimed.
+	if got := dispatchLabelStatus(62, []string{"agent:claimed"}, closed); got != "" {
+		t.Errorf("closed issue with stale agent:claimed: got %q, want \"\" (no override, so SyncClosed wins)", got)
+	}
+
+	// Open counterpart: issue #58 is NOT in the closed set — claim still wins.
+	if got := dispatchLabelStatus(58, []string{"agent:claimed"}, closed); got != "claimed" {
+		t.Errorf("open issue with agent:claimed: got %q, want \"claimed\"", got)
+	}
+
+	// Empty closed set = pre-fix behavior preserved.
+	if got := dispatchLabelStatus(58, []string{"agent:claimed"}, nil); got != "claimed" {
+		t.Errorf("nil closedSet with agent:claimed: got %q, want \"claimed\" (backward-compatible)", got)
+	}
+
+	// Terminal label on a closed issue still resolves — only the claim-lock is
+	// suppressed, since it's the re-animation vector.
+	if got := dispatchLabelStatus(62, []string{"agent:done"}, closed); got != "done" {
+		t.Errorf("closed issue with agent:done: got %q, want \"done\" (terminal wins)", got)
+	}
+
+	// Blocked label is not suppressed either — only agent:claimed is the zombie.
+	if got := dispatchLabelStatus(62, []string{"agent:blocked"}, closed); got != "blocked" {
+		t.Errorf("closed issue with agent:blocked: got %q, want \"blocked\"", got)
+	}
+}
+
+// TestDispatchLabelStatus_NoDispatchLabel confirms the empty-string return is
+// preserved when no dispatch label is present, regardless of closedSet state.
+func TestDispatchLabelStatus_NoDispatchLabel(t *testing.T) {
+	if got := dispatchLabelStatus(1, []string{"bug", "P1"}, nil); got != "" {
+		t.Errorf("no dispatch label, nil closedSet: got %q, want \"\"", got)
+	}
+	if got := dispatchLabelStatus(1, []string{"bug", "P1"}, map[int]bool{1: true}); got != "" {
+		t.Errorf("no dispatch label, in closedSet: got %q, want \"\"", got)
+	}
+}

--- a/internal/sprint/label_status_test.go
+++ b/internal/sprint/label_status_test.go
@@ -40,6 +40,36 @@ func TestDispatchLabelStatus_ClosedSetSuppressesClaim(t *testing.T) {
 	}
 }
 
+// TestDispatchLabelStatus_PriorityIndependentOfLabelOrder pins the fix for
+// Copilot's review note on PR #276: GitHub does not guarantee label ordering
+// on an issue, so dispatchLabelStatus must pick by priority (terminal > review
+// > blocked > claimed) rather than by first-match in the slice. Before the
+// priority-set fix, [agent:claimed, agent:done] resolved to "claimed" and
+// shadowed the terminal state.
+func TestDispatchLabelStatus_PriorityIndependentOfLabelOrder(t *testing.T) {
+	cases := []struct {
+		name   string
+		labels []string
+		want   string
+	}{
+		{"done-before-claimed", []string{"agent:done", "agent:claimed"}, "done"},
+		{"claimed-before-done", []string{"agent:claimed", "agent:done"}, "done"},
+		{"review-beats-claimed-order1", []string{"agent:review", "agent:claimed"}, "pr_open"},
+		{"review-beats-claimed-order2", []string{"agent:claimed", "agent:review"}, "pr_open"},
+		{"blocked-beats-claimed-order1", []string{"agent:blocked", "agent:claimed"}, "blocked"},
+		{"blocked-beats-claimed-order2", []string{"agent:claimed", "agent:blocked"}, "blocked"},
+		{"done-beats-blocked", []string{"agent:blocked", "agent:done"}, "done"},
+		{"noise-around-done", []string{"bug", "agent:done", "P1"}, "done"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := dispatchLabelStatus(1, tc.labels, nil); got != tc.want {
+				t.Errorf("labels=%v: got %q, want %q", tc.labels, got, tc.want)
+			}
+		})
+	}
+}
+
 // TestDispatchLabelStatus_NoDispatchLabel confirms the empty-string return is
 // preserved when no dispatch label is present, regardless of closedSet state.
 func TestDispatchLabelStatus_NoDispatchLabel(t *testing.T) {

--- a/internal/sprint/store.go
+++ b/internal/sprint/store.go
@@ -94,10 +94,23 @@ func classifyFastPath(title string, labels []string) bool {
 
 // dispatchLabelStatus maps dispatch state machine labels to sprint item statuses.
 // Returns "" if no dispatch label is present.
-func dispatchLabelStatus(labels []string) string {
+//
+// When closedSet contains issueNum, an "agent:claimed" label is treated as a
+// zombie (stale lock on an already-closed issue) and skipped, so the item can
+// fall through to SyncClosed / tombstoneFromOpenSet and resolve to "done".
+// Terminal labels ("agent:done") and explicit blockers still win — only the
+// claim-lock is suppressed, since the claim is what re-animates closed work.
+// See chitinhq/octi thread go-2026-04-17-0006 (turing slice): the label is
+// lying; this is the guard that stops the store from inheriting the lie.
+func dispatchLabelStatus(issueNum int, labels []string, closedSet map[int]bool) string {
+	closed := closedSet[issueNum]
 	for _, lbl := range labels {
 		switch lbl {
 		case "agent:claimed":
+			if closed {
+				// Zombie claim on a closed issue — ignore and let done win.
+				continue
+			}
 			return "claimed"
 		case "agent:done":
 			return "done"
@@ -207,6 +220,16 @@ func (s *Store) Sync(ctx context.Context, repo string) error {
 		return fmt.Errorf("parse gh output for %s: %w", repo, err)
 	}
 
+	// Fetch the closed set BEFORE iterating open issues so dispatchLabelStatus
+	// can suppress zombie "agent:claimed" labels on issues GitHub considers
+	// closed. If the fetch fails we log and proceed with an empty set — the
+	// label promotion then behaves exactly like the pre-guard code path.
+	closedSet, err := s.fetchClosedSet(ctx, repo)
+	if err != nil {
+		s.log.Printf("fetchClosedSet %s: %v (proceeding without closed-guard)", repo, err)
+		closedSet = map[int]bool{}
+	}
+
 	pipe := s.rdb.Pipeline()
 	now := time.Now().UTC().Format(time.RFC3339)
 
@@ -253,7 +276,8 @@ func (s *Store) Sync(ctx context.Context, repo string) error {
 
 		// Dispatch state machine labels override local status — GitHub is
 		// the source of truth for claim/done state set by the brain.
-		if labelStatus := dispatchLabelStatus(labelNames); labelStatus != "" {
+		// closedSet suppresses zombie "agent:claimed" labels (see function doc).
+		if labelStatus := dispatchLabelStatus(issue.Number, labelNames, closedSet); labelStatus != "" {
 			item.Status = labelStatus
 		}
 
@@ -597,11 +621,12 @@ func (s *Store) getByRepo(ctx context.Context, repo string) ([]SprintItem, error
 	return items, nil
 }
 
-// SyncClosed fetches recently closed issues from a GitHub repo and marks
-// any matching sprint items as "done". This prevents the brain from
-// re-dispatching work that has already shipped.
-// The limit matches syncOpenLimit so the window is consistent with the open-issue sync.
-func (s *Store) SyncClosed(ctx context.Context, repo string) error {
+// fetchClosedSet returns the set of recently-closed issue numbers for a repo,
+// bounded by syncOpenLimit. Used by Sync to suppress zombie "agent:claimed"
+// labels on issues GitHub already considers closed. On error the caller should
+// treat the set as empty rather than fail the sync — the guard is
+// belt-and-suspenders; SyncClosed still runs after the open-issue loop.
+func (s *Store) fetchClosedSet(ctx context.Context, repo string) (map[int]bool, error) {
 	cmd := exec.CommandContext(ctx, "gh", "issue", "list",
 		"-R", repo,
 		"--state", "closed",
@@ -610,19 +635,33 @@ func (s *Store) SyncClosed(ctx context.Context, repo string) error {
 	)
 	out, err := cmd.Output()
 	if err != nil {
-		return fmt.Errorf("gh issue list --state closed -R %s: %w", repo, err)
+		return nil, fmt.Errorf("gh issue list --state closed -R %s: %w", repo, err)
 	}
-
 	var issues []struct {
 		Number int `json:"number"`
 	}
 	if err := json.Unmarshal(out, &issues); err != nil {
-		return fmt.Errorf("parse closed issues for %s: %w", repo, err)
+		return nil, fmt.Errorf("parse closed issues for %s: %w", repo, err)
 	}
+	set := make(map[int]bool, len(issues))
+	for _, issue := range issues {
+		set[issue.Number] = true
+	}
+	return set, nil
+}
 
-	nums := make([]int, len(issues))
-	for i, issue := range issues {
-		nums[i] = issue.Number
+// SyncClosed fetches recently closed issues from a GitHub repo and marks
+// any matching sprint items as "done". This prevents the brain from
+// re-dispatching work that has already shipped.
+// The limit matches syncOpenLimit so the window is consistent with the open-issue sync.
+func (s *Store) SyncClosed(ctx context.Context, repo string) error {
+	closedSet, err := s.fetchClosedSet(ctx, repo)
+	if err != nil {
+		return err
+	}
+	nums := make([]int, 0, len(closedSet))
+	for n := range closedSet {
+		nums = append(nums, n)
 	}
 
 	marked, err := s.markClosedItems(ctx, repo, nums)

--- a/internal/sprint/store.go
+++ b/internal/sprint/store.go
@@ -103,22 +103,32 @@ func classifyFastPath(title string, labels []string) bool {
 // See chitinhq/octi thread go-2026-04-17-0006 (turing slice): the label is
 // lying; this is the guard that stops the store from inheriting the lie.
 func dispatchLabelStatus(issueNum int, labels []string, closedSet map[int]bool) string {
-	closed := closedSet[issueNum]
+	// Build a set so we can check by priority order rather than by GitHub's
+	// (unspecified) label ordering on the issue. Without this, a label slice
+	// of ["agent:claimed", "agent:done"] would resolve to "claimed" and shadow
+	// the terminal state — bug Copilot caught on the initial turing patch.
+	set := make(map[string]bool, len(labels))
 	for _, lbl := range labels {
-		switch lbl {
-		case "agent:claimed":
-			if closed {
-				// Zombie claim on a closed issue — ignore and let done win.
-				continue
-			}
-			return "claimed"
-		case "agent:done":
-			return "done"
-		case "agent:review":
-			return "pr_open"
-		case "agent:blocked":
-			return "blocked"
+		set[lbl] = true
+	}
+
+	// Priority: terminal > review > blocked > claimed. Claim is the weakest
+	// signal because it is the one the brain writes speculatively and the
+	// one that leaks (zombie-claims finding, session 2026-04-17-0006).
+	switch {
+	case set["agent:done"]:
+		return "done"
+	case set["agent:review"]:
+		return "pr_open"
+	case set["agent:blocked"]:
+		return "blocked"
+	case set["agent:claimed"]:
+		if closedSet[issueNum] {
+			// Zombie claim on a GH-closed issue — ignore; let tombstone /
+			// SyncClosed resolve to done.
+			return ""
 		}
+		return "claimed"
 	}
 	return ""
 }


### PR DESCRIPTION
## Summary

`dispatchLabelStatus` unconditionally promoted any issue carrying `agent:claimed` back to `status=claimed` on every `Sync` — even when GitHub already considered the issue closed. The claim label is a *zombie lock* left over from a prior claim; the state-machine spec only writes `LabelClaimed`, never `LabelDone`, so these zombies accumulate indefinitely on closed issues.

This PR threads a `closedSet` through `dispatchLabelStatus` and suppresses the `agent:claimed` → `claimed` promotion for issues GitHub has already closed. Terminal labels (`agent:done`, `agent:blocked`) still resolve — only the re-animation vector (the claim-lock on closed work) is guarded.

## Context

Surfaced during `/go` session `2026-04-17-0006` (party Dawn Counsel). `sprint_status` showed **191 items at `claimed`, only 1 at `done`** across 7 squads. Cross-check found issue #62 **closed on GH since 2026-04-16 but still carrying `agent:claimed`** — the label was lying; the store correctly had it as `done` via `SyncClosed` but inherited the lie on every subsequent re-sync.

## What the diff does

- **`dispatchLabelStatus(issueNum, labels, closedSet)`** — new signature. When `closedSet[issueNum]` is true, `agent:claimed` is skipped (falls through to `""`, so the downstream `SyncClosed` / `tombstoneFromOpenSet` path can mark the item `done`). `agent:done` and `agent:blocked` are **not** suppressed.
- **`fetchClosedSet`** — new helper. Pulls `gh issue list --state closed --json number` once per `Sync`. `SyncClosed` now reuses it. On fetch failure `Sync` logs and proceeds with an empty set — identical to pre-fix behavior, belt-and-suspenders not a hard dependency.

## Out of scope / follow-ups

- **Label-stripping via the GH API** is deliberately out — that requires DELETE endpoint plumbing and is a separate PR. Will file a follow-up issue.
- **Abandoned-but-still-open items** (e.g. #37, labeled `claimed` for 6+ days) are NOT caught by this fix — they're still open on GH so `closedSet` won't cover them. Curie's cohort report covers that population separately.
- **`queue_machine.go` (`QueueInProgress`)** also reads the `agent:claimed` label for dispatch skip decisions. Not touched here; may need a second pass after the cohort report lands.

## Test plan

- [x] `go test ./internal/sprint/...` — 35 passed
- [x] `go test ./internal/dispatch/...` — 320 passed
- [x] `go build ./...` — clean
- [x] New `TestDispatchLabelStatus_ClosedSetSuppressesClaim` pins:
  - closed + `agent:claimed` → `""` (no override)
  - open + `agent:claimed` → `"claimed"` (unchanged)
  - nil `closedSet` + `agent:claimed` → `"claimed"` (backward-compatible)
  - closed + `agent:done` → `"done"` (terminal wins)
  - closed + `agent:blocked` → `"blocked"` (only the claim-lock is suppressed)

Refs: `/go` session 2026-04-17-0006, party Dawn Counsel, turing slice (`proof-or-telemetry`).

Generated with Claude Code.