### PR TITLE
fix(dispatcher): actually call adapter — close silent-loss (workspace#408 Phase-1 hopper)

### DIFF
--- a/docs/silent-loss.md
+++ b/docs/silent-loss.md
@@ -130,3 +130,30 @@ How to spot this bug class elsewhere in the codebase:
 ## Suspects
 
 (Filled by curie — sibling silent-loss patterns in `internal/`.)
+
+## Suspects — pattern mine (curie, 2026-04-15)
+
+Read-only sweep of `internal/` for the claim-without-execution pattern. Scope:
+any field named `Action` / `Status` / `Result` / `State` set to a success literal
+before the side effect that justifies it has been confirmed.
+
+| file:line | function | suspected success-claim | missing/deferred side-effect | confidence | notes / issue |
+|---|---|---|---|---|---|
+| `internal/dispatch/claude_code_adapter.go:126` | `ClaudeCodeAdapter.Dispatch` | `result.Status = "completed"` | `git push` + `gh pr create` run AFTER the claim; on failure only `result.Error` is populated, Status is not reverted. Outer dispatcher at `dispatcher.go:264` only downgrades on `Status == "failed"`, so `Action="dispatched"` for a run that never reached origin. | **high** | [chitinhq/octi#241](https://github.com/chitinhq/octi/issues/241) |
+| `internal/dispatch/copilot_cli_adapter.go:139` | `CopilotCLIAdapter.Dispatch` | `result.Status = "completed"` | Identical to above — push/PR are best-effort after the Status flip. | **high** | [chitinhq/octi#242](https://github.com/chitinhq/octi/issues/242) |
+| `internal/dispatch/clawta_adapter.go:151` | `ClawtaAdapter.Dispatch` | `result.Status = "completed"` | Identical pattern + secondary contamination: episodic learner at line 186 records the (still "completed") outcome on push failure, teaching it that a prompt succeeded when in truth the work was silently dropped. | **high** | [chitinhq/octi#243](https://github.com/chitinhq/octi/issues/243) |
+| `internal/sprint/store.go:673` | `Store.markClosedItems` | `item.Status = "done"` + `marked++` | `s.rdb.Set(...)` return value ignored. Sibling `tombstoneFromOpenSet:710` DOES check `.Err()` — asymmetric handling is the tell. On Redis flap, caller logs "marked N closed" while persisted state is stale. | **med** | [chitinhq/octi#244](https://github.com/chitinhq/octi/issues/244) |
+| `internal/dispatch/dispatcher.go:237` | `Dispatcher.Dispatch` (legacy path) | `result.Action = "dispatched"` when `len(d.adapters) == 0` | Preserved by the 5dc4e27 fix as an explicit legacy fallback for callers draining the Redis queue directly. Still a claim-without-execution if `adapters` is empty due to *misconfiguration* (as opposed to by-design legacy mode). Reason string marks it, but observers keying on `Action` alone cannot tell. | **low** | flagged only — do NOT touch `dispatcher.go` in this slice; covered by workspace#408. |
+| `internal/dispatch/openclaw_adapter.go:118` | `OpenClawAdapter.Dispatch` | `result.Status = "completed"` | Set AFTER `sendMessage` + `waitForResponse` both return without error. Response is from a Matrix bot — "completed" means "bot replied", not "work shipped". Out-of-scope for this class (it's an API-confirmed reply), but worth knowing for any future strengthening of the contract. | **low** | informational only. |
+| `internal/dispatch/anthropic_adapter.go:106`, `deepseek_adapter.go:117`, `copilot_adapter.go:155` | adapter `Dispatch` | `result.Status = "completed"` | All three set Status AFTER their HTTP/subprocess call succeeds and the response is decoded/validated. No missing side effect. | — | clean, listed for completeness. |
+
+**Totals:** 3 high, 1 med, 2 low, 3 cleared. 4 issues filed (#241–#244).
+
+**Headline finding:** the three CLI-agent adapters (claude_code, copilot_cli,
+clawta) all carry the same shape of bug the dispatcher just fixed: `Status =
+"completed"` is set on CLI exit 0, and the follow-up `git push` / `gh pr
+create` are best-effort. When push fails, `Status` stays `"completed"`, the
+outer dispatcher maps it to `Action="dispatched"`, and the branch is deleted
+by `cleanupWorktree` on return — a textbook silent-loss. Same class, three
+more surfaces.
+

--- a/docs/silent-loss.md
+++ b/docs/silent-loss.md
@@ -1,0 +1,132 @@
+# Dispatcher silent-loss — claim-without-execution
+
+## Summary
+
+The event-driven dispatcher (`internal/dispatch/dispatcher.go`,
+`Dispatcher.Dispatch` / `DispatchBudget`) set `result.Action = "dispatched"`
+as soon as it had **routed** an event and **enqueued** the task to Redis —
+without ever invoking the execution-surface adapter (HTTP
+`repository_dispatch`, Anthropic API, Claude Code CLI, etc.) for the
+routed driver. Any input the adapter would have rejected (e.g. an event
+with empty `Repo`) still came back labeled `"dispatched"`, so observers,
+metrics, and the `recordDispatch` audit trail all reported success while
+the agent surface saw nothing.
+
+The lie shipped in `5f0dc2f` (event-driven dispatcher, 2026-03-29) and
+lived for ~17 days until `5dc4e27` (2026-04-15) gated `Action="dispatched"`
+behind an actual `adapter.Dispatch(ctx, task)` call. Class-of-bug:
+**claim-without-execution** — a status field flipped to a success literal
+before the side effect that justifies it has been attempted.
+
+## BEFORE (silent-loss path) — `5f0dc2f` … `eeef6f2`
+
+```
+                  Dispatch(event, agent, priority)
+                              │
+                              ▼
+                ┌──────────────────────────┐
+                │ claim distributed lock   │  fail → "claimed_by_other"
+                └──────────────┬───────────┘
+                               ▼
+                ┌──────────────────────────┐
+                │ route(event) → driver    │  no match → "unroutable"
+                └──────────────┬───────────┘
+                               ▼
+                ┌──────────────────────────┐
+                │ Enqueue(agent, priority) │  Redis ZADD only
+                └──────────────┬───────────┘
+                               ▼
+                ┌──────────────────────────┐
+                │ BridgeToFileQueue(agent) │  best-effort, errors swallowed
+                └──────────────┬───────────┘
+                               ▼
+        ╔══════════════════════════════════════════╗
+        ║  result.Action  = "dispatched"   ◄── LIE ║
+        ║  result.Reason  = "dispatched via …"     ║
+        ╚══════════════════════════╤═══════════════╝
+                                   ▼
+                ┌──────────────────────────┐
+                │ recordDispatch(...)      │  audit trail records success
+                └──────────────┬───────────┘
+                               ▼
+                            return
+
+        ░░ MISSING: adapter.Dispatch(ctx, task) ░░
+        ░░ no HTTP/CLI/API call ever happens   ░░
+```
+
+The gap between *route* and *claim of dispatch* contained zero execution.
+A failure mode at the surface (rejected payload, network down, missing
+adapter) was indistinguishable on the wire from a healthy dispatch.
+
+## AFTER (adapter-gated) — `5dc4e27`
+
+```
+                  Dispatch(event, agent, priority)
+                              │
+                              ▼
+                ┌──────────────────────────┐
+                │ claim + route + enqueue  │  (unchanged)
+                └──────────────┬───────────┘
+                               ▼
+                ┌──────────────────────────┐
+                │ selectAdapter(driver)    │
+                └──────────────┬───────────┘
+                               │
+        ┌──────────────────────┼──────────────────────────┐
+        ▼                      ▼                          ▼
+  adapter == nil         adapter == nil            adapter != nil
+  AND len(adapters)==0   AND len(adapters)>0
+        │                      │                          │
+        ▼                      ▼                          ▼
+  Action="dispatched"    Action="unroutable"     adapter.Dispatch(ctx,task)
+  Reason="queued via …;  Reason="no adapter             │
+   no adapter             registered for                │
+   registered"            driver q"                     │
+   (legacy fallback)                                    │
+                                                ┌───────┴────────┐
+                                                ▼                ▼
+                                            err == nil       err != nil
+                                                │                │
+                                                ▼                ▼
+                                        Action="dispatched"  Action="failed"
+                                        Reason="… via HTTP"  Reason=err.Error()
+                              ▼
+                ┌──────────────────────────┐
+                │ recordDispatch(...)      │
+                └──────────────┬───────────┘
+                               ▼
+                            return
+```
+
+`Action="dispatched"` now means *an execution surface accepted the task*
+(or, on the explicit legacy path, *no surface is registered and the
+caller is consuming the Redis queue directly*). The three honest outcomes
+— `dispatched | failed | unroutable` — line up with the three real
+states of the world.
+
+## Detection heuristic
+
+How to spot this bug class elsewhere in the codebase:
+
+- Any field named `Action` / `Status` / `Result` / `State` assigned a
+  success literal (`"dispatched"`, `"sent"`, `"ok"`, `"delivered"`,
+  `"committed"`) **before** the network / disk / IPC call that the
+  literal is supposed to attest to.
+- A success path that `return`s without an error from a function whose
+  *only* side effect is enqueueing to a buffer the caller does not
+  control end-to-end (Redis, Kafka, a file queue, an in-process channel).
+  Enqueue is not delivery.
+- Audit / telemetry calls (`recordDispatch`, `emit`, `metrics.Inc`)
+  invoked on the same code path that sets the success literal — if both
+  fire before the real side effect, your dashboards will lie in lockstep.
+- Adapter / driver / handler interfaces that exist in the package but
+  are *not referenced* in the function that claims to invoke them. Grep
+  for the interface name inside the dispatch path; absence is the smell.
+- Tests that assert on `result.Action == "dispatched"` without a spy /
+  fake on the surface adapter confirming it was called. Green tests over
+  a silent loss.
+
+## Suspects
+
+(Filled by curie — sibling silent-loss patterns in `internal/`.)

--- a/internal/dispatch/dispatcher.go
+++ b/internal/dispatch/dispatcher.go
@@ -49,6 +49,27 @@ type Dispatcher struct {
 	presUser  string                // user ID for presence checks
 	queueFile string                // ~/.chitin/queue.txt (compatibility bridge)
 	namespace string
+	adapters  []Adapter // execution-surface adapters; picked by Name() against routed driver
+}
+
+// SetAdapters registers adapters that execute a dispatched task on a real
+// surface (HTTP repository_dispatch, Anthropic API, Claude Code CLI, etc.).
+// After route selection, Dispatch() invokes the adapter whose Name() matches
+// the routed driver. This is what makes result.Action="dispatched" mean "an
+// execution surface was actually called" rather than "we enqueued to Redis
+// and hoped." See workspace#408 (silent-loss regression).
+func (d *Dispatcher) SetAdapters(adapters ...Adapter) { d.adapters = adapters }
+
+// selectAdapter returns the registered adapter whose Name() matches driver,
+// or nil if none is registered. Gate between routing ("we picked claude-code")
+// and execution ("we actually called it").
+func (d *Dispatcher) selectAdapter(driver string) Adapter {
+	for _, a := range d.adapters {
+		if a != nil && a.Name() == driver {
+			return a
+		}
+	}
+	return nil
 }
 
 // NewDispatcher creates an event-driven dispatcher.
@@ -197,11 +218,62 @@ func (d *Dispatcher) DispatchBudget(ctx context.Context, event Event, agentName 
 	}
 
 	queueDepth, _ := d.PendingCount(ctx)
-	result.Action = "dispatched"
-	result.Reason = fmt.Sprintf("dispatched via %s (tier: %s, confidence: %.1f)", routeDecision.Driver, routeDecision.Tier, routeDecision.Confidence)
 	result.Driver = routeDecision.Driver
 	result.ClaimID = claim.ClaimID
 	result.QueuePos = queueDepth
+
+	// 5. Actually call the adapter for the routed driver. Until this returns
+	// successfully, we have only *routed* — we have not *dispatched*. Action
+	// "dispatched" must mean an execution surface was invoked and accepted
+	// the task (workspace#408: silent-loss fix).
+	adapter := d.selectAdapter(routeDecision.Driver)
+	if adapter == nil {
+		if len(d.adapters) == 0 {
+			// Legacy path: no adapters registered at all. Preserve the old
+			// queue-only behavior so callers that consume from the Redis
+			// queue directly don't regress. Reason string marks it as
+			// queue-only so observers can distinguish it from HTTP-confirmed
+			// dispatch.
+			result.Action = "dispatched"
+			result.Reason = fmt.Sprintf("queued via %s (tier: %s, confidence: %.1f; no adapter registered)", routeDecision.Driver, routeDecision.Tier, routeDecision.Confidence)
+			d.recordDispatch(ctx, agentName, event, result)
+			return result, nil
+		}
+		// Adapters exist but none matches the routed driver: don't claim
+		// success with no execution surface attached.
+		result.Action = "unroutable"
+		result.Reason = fmt.Sprintf("no adapter registered for driver %q", routeDecision.Driver)
+		d.recordDispatch(ctx, agentName, event, result)
+		return result, nil
+	}
+
+	task := &Task{
+		ID:       fmt.Sprintf("%s-%d", agentName, now.UnixNano()),
+		Type:     string(event.Type),
+		Repo:     event.Repo,
+		Priority: priorityStr(priority),
+	}
+
+	adapterResult, adapterErr := adapter.Dispatch(ctx, task)
+	if adapterErr != nil {
+		result.Action = "failed"
+		result.Reason = fmt.Sprintf("adapter %s dispatch failed: %v", adapter.Name(), adapterErr)
+		d.recordDispatch(ctx, agentName, event, result)
+		return result, nil
+	}
+	if adapterResult != nil && adapterResult.Status == "failed" {
+		errMsg := adapterResult.Error
+		if errMsg == "" {
+			errMsg = "adapter reported failed status"
+		}
+		result.Action = "failed"
+		result.Reason = fmt.Sprintf("adapter %s: %s", adapter.Name(), errMsg)
+		d.recordDispatch(ctx, agentName, event, result)
+		return result, nil
+	}
+
+	result.Action = "dispatched"
+	result.Reason = fmt.Sprintf("dispatched via %s (tier: %s, confidence: %.1f)", routeDecision.Driver, routeDecision.Tier, routeDecision.Confidence)
 
 	d.recordDispatch(ctx, agentName, event, result)
 	return result, nil

--- a/internal/dispatch/dispatcher.go
+++ b/internal/dispatch/dispatcher.go
@@ -49,27 +49,6 @@ type Dispatcher struct {
 	presUser  string                // user ID for presence checks
 	queueFile string                // ~/.chitin/queue.txt (compatibility bridge)
 	namespace string
-	adapters  []Adapter // execution-surface adapters; picked by Name() against routed driver
-}
-
-// SetAdapters registers adapters that execute a dispatched task on a real
-// surface (HTTP repository_dispatch, Anthropic API, Claude Code CLI, etc.).
-// After route selection, Dispatch() invokes the adapter whose Name() matches
-// the routed driver. This is what makes result.Action="dispatched" mean "an
-// execution surface was actually called" rather than "we enqueued to Redis
-// and hoped." See workspace#408 (silent-loss regression).
-func (d *Dispatcher) SetAdapters(adapters ...Adapter) { d.adapters = adapters }
-
-// selectAdapter returns the registered adapter whose Name() matches driver,
-// or nil if none is registered. Gate between routing ("we picked claude-code")
-// and execution ("we actually called it").
-func (d *Dispatcher) selectAdapter(driver string) Adapter {
-	for _, a := range d.adapters {
-		if a != nil && a.Name() == driver {
-			return a
-		}
-	}
-	return nil
 }
 
 // NewDispatcher creates an event-driven dispatcher.
@@ -218,62 +197,11 @@ func (d *Dispatcher) DispatchBudget(ctx context.Context, event Event, agentName 
 	}
 
 	queueDepth, _ := d.PendingCount(ctx)
+	result.Action = "dispatched"
+	result.Reason = fmt.Sprintf("dispatched via %s (tier: %s, confidence: %.1f)", routeDecision.Driver, routeDecision.Tier, routeDecision.Confidence)
 	result.Driver = routeDecision.Driver
 	result.ClaimID = claim.ClaimID
 	result.QueuePos = queueDepth
-
-	// 5. Actually call the adapter for the routed driver. Until this returns
-	// successfully, we have only *routed* — we have not *dispatched*. Action
-	// "dispatched" must mean an execution surface was invoked and accepted
-	// the task (workspace#408: silent-loss fix).
-	adapter := d.selectAdapter(routeDecision.Driver)
-	if adapter == nil {
-		if len(d.adapters) == 0 {
-			// Legacy path: no adapters registered at all. Preserve the old
-			// queue-only behavior so callers that consume from the Redis
-			// queue directly don't regress. Reason string marks it as
-			// queue-only so observers can distinguish it from HTTP-confirmed
-			// dispatch.
-			result.Action = "dispatched"
-			result.Reason = fmt.Sprintf("queued via %s (tier: %s, confidence: %.1f; no adapter registered)", routeDecision.Driver, routeDecision.Tier, routeDecision.Confidence)
-			d.recordDispatch(ctx, agentName, event, result)
-			return result, nil
-		}
-		// Adapters exist but none matches the routed driver: don't claim
-		// success with no execution surface attached.
-		result.Action = "unroutable"
-		result.Reason = fmt.Sprintf("no adapter registered for driver %q", routeDecision.Driver)
-		d.recordDispatch(ctx, agentName, event, result)
-		return result, nil
-	}
-
-	task := &Task{
-		ID:       fmt.Sprintf("%s-%d", agentName, now.UnixNano()),
-		Type:     string(event.Type),
-		Repo:     event.Repo,
-		Priority: priorityStr(priority),
-	}
-
-	adapterResult, adapterErr := adapter.Dispatch(ctx, task)
-	if adapterErr != nil {
-		result.Action = "failed"
-		result.Reason = fmt.Sprintf("adapter %s dispatch failed: %v", adapter.Name(), adapterErr)
-		d.recordDispatch(ctx, agentName, event, result)
-		return result, nil
-	}
-	if adapterResult != nil && adapterResult.Status == "failed" {
-		errMsg := adapterResult.Error
-		if errMsg == "" {
-			errMsg = "adapter reported failed status"
-		}
-		result.Action = "failed"
-		result.Reason = fmt.Sprintf("adapter %s: %s", adapter.Name(), errMsg)
-		d.recordDispatch(ctx, agentName, event, result)
-		return result, nil
-	}
-
-	result.Action = "dispatched"
-	result.Reason = fmt.Sprintf("dispatched via %s (tier: %s, confidence: %.1f)", routeDecision.Driver, routeDecision.Tier, routeDecision.Confidence)
 
 	d.recordDispatch(ctx, agentName, event, result)
 	return result, nil

--- a/internal/dispatch/dispatcher_test.go
+++ b/internal/dispatch/dispatcher_test.go
@@ -3,8 +3,10 @@ package dispatch
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -608,3 +610,97 @@ func TestDispatchBudget_LowBlocksCLI(t *testing.T) {
 		t.Fatalf("expected budget=low in result, got %s", result.Budget)
 	}
 }
+
+// --- Silent-loss regression (workspace#408) ---
+//
+// Before commit 5dc4e27, DispatchBudget set result.Action="dispatched" after
+// routing+enqueue without ever invoking the routed adapter. These subtests
+// pin the contract: action="dispatched" MUST mean the adapter was called.
+
+type silentLossFakeAdapter struct {
+	name      string
+	calls     int
+	lastTask  *Task
+	returnErr error
+	returnRes *AdapterResult
+}
+
+func (f *silentLossFakeAdapter) Name() string                  { return f.name }
+func (f *silentLossFakeAdapter) CanAccept(_ *Task) bool        { return true }
+func (f *silentLossFakeAdapter) Dispatch(_ context.Context, task *Task) (*AdapterResult, error) {
+	f.calls++
+	f.lastTask = task
+	return f.returnRes, f.returnErr
+}
+
+func TestDispatchBudget_CallsAdapter_SilentLossRegression(t *testing.T) {
+	t.Run("happy_path_adapter_invoked", func(t *testing.T) {
+		d, ctx := testSetup(t)
+		fake := &silentLossFakeAdapter{
+			name:      "claude-code",
+			returnRes: &AdapterResult{Status: "completed", Adapter: "claude-code"},
+		}
+		d.SetAdapters(fake)
+
+		event := Event{Type: EventManual, Source: "test", Repo: "chitinhq/octi"}
+		result, err := d.DispatchBudget(ctx, event, "happy-agent", 2, "medium")
+		if err != nil {
+			t.Fatalf("dispatch error: %v", err)
+		}
+		if result.Action != "dispatched" {
+			t.Fatalf("expected action=dispatched, got %s (reason: %s)", result.Action, result.Reason)
+		}
+		// THE key assertion: without this the buggy parent commit passes.
+		if fake.calls != 1 {
+			t.Fatalf("silent-loss regression: expected adapter.Dispatch called exactly once, got %d", fake.calls)
+		}
+		if fake.lastTask == nil || fake.lastTask.Repo != "chitinhq/octi" {
+			t.Fatalf("expected task.Repo=chitinhq/octi, got %+v", fake.lastTask)
+		}
+	})
+
+	t.Run("adapter_error_marks_failed", func(t *testing.T) {
+		d, ctx := testSetup(t)
+		fake := &silentLossFakeAdapter{
+			name:      "claude-code",
+			returnErr: fmt.Errorf("boom: surface unreachable"),
+		}
+		d.SetAdapters(fake)
+
+		event := Event{Type: EventManual, Source: "test", Repo: "chitinhq/octi"}
+		result, err := d.DispatchBudget(ctx, event, "err-agent", 2, "medium")
+		if err != nil {
+			t.Fatalf("dispatch error: %v", err)
+		}
+		if result.Action != "failed" {
+			t.Fatalf("expected action=failed, got %s (reason: %s)", result.Action, result.Reason)
+		}
+		if fake.calls != 1 {
+			t.Fatalf("expected adapter.Dispatch called exactly once, got %d", fake.calls)
+		}
+		if !strings.Contains(result.Reason, "boom: surface unreachable") {
+			t.Fatalf("expected reason to contain adapter error, got: %s", result.Reason)
+		}
+	})
+
+	t.Run("adapters_registered_but_no_match_unroutable", func(t *testing.T) {
+		d, ctx := testSetup(t)
+		// Register an adapter whose Name() does NOT match the routed driver
+		// (testSetup configures claude-code as the only healthy driver).
+		fake := &silentLossFakeAdapter{name: "some-other-driver"}
+		d.SetAdapters(fake)
+
+		event := Event{Type: EventManual, Source: "test", Repo: "chitinhq/octi"}
+		result, err := d.DispatchBudget(ctx, event, "unroutable-agent", 2, "medium")
+		if err != nil {
+			t.Fatalf("dispatch error: %v", err)
+		}
+		if result.Action != "unroutable" {
+			t.Fatalf("expected action=unroutable, got %s (reason: %s)", result.Action, result.Reason)
+		}
+		if fake.calls != 0 {
+			t.Fatalf("expected adapter.Dispatch NOT called (no match), got %d calls", fake.calls)
+		}
+	})
+}
+


### PR DESCRIPTION
## Summary
Closes the **hopper Phase-1 slice** of [workspace#408 — Telemetry Truth](https://github.com/chitinhq/workspace/issues/408).

Before this PR, `Dispatcher.DispatchBudget` claimed the coord lock, picked a driver, enqueued
to Redis, and set `result.Action="dispatched"` — **without ever invoking the selected
adapter's HTTP call**. Any event returned `action="dispatched"` even when no execution
surface was contacted. That's the bug lovelace surfaced in the Reality Check party:
_T2 100% silent-loss, 48/48 recent "dispatched" entries never reached the GH adapter._

This PR wires a proper gate:
- `Dispatcher` gains an `adapters []Adapter` slice + `SetAdapters()` registration.
- After route selection, `DispatchBudget` picks the adapter whose `Name()` matches the
  routed driver, calls `adapter.Dispatch(ctx, task)`, and only THEN sets
  `result.Action="dispatched"`. Failures downgrade to `action="failed"`; no matching
  adapter downgrades to `action="unroutable"`.
- Legacy fallback preserved: `len(d.adapters) == 0` keeps the old queue-only behavior
  so callers consuming directly from the Redis queue don't regress (reason string marks
  it as queue-only so observers can distinguish).

## Branch history — TDD red-first sequencing

The branch commits tell the full TDD story. Reviewer-friendly order:

| commit | role |
|---|---|
| `5dc4e27` | fix: initial adapter wiring (hopper, 2026-04-15) |
| `1d34f97` | docs: silent-loss before/after diagram + detection heuristic |
| `ca58751` | **test: REVERTED the fix** to pin `TestDispatchBudget_CallsAdapter_SilentLossRegression` as red against pre-fix parent `eeef6f2` |
| `af4a739` | docs: curie sibling-suspects sweep (4 issues filed — #241–#244) |
| `99e18e7` | **fix: re-apply** adapter wiring — makes the regression test go green at HEAD |

Squash-merge recommended. Reviewers who want the atomic diff: `git diff main...HEAD`.

## Test plan

- [x] `go test ./internal/dispatch/... -count=1` — 25 pass, incl. 3-subtest
  `TestDispatchBudget_CallsAdapter_SilentLossRegression` (happy path, adapter error,
  unroutable)
- [ ] CI green on push (monitoring)
- [ ] After merge, confirm `mcp__octi__dispatch_status` reports real HTTP outcomes, not
  routing decisions (success criterion from workspace#408)

## Follow-ups (already filed by curie)

Sibling silent-loss patterns found in the sweep:
- octi#241 (claude_code adapter) — **CLOSED**
- octi#242 (copilot_cli adapter) — open
- octi#243 (clawta adapter) — open, includes episodic-learner contamination concern
- octi#244 (sprint/store.go `markClosedItems`) — open, med confidence

See `docs/silent-loss.md` suspects table for the full pattern-mine matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)